### PR TITLE
zypp/PublicKey.cc: Use GPG_BINARY from KeyRing.cc

### DIFF
--- a/zypp/KeyRing.cc
+++ b/zypp/KeyRing.cc
@@ -37,6 +37,7 @@ using std::endl;
 #undef  ZYPP_BASE_LOGGER_LOGGROUP
 #define ZYPP_BASE_LOGGER_LOGGROUP "zypp::KeyRing"
 
+/** \todo Fix duplicate define in PublicKey/KeyRing */
 #define GPG_BINARY "/usr/bin/gpg2"
 
 ///////////////////////////////////////////////////////////////////

--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -28,6 +28,9 @@
 
 #include <ctime>
 
+/** \todo Fix duplicate define in PublicKey/KeyRing */
+#define GPG_BINARY "/usr/bin/gpg2"
+
 using std::endl;
 
 ///////////////////////////////////////////////////////////////////
@@ -349,7 +352,7 @@ namespace zypp
         static filesystem::TmpDir dir;
         const char* argv[] =
         {
-          "gpg",
+          GPG_BINARY,
           "-v",
           "--no-default-keyring",
           "--fixed-list-mode",


### PR DESCRIPTION
On systems where `gpg` is not available, checking the public key
would fail. Use `GPG_BINARY` in both `PublicKey.cc` and `KeyRing.cc`,
and define it in a single place only (`ExternalProgram.h`).