### PR TITLE
Added Hint_nestedVolume flag to DiskUsageCounter::MountPoint

### DIFF
--- a/package/libzypp.changes
+++ b/package/libzypp.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 15 09:06:52 UTC 2016 - ancor@suse.com
+
+- Added Hint_nestedVolume flag to DiskUsageCounter::MountPoint
+
+-------------------------------------------------------------------
 Thu Jan 14 01:13:17 CET 2016 - ma@suse.de
 
 - Update zypp-po.tar.bz2

--- a/zypp/DiskUsageCounter.h
+++ b/zypp/DiskUsageCounter.h
@@ -51,6 +51,7 @@ namespace zypp
       // hint bits:
       bool readonly:1;			///< hint for readonly partitions
       bool growonly:1;			///< hint for growonly partitions (e.g. snapshotting btrfs)
+      bool nestedVolume:1;		//< hint for non-root btrfs-style volumes
 
 
       /** HinFlags for ctor */
@@ -59,6 +60,7 @@ namespace zypp
 	NoHint		= 0,
 	Hint_readonly	= (1<<0),	///< readonly partitions
 	Hint_growonly	= (1<<1),	///< growonly partitions (e.g. snapshotting btrfs)
+	Hint_nestedVolume = (1<<2),	///< non-root btrfs-style volumes
       };
       ZYPP_DECLARE_FLAGS(HintFlags,Hint);
 
@@ -71,6 +73,7 @@ namespace zypp
 	, block_size(bs), total_size(total), used_size(used), pkg_size(pkg)
 	, readonly(hints.testFlag(Hint_readonly))
 	, growonly(hints.testFlag(Hint_growonly))
+	, nestedVolume(hints.testFlag(Hint_nestedVolume))
       {}
        /** \overload <tt>const char *</tt> to allow e.g. initiailzer lists
        * \code


### PR DESCRIPTION
Just an idea for issue #54 (just in case is not possible to implement a better subvolumes handling).

As said. I'm not a C++ developer, so this could be completely broken. In fact, I have not been able to make it work with our C++ code in YaST. But I hope the bug is not in this pull request, but in my linking and compiling problem.