### PR TITLE
make package-manager the default package-manager for dolphin

### DIFF
--- a/tools/package-manager/package-manager.desktop
+++ b/tools/package-manager/package-manager.desktop
@@ -9,3 +9,4 @@ Type=Application
 Categories=PackageManager;X-SuSE-ControlCenter-System;
 MimeType=application/x-rpm;application/x-redhat-package-manager;
 StartupNotify=true
+InitialPreference=20


### PR DESCRIPTION
Hello,

in this wiki page
http://en.opensuse.org/openSUSE:KDE_improvements#General_Improvements

there is a feature for accessing the RPM files from dolphin with yast instead of apper.

This patch will make package-manager prefered application for RPMs and
package-manager calls the "yast2 --install" so it makes yast the default application
for RPMs.

I have tested the patch and it works.

Can you tell what's the purpose of the package-manager application and why it calls yast
and not zypper??
