### PR TITLE
fix CpeId_test on archs where char is unsigned

### DIFF
--- a/tests/zypp/CpeId_test.cc
+++ b/tests/zypp/CpeId_test.cc
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(cpeid_value_valid)
 {
   static const char *const hdig = "0123456789abcdef";
 
-  for ( char ch = 0x00; ch >= 0; ++ch )
+  for ( char ch = 0; ch < CHAR_MAX; ++ch )
   {
     // cout << "==== " << unsigned(ch) << endl;
     char qchstr[] = { '\\', ch, '\0' };


### PR DESCRIPTION
If 'char' is unsigned by default (e.g. on s390\*, ppc\*, arm\*), then the loop will run forever (since 'ch' will always be greater or equal than zero, even after overflow).

Make sure to increase until the actual maximum value for char.