### PR TITLE
Provide $snapshot_version repo variable.

### DIFF
--- a/doc/autoinclude/RepoVariables.doc
+++ b/doc/autoinclude/RepoVariables.doc
@@ -30,4 +30,7 @@ The variable expander also supports shell like definition of default and alterna
 \li \c $releasever_major -
 	\c $releasever_major will be set to the leading portion up to (but not including) the 1st dot; \c $releasever_minor to the trailing portion after the 1st dot. If there's no dot in \c $releasever, \c $releasever_major is the same as \c $releasever and \c $releasever_minor is empty.
 
+\li \c $snapshot_version -
+	Tumbleweed snapshot version to target.
+
 */

--- a/tests/repo/RepoVariables_test.cc
+++ b/tests/repo/RepoVariables_test.cc
@@ -202,6 +202,8 @@ BOOST_AUTO_TEST_CASE(replace_text)
   BOOST_CHECK_EQUAL( replacer1("${releasever_major}"),	"13" );
   BOOST_CHECK_EQUAL( replacer1("${releasever_minor}"),	"2" );
 
+  BOOST_CHECK_EQUAL( replacer1("${snapshot_version}"),	"current" );
+
   BOOST_CHECK_EQUAL(replacer1("http://foo/$arch/bar"), "http://foo/i686/bar");
 
   /* check RepoVariablesUrlReplacer */

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -328,6 +328,7 @@ namespace zypp
 	, pkgGpgCheck			( indeterminate )
         , solver_onlyRequires		( false )
         , solver_allowVendorChange	( false )
+	, snapshot_version ( "current" )
 	, solver_dupAllowDowngrade	( true )
 	, solver_dupAllowNameChange	( true )
 	, solver_dupAllowArchChange	( true )
@@ -489,6 +490,10 @@ namespace zypp
                 else if ( entry == "multiversiondir" )
                 {
                   cfg_multiversion_path = Pathname(value);
+                }
+                else if ( entry == "snapshotVersion" )
+                {
+                    snapshot_version.set(value);
                 }
                 else if ( entry == "solver.onlyRequires" )
                 {
@@ -654,6 +659,8 @@ namespace zypp
     Option<bool>	gpgCheck;
     Option<TriBool>	repoGpgCheck;
     Option<TriBool>	pkgGpgCheck;
+
+    DefaultOption<std::string> snapshot_version;
 
     Option<bool>	solver_onlyRequires;
     Option<bool>	solver_allowVendorChange;
@@ -1008,6 +1015,12 @@ namespace zypp
 
   TriBool ZConfig::pkgGpgCheck() const
   { return _pimpl->pkgGpgCheck; }
+
+  std::string ZConfig::snapshotVersion() const
+  { return _pimpl->snapshot_version; }
+
+  void ZConfig::setSnapshotVersion( const std::string & val_r )
+  { _pimpl->snapshot_version.set(val_r); }
 
   bool ZConfig::solver_onlyRequires() const
   { return _pimpl->solver_onlyRequires; }

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -74,7 +74,16 @@ namespace zypp
       Pathname systemRoot() const;
 
     public:
+      static std::string defaultSnapshotVersion();
 
+      std::string snapshotVersion() const;
+
+      void setSnapshotVersion( const std::string & version_r );
+
+      void resetSnapshotVersion()
+      { setSnapshotVersion( defaultSnapshotVersion() ); }
+
+    public:
       /** The autodetected system architecture. */
       static Arch defaultSystemArchitecture();
 

--- a/zypp/repo/RepoVariables.cc
+++ b/zypp/repo/RepoVariables.cc
@@ -443,6 +443,12 @@ namespace zypp
 	  return _releaseverMinor;
 	}
 
+	const std::string & snapshotVersion() const
+	{
+	  assertSnapshotVersionStr();
+	  return _snapshotVersion;
+	}
+
       private:
 	void assertArchStr() const
 	{
@@ -475,12 +481,21 @@ namespace zypp
 	    }
 	  }
 	}
+
+	void assertSnapshotVersionStr() const
+	{
+		if ( _snapshotVersion.empty() )
+		{
+			_snapshotVersion = ZConfig::instance().snapshotVersion();
+		}
+	}
       private:
 	mutable std::string _arch;
 	mutable std::string _basearch;
 	mutable std::string _releasever;
 	mutable std::string _releaseverMajor;
 	mutable std::string _releaseverMinor;
+	mutable std::string _snapshotVersion;
       };
 
       /** \brief */
@@ -494,7 +509,8 @@ namespace zypp
 	  case  8:	ASSIGN_IF( "basearch",		&RepoVars::basearch );		break;
 	  case 10:	ASSIGN_IF( "releasever",	&RepoVars::releasever );	break;
 	  case 16:	ASSIGN_IF( "releasever_major",	&RepoVars::releaseverMajor );
-	      else	ASSIGN_IF( "releasever_minor",	&RepoVars::releaseverMinor );	break;
+	      else	ASSIGN_IF( "releasever_minor",	&RepoVars::releaseverMinor );
+	      else	ASSIGN_IF( "snapshot_version",	&RepoVars::snapshotVersion );	break;
 #undef ASSIGN_IF
 	}
 

--- a/zypp/repo/RepoVariables.h
+++ b/zypp/repo/RepoVariables.h
@@ -70,8 +70,8 @@ namespace zypp
     /**
      * \short Functor replacing repository variables
      *
-     * Replaces '$arch', '$basearch' and $releasever in a string
-     * with the global ZYpp values.
+     * Replaces '$arch', '$basearch', $releasever, and $snapshot_version, in a
+     * string with the global ZYpp values.
      *
      * Additionally $releasever_major and $releasever_minor can be used
      * to refer to $releasever major number (everything up to the 1st \c '.' )


### PR DESCRIPTION
The idea behind this is to support the, soon to be deployed, historical Tumbleweed snapshots in a clean manor at the libzypp level. The variable will be updated in the zypp.conf to point to the desired snapshot. I have developed a cli tool to manually replace the URLs without this change, but I will adapt to utilize this if accepted.

The end result is something like, `libypp.conf`:

```ini
snapshotVersion = 20170516
```

and a `tw-oss.repo`:

```ini
[tw-oss]
name=tw-oss-$snapshot_version
baseurl=http://download.opensuse.org/tumbleweed/$snapshot_version/repo/oss/
```