### PR TITLE
Set dupAllowVendorChange to 'false' by default

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -368,19 +368,18 @@
 
 ##
 ## EXPERTS ONLY: TUNE DISTRIBUTION UPGRADE (DUP)
-## Set whether to allow changing the packages vendor upon DUP. If you
-## are following a continuous distribution like Tumbleweed or Factory
-## where you use 'zypper dup --no-allow-vendor-change' quite frequently,
-## you may indeed benefit from disabling the VendorChange. Packages from
-## OBS repos will then be kept rather than being overwritten by Tumbleweeds
-## version.
+## Set whether to allow changing the packages vendor upon DUP. In most cases you
+## want to continue using the packages from the same source/vendor as currently
+## installed. If you would prefer Packages from OBS/additional repos overwriting
+## packages from your currently in-use repositories you may consider changing
+## this option.
 ##
 ## CHANGING THE DEFAULT IS NOT RECOMMENDED.
 ##
 ## Valid values:  boolean
-## Default value: true
+## Default value: false
 ##
-# solver.dupAllowVendorChange = true
+# solver.dupAllowVendorChange = false
 
 ##
 ## EXPERTS ONLY: Cleanup when deleting packages. Whether the solver should

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -331,7 +331,7 @@ namespace zypp
 	, solver_dupAllowDowngrade	( true )
 	, solver_dupAllowNameChange	( true )
 	, solver_dupAllowArchChange	( true )
-	, solver_dupAllowVendorChange	( true )
+	, solver_dupAllowVendorChange	( false )
         , solver_cleandepsOnRemove	( false )
         , solver_upgradeTestcasesToKeep	( 2 )
         , solverUpgradeRemoveDroppedPackages( true )


### PR DESCRIPTION
Based on discussions triggered after my recent Tumbleweed talk ( https://youtu.be/RbP9lNvmWKk?t=32m16s ) and the realisation of the following:

1. Tumbleweed obviously already only recommend dup with --no-allow-vendor-change
2. SLE's recommendation for 'dup' usage is only with --no-allow-vendor-change (https://www.susecon.com/doc/2015/sessions/TUT16735.pdf slide 44)
3. A dup from Leap versions with --no-allow-vendor-change would allow a smoother transition between minor versions while still using OBS repos and simplify the guidance on https://en.opensuse.org/SDB:System_upgrade

This in my mind makes a compelling argument for the default for dupAllowVendorChange to by false.