### PR TITLE
Support for armv6hl

### DIFF
--- a/zypp/Arch.cc
+++ b/zypp/Arch.cc
@@ -194,6 +194,7 @@ namespace zypp
     DEF_BUILTIN( armv7nhl );
     DEF_BUILTIN( armv7hl );
     DEF_BUILTIN( armv7l );
+    DEF_BUILTIN( armv6hl );
     DEF_BUILTIN( armv6l );
     DEF_BUILTIN( armv5tejl );
     DEF_BUILTIN( armv5tel );
@@ -323,6 +324,7 @@ namespace zypp
         defCompatibleWith( _armv5tel(),		_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l() );
         defCompatibleWith( _armv5tejl(),	_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel() );
         defCompatibleWith( _armv6l(),		_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel(),_armv5tejl() );
+        defCompatibleWith( _armv6hl(),		_noarch() );
         defCompatibleWith( _armv7l(),		_noarch(),_armv3l(),_armv4l(),_armv4tl(),_armv5l(),_armv5tel(),_armv5tejl(),_armv6l() );
         defCompatibleWith( _armv7hl(),		_noarch() );
         defCompatibleWith( _armv7nhl(),		_noarch(),_armv7hl() );
@@ -441,6 +443,7 @@ namespace zypp
   const Arch Arch_armv7nhl ( _armv7nhl() );
   const Arch Arch_armv7hl ( _armv7hl() );
   const Arch Arch_armv7l( _armv7l() );
+  const Arch Arch_armv6hl ( _armv6hl() );
   const Arch Arch_armv6l( _armv6l() );
   const Arch Arch_armv5tejl( _armv5tejl() );
   const Arch Arch_armv5tel( _armv5tel() );

--- a/zypp/Arch.h
+++ b/zypp/Arch.h
@@ -236,6 +236,8 @@ namespace zypp
   /** \relates Arch */
   extern const Arch Arch_armv7l;
   /** \relates Arch */
+  extern const Arch Arch_armv6hl;
+  /** \relates Arch */
   extern const Arch Arch_armv6l;
   /** \relates Arch */
   extern const Arch Arch_armv5tejl;

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -127,7 +127,7 @@ namespace zypp
           ERR << "Cant open " << PathInfo("/proc/cpuinfo") << endl;
         }
       }
-      else if ( architecture == Arch_armv7l)
+      else if ( architecture == Arch_armv7l || architecture == Arch_armv6l )
       {
 	std::ifstream platform( "/etc/rpm/platform" );
 	if (platform)
@@ -138,6 +138,12 @@ namespace zypp
 	    {
 	      architecture = Arch_armv7hl;
 	      WAR << "/etc/rpm/platform contains armv7hl-: architecture upgraded to '" << architecture << "'" << endl;
+	      break;
+	    }
+	    if ( str::hasPrefix( *in, "armv6hl-" ) )
+	    {
+	      architecture = Arch_armv6hl;
+	      WAR << "/etc/rpm/platform contains armv6hl-: architecture upgraded to '" << architecture << "'" << endl;
 	      break;
 	    }
 	  }


### PR DESCRIPTION
armv6hl is similar to armv7hl, it can be either
hard float or soft float. So extend the gross platform
detection hack to also cover armv6l.
