### PR TITLE
Fix another static initialization problem

### DIFF
--- a/zypp/media/CredentialManager.cc
+++ b/zypp/media/CredentialManager.cc
@@ -39,16 +39,16 @@ namespace zypp
   //
   //////////////////////////////////////////////////////////////////////
 
-  const url::ViewOption AuthDataComparator::vopt =
-    url::ViewOption::DEFAULTS
-    - url::ViewOption::WITH_USERNAME
-    - url::ViewOption::WITH_PASSWORD
-    - url::ViewOption::WITH_QUERY_STR;
-
   bool
   AuthDataComparator::operator()(
       const AuthData_Ptr & lhs, const AuthData_Ptr & rhs)
   {
+    static const url::ViewOption vopt =
+        url::ViewOption::DEFAULTS
+        - url::ViewOption::WITH_USERNAME
+        - url::ViewOption::WITH_PASSWORD
+        - url::ViewOption::WITH_QUERY_STR;
+
     if (lhs->username() != rhs->username())
       return true;
 
@@ -348,6 +348,8 @@ namespace zypp
       _pimpl->_credsUser.insert(c_ptr);
       _pimpl->_userDirty = true;
     }
+
+    DBG << "creduser size" << _pimpl->_credsUser.size() << endl;
   }
 
 

--- a/zypp/media/CredentialManager.h
+++ b/zypp/media/CredentialManager.h
@@ -48,7 +48,6 @@ namespace zypp
   // comparator for CredentialSet
   struct AuthDataComparator
   {
-    static const url::ViewOption vopt;
     bool operator()(const AuthData_Ptr & lhs, const AuthData_Ptr & rhs);
   };
 


### PR DESCRIPTION
Settings were never saved since the URL comparison failed. This
fixes various zypper authentication issues on Ubuntu 11.10.
