### PR TITLE
fix build-compare

### DIFF
--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -1108,7 +1108,7 @@ namespace zypp
 
   std::ostream & ZConfig::about( std::ostream & str ) const
   {
-    str << "libzypp: " << VERSION << " built " << __DATE__ << " " <<  __TIME__ << endl;
+    str << "libzypp: " << VERSION << endl;
 
     str << "libsolv: " << solv_version;
     if ( ::strcmp( solv_version, LIBSOLV_VERSION_STRING ) )


### PR DESCRIPTION
follow-up on commit 1597d7cb13ab

this is really the last occurrence of 
```
__TIME__ and __DATE__
```

the alternative would be to replace it with time of last source change