### PR TITLE
Fix typo so that ninja build works

### DIFF
--- a/cmake/modules/ZyppCommon.cmake
+++ b/cmake/modules/ZyppCommon.cmake
@@ -117,7 +117,7 @@ MACRO(GENERATE_PACKAGING PACKAGE VERSION)
   SPECFILE()
 
   ADD_CUSTOM_TARGET( svncheck
-    COMMAND cd $(CMAKE_SOURCE_DIR) && LC_ALL=C git status | grep -q "nothing to commit .working directory clean."
+    COMMAND cd ${CMAKE_SOURCE_DIR} && LC_ALL=C git status | grep -q "nothing to commit .working directory clean."
   )
 
   SET( AUTOBUILD_COMMAND


### PR DESCRIPTION
[Ninja](http://martine.github.io/ninja) is an alternative to make.

```
Ninja is a small build system with a focus on speed.
It differs from other build systems in two major respects:
it is designed to have its input files generated by a higher-level build system,
and it is designed to run builds as fast as possible.
```

Then libzypp can be built as as:

```
sudo zypper install ninja
cd build
cmake -G Ninja ..
ninja
```
