### PR TITLE
Require header explicitly.

### DIFF
--- a/zypp/ContentType.h
+++ b/zypp/ContentType.h
@@ -13,6 +13,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <stdexcept>
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp


### PR DESCRIPTION
Without this it fails on Gentoo.

[ 40%] Building CXX object zypp/CMakeFiles/zypp.dir/target/TargetImpl.cc.o
cd /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4_build/zypp && /usr/lib64/ccache/bin/x86_64-pc-linux-gnu-g++  -DHAVE_PIPE2 -DHAVE_UDEV -DLOCALEDIR=\"/usr/share/locale\" -DTEXTDOMAIN=\"zypp\" -DVERSION=\"14.29.4\" -DZYPP_DLL -D_FILE_OFFSET_BITS=64 -D_RPM_4_X -Dzypp_EXPORTS  -DNDEBUG -O2 -pipe -march=corei7-avx  -fvisibility-inlines-hidden -fno-strict-aliasing -fPIC -g -rdynamic -Wall -Woverloaded-virtual -Wnon-virtual-dtor -Wl,-as-needed -std=c++11 -Werror=format-security -fPIC -I/var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4 -I/var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4_build -I/usr/include/rpm -I/usr/include/libxml2 -I/var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4_build/zypp    -DZYPP_BASE_LOGGER_LOGGROUP=\"zypp\" -o CMakeFiles/zypp.dir/target/TargetImpl.cc.o -c /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/target/TargetImpl.cc
In file included from /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/UserData.h:21:0,
                 from /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/ZYppCallbacks.h:17,
                 from /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/target/TargetCallbackReceiver.h:15,
                 from /var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/target/TargetCallbackReceiver.cc:13:
/var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/ContentType.h: In member function ‘void zypp::ContentType::testAndSet(std::string&, const string&)’:
/var/tmp/portage/dev-libs/libzypp-14.29.4/work/libzypp-14.29.4/zypp/ContentType.h:105:8: error: ‘invalid_argument’ is not a member of ‘std’
zypp/CMakeFiles/zypp.dir/build.make:2104: recipe for target 'zypp/CMakeFiles/zypp.dir/target/TargetCallbackReceiver.cc.o' failed
make[2]: **\* [zypp/CMakeFiles/zypp.dir/target/TargetCallbackReceiver.cc.o] Error 1
