### PR TITLE
rpm: do not obsolete yast2-packagemanager-devel by libzypp-devel-doc

### DIFF
--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -134,17 +134,6 @@ Requires:       libcurl   >= %{min_curl_version}
 %description
 Package, Patch, Pattern, and Product Management
 
-Authors:
---------
-    Michael Andres <ma@suse.de>
-    Jiri Srain <jsrain@suse.cz>
-    Stefan Schubert <schubi@suse.de>
-    Duncan Mac-Vicar <dmacvicar@suse.de>
-    Klaus Kaempf <kkaempf@suse.de>
-    Marius Tomaschewski <mt@suse.de>
-    Stanislav Visnovsky <visnov@suse.cz>
-    Ladislav Slezak <lslezak@suse.cz>
-
 %package devel
 Summary:        Package, Patch, Pattern, and Product Management - developers files
 Group:          Development/Libraries/C and C++
@@ -190,8 +179,6 @@ Package, Patch, Pattern, and Product Management - developers files
 %package devel-doc
 Summary:        Package, Patch, Pattern, and Product Management - developers files
 Group:          Documentation/HTML
-Provides:       yast2-packagemanager-devel
-Obsoletes:      yast2-packagemanager-devel
 
 %description devel-doc
 Package, Patch, Pattern, and Product Management - developers files

--- a/package/libzypp.changes
+++ b/package/libzypp.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 27 07:40:30 UTC 2014 - dimstar@opensuse.org
+
+- Do not provide/obsolete yast2-packagemanager-devel by the -doc
+  package: the -devel package already does that.
+- Minor .spec cleanup (remove Authors section).
+
+-------------------------------------------------------------------
 Tue Nov 11 17:09:28 CET 2014 - ma@suse.de
 
 - Call rpm with '--noglob' (bnc#892431)


### PR DESCRIPTION
This will help solve the current unresolvable state of various yast packages, requiring yast2-packagemanager-devel; having one subpackage do the provides/obsoletes is sufficient.
