### PR TITLE
Support for *.check files in the systemCheck.d directory

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -354,6 +354,16 @@
 # solver.checkSystemFile = /etc/zypp/systemCheck
 
 ##
+## This directory can contain files that contain requirements/conflicts
+## which fulfill the needs of a running system (see checkSystemFile).
+##
+## Files are read in alphabetical order.
+##
+## Default value: {configdir}/systemCheck.d
+##
+# solver.checkSystemFileDir = /etc/zypp/systemCheck.d
+
+##
 ## When committing a dist upgrade (e.g. 'zypper dup') a solver testcase
 ## is written to /var/log/updateTestcase-<date>. It is needed in bugreports.
 ## This option returns the number of testcases to keep on the system. Old

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -487,6 +487,10 @@ namespace zypp
                 {
                   solver_checkSystemFile = Pathname(value);
                 }
+                else if ( entry == "solver.checkSystemFileDir" )
+                {
+                  solver_checkSystemFileDir = Pathname(value);
+                }
                 else if ( entry == "multiversion" )
                 {
                   str::split( value, inserter( _multiversion, _multiversion.end() ), ", \t" );
@@ -611,6 +615,7 @@ namespace zypp
     DefaultOption<bool> solverUpgradeRemoveDroppedPackages;
 
     Pathname solver_checkSystemFile;
+    Pathname solver_checkSystemFileDir;
 
     std::set<std::string> &		multiversion()		{ return getMultiversion(); }
     const std::set<std::string> &	multiversion() const	{ return getMultiversion(); }
@@ -906,6 +911,10 @@ namespace zypp
   Pathname ZConfig::solver_checkSystemFile() const
   { return ( _pimpl->solver_checkSystemFile.empty()
       ? (configPath()/"systemCheck") : _pimpl->solver_checkSystemFile ); }
+
+  Pathname ZConfig::solver_checkSystemFileDir() const
+  { return ( _pimpl->solver_checkSystemFileDir.empty()
+      ? (configPath()/"systemCheck.d") : _pimpl->solver_checkSystemFileDir ); }
 
   unsigned ZConfig::solver_upgradeTestcasesToKeep() const
   { return _pimpl->solver_upgradeTestcasesToKeep; }

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -299,6 +299,13 @@ namespace zypp
       Pathname solver_checkSystemFile() const;
 
       /**
+       * Directory, which may or may not contain files in which
+       * dependencies described which has to be fulfilled for a
+       * running system.
+       */
+      Pathname solver_checkSystemFileDir() const;
+
+      /**
        * Whether vendor check is by default enabled.
        */
       bool solver_allowVendorChange() const;

--- a/zypp/solver/detail/SystemCheck.h
+++ b/zypp/solver/detail/SystemCheck.h
@@ -38,10 +38,19 @@ namespace zypp
         /** Return the file path. */
         const Pathname & file();
 
+        /** Return the directory path. */
+        const Pathname & dir();
+
         /** Set configuration file of system requirements
 	 *  Should be used for testcase only   
 	 */
         bool setFile(const Pathname & file) const;
+
+        /** Set configuration directory for files of system
+	 *  requirements.
+         *  Should be used for testcase only
+	 */
+        bool setDir(const Pathname & dir) const;
 
         /** Returns a list of required system capabilities.
         */
@@ -54,8 +63,8 @@ namespace zypp
       private:
         /** Ctor taking the file to read. */
         SystemCheck();
-	bool loadFile() const;
-
+        bool loadFile(Pathname &file, bool reset_caps = true) const;
+	bool loadFiles() const;
     };
     ///////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Reads files from `/etc/zypp/systemCheck.d` (default) in alphabetical order and adds the listed requires and conflicts rules to the system requirements as if they would be listed in the file `/etc/zypp/systemCheck`.

We use this downstream in Nemo Mobile / Sailfish OS to be able to ship custom additions to the `systemCheck` file easily.