### PR TITLE
Avoid direct BuildRequire on libudev-devel

### DIFF
--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -48,7 +48,7 @@ Recommends:     lsof
 BuildRequires:  cmake
 BuildRequires:  openssl-devel
 %if 0%{?suse_version} >= 1130 || 0%{?fedora_version} >= 16
-BuildRequires:  libudev-devel
+BuildRequires:  pkgconfig(libudev)
 %else
 BuildRequires:  hal-devel
 %endif


### PR DESCRIPTION
By using pkgconfig(libudev) OBS prefers libudev-mini-devel which may
allow libzypp to start building earlier in a full rebuild. The full udev
package is behind texlive so takes hours.