### PR TITLE
PathInfo: rename major/minor to devMajor/devMinor

### DIFF
--- a/zypp/PathInfo.cc
+++ b/zypp/PathInfo.cc
@@ -236,22 +236,22 @@ namespace zypp
 
     /******************************************************************
      **
-     **	FUNCTION NAME : PathInfo::major
+     **	FUNCTION NAME : PathInfo::devMajor
      **	FUNCTION TYPE : unsigned int
      */
-    unsigned int PathInfo::major() const
+    unsigned int PathInfo::devMajor() const
     {
-      return isBlk() || isChr() ? ::major(statbuf_C.st_rdev) : 0;
+      return isBlk() || isChr() ? major(statbuf_C.st_rdev) : 0;
     }
 
     /******************************************************************
      **
-     **	FUNCTION NAME : PathInfo::minor
+     **	FUNCTION NAME : PathInfo::devMinor
      **	FUNCTION TYPE : unsigned int
      */
-    unsigned int PathInfo::minor() const
+    unsigned int PathInfo::devMinor() const
     {
-      return isBlk() || isChr() ? ::minor(statbuf_C.st_rdev) : 0;
+      return isBlk() || isChr() ? minor(statbuf_C.st_rdev) : 0;
     }
 
     /******************************************************************

--- a/zypp/PathInfo.h
+++ b/zypp/PathInfo.h
@@ -359,8 +359,8 @@ namespace zypp
       dev_t  dev()     const { return isExist() ? statbuf_C.st_dev  : 0; }
       dev_t  rdev()    const { return isExist() ? statbuf_C.st_rdev : 0; }
 
-      unsigned int major() const;
-      unsigned int minor() const;
+      unsigned int devMajor() const;
+      unsigned int devMinor() const;
       //@}
 
       /** \name Size info. */

--- a/zypp/media/MediaCD.cc
+++ b/zypp/media/MediaCD.cc
@@ -127,7 +127,7 @@ namespace zypp
 	  PathInfo devnode( devnodePtr );
 	  if ( devnode.isBlk() )
 	  {
-	    MediaSource media( "cdrom", devnode.path().asString(), devnode.major(), devnode.minor() );
+	    MediaSource media( "cdrom", devnode.path().asString(), devnode.devMajor(), devnode.devMinor() );
 	    DBG << "Found (udev): " << media << std::endl;
 	    detected.push_back( media );
 	  }
@@ -335,14 +335,14 @@ namespace zypp
       PathInfo cdrinfo( "/dev/cdrom" );
       if ( dvdinfo.isBlk() )
       {
-	MediaSource media( "cdrom", dvdinfo.path().asString(), dvdinfo.major(), dvdinfo.minor() );
+	MediaSource media( "cdrom", dvdinfo.path().asString(), dvdinfo.devMajor(), dvdinfo.devMinor() );
 	DBG << "Found (GUESS): " << media << std::endl;
 	detected.push_back( media );
       }
       if ( cdrinfo.isBlk()
-	&& ! ( cdrinfo.major() == dvdinfo.major() && cdrinfo.minor() == dvdinfo.minor() ) )
+	&& ! ( cdrinfo.devMajor() == dvdinfo.devMajor() && cdrinfo.devMinor() == dvdinfo.devMinor() ) )
       {
-	MediaSource media( "cdrom", cdrinfo.path().asString(), cdrinfo.major(), cdrinfo.minor() );
+	MediaSource media( "cdrom", cdrinfo.path().asString(), cdrinfo.devMajor(), cdrinfo.devMinor() );
 	DBG << "Found (GUESS): " << media << std::endl;
 	detected.push_back( media );
       }
@@ -364,7 +364,7 @@ namespace zypp
       PathInfo dinfo( device );
       if ( dinfo.isBlk() )
       {
-	MediaSource media( "cdrom", device, dinfo.major(), dinfo.minor() );
+	MediaSource media( "cdrom", device, dinfo.devMajor(), dinfo.devMinor() );
 	if ( detected.empty() )
 	{
 	  _devices.push_front( media );	// better try this than nothing
@@ -453,8 +453,8 @@ namespace zypp
       }
       DBG << "trying device " << dinfo << endl;
 
-      temp.maj_nr = dinfo.major();
-      temp.min_nr = dinfo.minor();
+      temp.maj_nr = dinfo.devMajor();
+      temp.min_nr = dinfo.devMinor();
       MediaSourceRef media( new MediaSource(temp));
       AttachedMedia ret( findAttachedMedia( media));
 
@@ -490,8 +490,8 @@ namespace zypp
             is_device = true;
           }
 
-          if( is_device && media->maj_nr == dev_info.major() &&
-                           media->min_nr == dev_info.minor())
+          if( is_device && media->maj_nr == dev_info.devMajor() &&
+                           media->min_nr == dev_info.devMinor())
           {
             AttachPointRef ap( new AttachPoint(e->dir, false));
             AttachedMedia  am( media, ap);

--- a/zypp/media/MediaDISK.cc
+++ b/zypp/media/MediaDISK.cc
@@ -114,8 +114,8 @@ namespace zypp {
 	  for(it = dlist.begin(); it != dlist.end(); ++it)
 	  {
 	    PathInfo vol_info(*it);
-	    if( vol_info.isBlk() && vol_info.major() == dev_info.major() &&
-	                            vol_info.minor() == dev_info.minor())
+	    if( vol_info.isBlk() && vol_info.devMajor() == dev_info.devMajor() &&
+	                            vol_info.devMinor() == dev_info.devMinor())
 	    {
 	      DBG << "Specified device name " << dev_name
 		  << " is a volume (disk/by-uuid link "
@@ -138,8 +138,8 @@ namespace zypp {
 	  for(it = dlist.begin(); it != dlist.end(); ++it)
 	  {
 	    PathInfo vol_info(*it);
-	    if( vol_info.isBlk() && vol_info.major() == dev_info.major() &&
-	                            vol_info.minor() == dev_info.minor())
+	    if( vol_info.isBlk() && vol_info.devMajor() == dev_info.devMajor() &&
+	                            vol_info.devMinor() == dev_info.devMinor())
 	    {
 	      DBG << "Specified device name " << dev_name
 		  << " is a volume (disk/by-label link "
@@ -207,7 +207,7 @@ namespace zypp {
 	ZYPP_THROW(MediaBadUrlEmptyFilesystemException(url()));
 
       MediaSourceRef media( new MediaSource(
-      	"disk", _device, dev_info.major(), dev_info.minor()
+      	"disk", _device, dev_info.devMajor(), dev_info.devMinor()
       ));
       AttachedMedia  ret( findAttachedMedia( media));
 
@@ -242,8 +242,8 @@ namespace zypp {
 	  is_device = true;
 	}
 
-	if( is_device && media->maj_nr == dev_info.major() &&
-	                 media->min_nr == dev_info.minor())
+	if( is_device && media->maj_nr == dev_info.devMajor() &&
+	                 media->min_nr == dev_info.devMinor())
 	{
 	  AttachPointRef ap( new AttachPoint(e->dir, false));
 	  AttachedMedia  am( media, ap);

--- a/zypp/media/MediaHandler.cc
+++ b/zypp/media/MediaHandler.cc
@@ -544,7 +544,7 @@ MediaHandler::checkAttached(bool matchMountFs) const
 	                   ref.mediaSource->bdir.empty()))
         {
           std::string mtype(matchMountFs ? e->type : ref.mediaSource->type);
-          MediaSource media(mtype, e->src, dev_info.major(), dev_info.minor());
+          MediaSource media(mtype, e->src, dev_info.devMajor(), dev_info.devMinor());
 
           if( ref.mediaSource->equals( media ) )
           {
@@ -822,7 +822,7 @@ void MediaHandler::forceRelaseAllMedia(const MediaSourceRef &ref,
     if( is_device &&  ref->maj_nr)
     {
       std::string mtype(matchMountFs ? e->type : ref->type);
-      MediaSource media(mtype, e->src, dev_info.major(), dev_info.minor());
+      MediaSource media(mtype, e->src, dev_info.devMajor(), dev_info.devMinor());
 
       if( ref->equals( media) && e->type != "subfs")
       {

--- a/zypp/media/MediaISO.cc
+++ b/zypp/media/MediaISO.cc
@@ -222,8 +222,8 @@ namespace zypp
       PathInfo dinfo(loopdev);
       if( dinfo.isBlk())
       {
-        media->maj_nr = dinfo.major();
-        media->min_nr = dinfo.minor();
+        media->maj_nr = dinfo.devMajor();
+        media->min_nr = dinfo.devMinor();
       }
       else
         ERR << loopdev << " is not a block device" << endl;


### PR DESCRIPTION
`major()` and `minor()` conlict with the GNU libc macros with the same names, so if any system header bringing them (directly or indirectly) is included before PathInfo.h, then PathInfo.h is unusable.

Unfortunately, the only clean way to solve this conflict is renaming `PathInfo::major()` & `PathInfo::minor()` resp. to `devMajor()` & `devMinor()`.

--- 
libzypp maintainers: is such kind of API change wanted? Should I bump `LIBZYPP_COMPATMINOR` & `LIBZYPP_MINOR` in VERSION.cmake as well, or will you do that just once before the release?