### PR TITLE
Use O_CLOEXEC where needed

### DIFF
--- a/zypp/PathInfo.cc
+++ b/zypp/PathInfo.cc
@@ -1058,7 +1058,7 @@ namespace zypp
     {
       ZIP_TYPE ret = ZT_NONE;
 
-      int fd = open( file.asString().c_str(), O_RDONLY );
+      int fd = open( file.asString().c_str(), O_RDONLY|O_CLOEXEC );
 
       if ( fd != -1 ) {
         const int magicSize = 3;

--- a/zypp/Repository.cc
+++ b/zypp/Repository.cc
@@ -248,7 +248,7 @@ namespace zypp
     {
       NO_REPOSITORY_THROW( Exception( "Can't add solvables to norepo." ) );
 
-      AutoDispose<FILE*> file( ::fopen( file_r.c_str(), "r" ), ::fclose );
+      AutoDispose<FILE*> file( ::fopen( file_r.c_str(), "re" ), ::fclose );
       if ( file == NULL )
       {
         file.resetDispose();
@@ -270,7 +270,7 @@ namespace zypp
       std::string command( file_r.extension() == ".gz" ? "zcat " : "cat " );
       command += file_r.asString();
 
-      AutoDispose<FILE*> file( ::popen( command.c_str(), "r" ), ::pclose );
+      AutoDispose<FILE*> file( ::popen( command.c_str(), "re" ), ::pclose );
       if ( file == NULL )
       {
         file.resetDispose();

--- a/zypp/TmpPath.cc
+++ b/zypp/TmpPath.cc
@@ -187,7 +187,7 @@ namespace zypp {
           return;
         }
 
-      int tmpFd = ::mkstemp( buf );
+      int tmpFd = ::mkostemp( buf, O_CLOEXEC );
       if ( tmpFd != -1 )
         {
           // success; create _impl

--- a/zypp/base/GzStream.cc
+++ b/zypp/base/GzStream.cc
@@ -79,12 +79,12 @@ namespace zypp
 	  // we expect gzdopen to handle errors of ::open
           if ( mode_r == std::ios_base::in )
 	  {
-            _fd = ::open( name_r, O_RDONLY );
+            _fd = ::open( name_r, O_RDONLY | O_CLOEXEC );
             _file = gzdopen( _fd, "rb" );
 	  }
           else if ( mode_r == std::ios_base::out )
 	  {
-            _fd = ::open( name_r, O_WRONLY|O_CREAT, 0666 );
+            _fd = ::open( name_r, O_WRONLY|O_CREAT|O_CLOEXEC, 0666 );
             _file = gzdopen( _fd, "wb" );
 	  }
           // else: not supported

--- a/zypp/base/Random.cc
+++ b/zypp/base/Random.cc
@@ -17,7 +17,7 @@ int random_int()
   {
       unsigned int seed;
       init = true;
-      int fd = open("/dev/urandom", O_RDONLY);
+      int fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC);
       if (fd < 0 || ::read(fd, &seed, sizeof(seed)) != sizeof(seed))
       {
             // No /dev/urandom... try something else.

--- a/zypp/media/MediaCD.cc
+++ b/zypp/media/MediaCD.cc
@@ -249,7 +249,7 @@ namespace zypp
   //
   bool MediaCD::openTray( const std::string & device_r )
   {
-    int fd = ::open( device_r.c_str(), O_RDONLY|O_NONBLOCK );
+    int fd = ::open( device_r.c_str(), O_RDONLY|O_NONBLOCK|O_CLOEXEC );
     int res = -1;
 
     if ( fd != -1)
@@ -308,7 +308,7 @@ namespace zypp
   //
   bool MediaCD::closeTray( const std::string & device_r )
   {
-    int fd = ::open( device_r.c_str(), O_RDONLY|O_NONBLOCK );
+    int fd = ::open( device_r.c_str(), O_RDONLY|O_NONBLOCK|O_CLOEXEC );
     if ( fd == -1 ) {
       WAR << "Unable to open '" << device_r << "' (" << ::strerror( errno ) << ")" << endl;
       return false;

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -1220,7 +1220,7 @@ void MediaCurl::doGetFileCopy( const Pathname & filename , const Pathname & targ
       ZYPP_THROW(MediaSystemException(url, "out of memory for temp file name"));
     }
 
-    int tmp_fd = ::mkstemp( buf );
+    int tmp_fd = ::mkostemp( buf, O_CLOEXEC );
     if( tmp_fd == -1)
     {
       free( buf);
@@ -1230,7 +1230,7 @@ void MediaCurl::doGetFileCopy( const Pathname & filename , const Pathname & targ
     destNew = buf;
     free( buf);
 
-    FILE *file = ::fdopen( tmp_fd, "w" );
+    FILE *file = ::fdopen( tmp_fd, "we" );
     if ( !file ) {
       ::close( tmp_fd);
       filesystem::unlink( destNew );

--- a/zypp/media/Mount.cc
+++ b/zypp/media/Mount.cc
@@ -302,7 +302,7 @@ Mount::getEntries(const std::string &mtab)
     {
       DBG << "Reading mount table from '" << *t << "'" << std::endl;
     }
-    FILE *fp = setmntent(t->c_str(), "r");
+    FILE *fp = setmntent(t->c_str(), "re");
     if( fp)
     {
       char          buf[PATH_MAX * 4];

--- a/zypp/target/modalias/Modalias.cc
+++ b/zypp/target/modalias/Modalias.cc
@@ -115,7 +115,7 @@ read_modalias(const char *dir, const char *file, void *arg)
 		return 0;
 	}
 	snprintf(path, sizeof(path), "%s/%s", dir, file);
-	if ((fd = open(path, O_RDONLY)) == -1)
+	if ((fd = open(path, O_RDONLY|O_CLOEXEC)) == -1)
 		return 0;
 	len = read(fd, modalias, sizeof(modalias) - 1);
 	if (len < 0)


### PR DESCRIPTION
Fds should be opened using O_CLOEXEC to avoid all sort of leaks and races.

make test passes after applying this patch but with an unrelated failure in "Date_test"
"error in "date_test": check zypp::Date(date,format).form(format) == date failed [2009-02-14 01:31:30 != 2009-02-14 00:31:30]"
