### PR TITLE
Fix static initialization problem

### DIFF
--- a/zypp/Arch.cc
+++ b/zypp/Arch.cc
@@ -152,7 +152,7 @@ namespace zypp
     // NOTE: Thake care CompatBits::IntT is able to provide one
     //       bit for each architecture.
     //
-#define DEF_BUILTIN(A) const IdString  _##A( #A );
+#define DEF_BUILTIN(A) static inline const IdString & _##A () { static IdString __str(#A); return __str; }
     DEF_BUILTIN( noarch );
 
     DEF_BUILTIN( i386 );
@@ -273,63 +273,61 @@ namespace zypp
         // _noarch must have _idBit 0.
         // Other builtins have 1-bit set
         // and are initialized done on the fly.
-        _compatSet.insert( Arch::CompatEntry( _noarch, 0 ) );
+        _compatSet.insert( Arch::CompatEntry( _noarch(), 0 ) );
         ///////////////////////////////////////////////////////////////////
         // Define the CompatibleWith relation:
         //
         // NOTE: Order of definition is significant! (Arch::compare)
 	//       - define compatible (less) architectures first!
         //
-        defCompatibleWith( _i386,	_noarch );
-        defCompatibleWith( _i486,	_noarch,_i386 );
-        defCompatibleWith( _i586,	_noarch,_i386,_i486 );
-        defCompatibleWith( _i686,	_noarch,_i386,_i486,_i586 );
-        defCompatibleWith( _athlon,	_noarch,_i386,_i486,_i586,_i686 );
-        defCompatibleWith( _x86_64,	_noarch,_i386,_i486,_i586,_i686,_athlon );
+        defCompatibleWith( _i386(),	_noarch() );
+        defCompatibleWith( _i486(),	_noarch(),_i386() );
+        defCompatibleWith( _i586(),	_noarch(),_i386(),_i486() );
+        defCompatibleWith( _i686(),	_noarch(),_i386(),_i486(),_i586() );
+        defCompatibleWith( _athlon(),	_noarch(),_i386(),_i486(),_i586(),_i686() );
+        defCompatibleWith( _x86_64(),	_noarch(),_i386(),_i486(),_i586(),_i686(),_athlon() );
 
-        defCompatibleWith( _pentium3,	_noarch,_i386,_i486,_i586,_i686 );
-        defCompatibleWith( _pentium4,	_noarch,_i386,_i486,_i586,_i686,_pentium3 );
+        defCompatibleWith( _pentium3(),	_noarch(),_i386(),_i486(),_i586(),_i686() );
+        defCompatibleWith( _pentium4(),	_noarch(),_i386(),_i486(),_i586(),_i686(),_pentium3() );
 
-        defCompatibleWith( _ia64,	_noarch,_i386,_i486,_i586,_i686 );
+        defCompatibleWith( _ia64(),	_noarch(),_i386(),_i486(),_i586(),_i686() );
         //
-        defCompatibleWith( _s390,	_noarch );
-        defCompatibleWith( _s390x,	_noarch,_s390 );
+        defCompatibleWith( _s390(),	_noarch() );
+        defCompatibleWith( _s390x(),	_noarch(),_s390() );
         //
-        defCompatibleWith( _ppc,	_noarch );
-        defCompatibleWith( _ppc64,	_noarch,_ppc );
+        defCompatibleWith( _ppc(),	_noarch() );
+        defCompatibleWith( _ppc64(),	_noarch(),_ppc() );
         //
-        defCompatibleWith( _alpha,	_noarch );
-        defCompatibleWith( _alphaev5,	_noarch,_alpha );
-        defCompatibleWith( _alphaev56,	_noarch,_alpha,_alphaev5 );
-        defCompatibleWith( _alphapca56,	_noarch,_alpha,_alphaev5,_alphaev56 );
-        defCompatibleWith( _alphaev6,	_noarch,_alpha,_alphaev5,_alphaev56,_alphapca56 );
-        defCompatibleWith( _alphaev67,	_noarch,_alpha,_alphaev5,_alphaev56,_alphapca56,_alphaev6 );
+        defCompatibleWith( _alpha(),	_noarch() );
+        defCompatibleWith( _alphaev5(),	_noarch(),_alpha() );
+        defCompatibleWith( _alphaev56(),	_noarch(),_alpha(),_alphaev5() );
+        defCompatibleWith( _alphapca56(),	_noarch(),_alpha(),_alphaev5(),_alphaev56() );
+        defCompatibleWith( _alphaev6(),	_noarch(),_alpha(),_alphaev5(),_alphaev56(),_alphapca56() );
+        defCompatibleWith( _alphaev67(),	_noarch(),_alpha(),_alphaev5(),_alphaev56(),_alphapca56(),_alphaev6() );
         //
-        defCompatibleWith( _sparc,	_noarch );
-        defCompatibleWith( _sparcv8,	_noarch,_sparc );
-        defCompatibleWith( _sparcv9,	_noarch,_sparc,_sparcv8 );
-	defCompatibleWith( _sparcv9v,	_noarch,_sparc,_sparcv8,_sparcv9 );
+        defCompatibleWith( _sparc(),	_noarch() );
+        defCompatibleWith( _sparcv8(),	_noarch(),_sparc() );
+        defCompatibleWith( _sparcv9(),	_noarch(),_sparc(),_sparcv8() );
+	defCompatibleWith( _sparcv9v(),	_noarch(),_sparc(),_sparcv8(),_sparcv9() );
 	//
-        defCompatibleWith( _sparc64,	_noarch,_sparc,_sparcv8,_sparcv9 );
-	defCompatibleWith( _sparc64v,	_noarch,_sparc,_sparcv8,_sparcv9,_sparcv9v,_sparc64 );
+        defCompatibleWith( _sparc64(),	_noarch(),_sparc(),_sparcv8(),_sparcv9() );
+	defCompatibleWith( _sparc64v(),	_noarch(),_sparc(),_sparcv8(),_sparcv9(),_sparcv9v(),_sparc64() );
         //
-        defCompatibleWith( _armv3l,	_noarch );
-        defCompatibleWith( _armv4l,	_noarch,_armv3l );
-        defCompatibleWith( _armv4tl,	_noarch,_armv3l,_armv4l );
-        defCompatibleWith( _armv5l,	_noarch,_armv3l,_armv4l,_armv4tl );
-        defCompatibleWith( _armv5tel,	_noarch,_armv3l,_armv4l,_armv4tl,_armv5l );
-        defCompatibleWith( _armv5tejl,	_noarch,_armv3l,_armv4l,_armv4tl,_armv5l,_armv5tel );
-        defCompatibleWith( _armv6l,	_noarch,_armv3l,_armv4l,_armv4tl,_armv5l,_armv5tel,_armv5tejl );
-        defCompatibleWith( _armv7l,	_noarch,_armv3l,_armv4l,_armv4tl,_armv5l,_armv5tel,_armv5tejl,_armv6l );
-        defCompatibleWith( _armv7hl,    _noarch );
-        defCompatibleWith( _armv7nhl,   _noarch,_armv7hl );
-        defCompatibleWith( _armv7thl,   _noarch,_armv7hl );
-        defCompatibleWith( _armv7tnhl,  _noarch,_armv7hl,_armv7nhl,_armv7thl);
+        defCompatibleWith( _armv3l(),	_noarch() );
+        defCompatibleWith( _armv4l(),	_noarch(),_armv3l() );
+        defCompatibleWith( _armv4tl(),	_noarch(),_armv3l(),_armv4l() );
+        defCompatibleWith( _armv5l(),	_noarch(),_armv3l(),_armv4l(),_armv4tl() );
+        defCompatibleWith( _armv5tel(),	_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l() );
+        defCompatibleWith( _armv5tejl(),	_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel() );
+        defCompatibleWith( _armv6l(),	_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel(),_armv5tejl() );
+        defCompatibleWith( _armv7l(),	_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel(),_armv5tejl(),_armv6l() );
+        defCompatibleWith( _armv7hl(),    _noarch() );
+        defCompatibleWith( _armv7nhl(),   _noarch(), _armv7hl() );
         //
-        defCompatibleWith( _sh3,	_noarch );
+        defCompatibleWith( _sh3(),	_noarch() );
         //
-        defCompatibleWith( _sh4,	_noarch );
-        defCompatibleWith( _sh4a,	_noarch,_sh4 );
+        defCompatibleWith( _sh4(),	_noarch() );
+        defCompatibleWith( _sh4a(),	_noarch(),_sh4() );
         //
         ///////////////////////////////////////////////////////////////////
         // dumpOn( USR ) << endl;
@@ -396,57 +394,55 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   const Arch Arch_empty ( IdString::Empty );
-  const Arch Arch_noarch( _noarch );
+  const Arch Arch_noarch( _noarch() );
 
-  const Arch Arch_i386( _i386 );
-  const Arch Arch_i486( _i486 );
-  const Arch Arch_i586( _i586 );
-  const Arch Arch_i686( _i686 );
-  const Arch Arch_athlon( _athlon );
-  const Arch Arch_x86_64( _x86_64 );
+  const Arch Arch_i386( _i386() );
+  const Arch Arch_i486( _i486() );
+  const Arch Arch_i586( _i586() );
+  const Arch Arch_i686( _i686() );
+  const Arch Arch_athlon( _athlon() );
+  const Arch Arch_x86_64( _x86_64() );
 
-  const Arch Arch_pentium3( _pentium3 );
-  const Arch Arch_pentium4( _pentium4 );
+  const Arch Arch_pentium3( _pentium3() );
+  const Arch Arch_pentium4( _pentium4() );
 
-  const Arch Arch_s390( _s390 );
-  const Arch Arch_s390x( _s390x );
+  const Arch Arch_s390( _s390() );
+  const Arch Arch_s390x( _s390x() );
 
-  const Arch Arch_ppc( _ppc );
-  const Arch Arch_ppc64( _ppc64 );
+  const Arch Arch_ppc( _ppc() );
+  const Arch Arch_ppc64( _ppc64() );
 
-  const Arch Arch_ia64( _ia64 );
+  const Arch Arch_ia64( _ia64() );
 
-  const Arch Arch_alphaev67( _alphaev67 );
-  const Arch Arch_alphaev6( _alphaev6 );
-  const Arch Arch_alphapca56( _alphapca56 );
-  const Arch Arch_alphaev56( _alphaev56 );
-  const Arch Arch_alphaev5( _alphaev5 );
-  const Arch Arch_alpha( _alpha );
+  const Arch Arch_alphaev67( _alphaev67() );
+  const Arch Arch_alphaev6( _alphaev6() );
+  const Arch Arch_alphapca56( _alphapca56() );
+  const Arch Arch_alphaev56( _alphaev56() );
+  const Arch Arch_alphaev5( _alphaev5() );
+  const Arch Arch_alpha( _alpha() );
 
-  const Arch Arch_sparc64v( _sparc64v );
-  const Arch Arch_sparc64( _sparc64 );
-  const Arch Arch_sparcv9v( _sparcv9v );
-  const Arch Arch_sparcv9( _sparcv9 );
-  const Arch Arch_sparcv8( _sparcv8 );
-  const Arch Arch_sparc( _sparc );
+  const Arch Arch_sparc64v( _sparc64v() );
+  const Arch Arch_sparc64( _sparc64() );
+  const Arch Arch_sparcv9v( _sparcv9v() );
+  const Arch Arch_sparcv9( _sparcv9() );
+  const Arch Arch_sparcv8( _sparcv8() );
+  const Arch Arch_sparc( _sparc() );
 
-  const Arch Arch_armv7tnhl( _armv7tnhl );
-  const Arch Arch_armv7thl( _armv7thl );
-  const Arch Arch_armv7nhl( _armv7nhl );
-  const Arch Arch_armv7hl( _armv7hl );
-  const Arch Arch_armv7l( _armv7l );
-  const Arch Arch_armv6l( _armv6l );
-  const Arch Arch_armv5tejl( _armv5tejl );
-  const Arch Arch_armv5tel( _armv5tel );
-  const Arch Arch_armv5l( _armv5l );
-  const Arch Arch_armv4tl( _armv4tl );
-  const Arch Arch_armv4l( _armv4l );
-  const Arch Arch_armv3l( _armv3l );
+  const Arch Arch_armv7nhl ( _armv7nhl() );
+  const Arch Arch_armv7hl ( _armv7hl() );
+  const Arch Arch_armv7l( _armv7l() );
+  const Arch Arch_armv6l( _armv6l() );
+  const Arch Arch_armv5tejl( _armv5tejl() );
+  const Arch Arch_armv5tel( _armv5tel() );
+  const Arch Arch_armv5l( _armv5l() );
+  const Arch Arch_armv4tl( _armv4tl() );
+  const Arch Arch_armv4l( _armv4l() );
+  const Arch Arch_armv3l( _armv3l() );
 
-  const Arch Arch_sh3( _sh3 );
+  const Arch Arch_sh3( _sh3() );
 
-  const Arch Arch_sh4( _sh4 );
-  const Arch Arch_sh4a( _sh4a );
+  const Arch Arch_sh4( _sh4() );
+  const Arch Arch_sh4a( _sh4a() );
 
   ///////////////////////////////////////////////////////////////////
   //
@@ -454,7 +450,7 @@ namespace zypp
   //	METHOD TYPE : Ctor
   //
   Arch::Arch()
-  : _entry( &ArchCompatSet::instance().assertDef( _noarch ) )
+  : _entry( &ArchCompatSet::instance().assertDef( _noarch() ) )
   {}
 
   Arch::Arch( IdString::IdType id_r )


### PR DESCRIPTION
The IdStrings' constructors would run after usage, meaning that the Set
was all messed up. This patch enforces propper initialization order
without relying on the compiler.

This fixes the Arch_test on Ubuntu 11.10
