### PR TITLE
Downloader: allow to skip appdata files

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -89,13 +89,10 @@ namespace zypp
         do { ++ch; } while ( *ch != '\0' );	// skip to next field
       }
 
-      if ( pinfo.command.size() == 15 )
-      {
-        // the command name might be truncated, so we check against /proc/<pid>/exe
-        Pathname command( filesystem::readlink( Pathname("/proc")/pinfo.pid/"exe" ) );
-        if ( ! command.empty() )
-          pinfo.command = command.basename();
-      }
+      // the command name might be truncated, so we check against /proc/<pid>/exe
+      Pathname command( filesystem::readlink( Pathname("/proc")/pinfo.pid/"exe" ) );
+      if ( ! command.empty() )
+        pinfo.command = command.basename();
       //MIL << " Take " << pinfo << endl;
     }
 


### PR DESCRIPTION
For a majority of the users, downloading huge appdata files is a total
waste of time and bandwidth, because they are only used by appdata-aware
desktop apps (GNOME). Allow users to opt-out of this by setting
ZYPP_SKIP_APPDATA=1 environment variable.

In a perfect world, we could set this in zypp.conf, but this will do for now.