### PR TITLE
VendorAttr: do not try to read a directory as file

### DIFF
--- a/zypp/VendorAttr.cc
+++ b/zypp/VendorAttr.cc
@@ -253,14 +253,7 @@ namespace zypp
 
   bool VendorAttr::addVendorDirectory( const Pathname & dirname ) const
   {
-      parser::IniDict dict;
-
-      if ( PathInfo(dirname).isExist())
-      {
-          InputStream is(dirname);
-          dict.read(is);
-      }
-      else
+      if ( ! PathInfo(dirname).isExist() )
       {
           MIL << dirname << " not found." << endl;
           return false;


### PR DESCRIPTION
When adding a new directory with vendor configuration, do not try to read the directory as if it was a config/ini file, which is going to always fail (and whose result was discarded anyway).