### PR TITLE
SUSEMediaVerifier: add debug logs

### DIFF
--- a/zypp/repo/SUSEMediaVerifier.cc
+++ b/zypp/repo/SUSEMediaVerifier.cc
@@ -8,6 +8,7 @@
 \---------------------------------------------------------------------*/
 
 #include <fstream>
+#include "zypp/base/Logger.h"
 #include "zypp/repo/SUSEMediaVerifier.h"
 
 using namespace std;
@@ -31,7 +32,7 @@ SUSEMediaVerifier::SUSEMediaVerifier( int media_nr, const Pathname &path_r )
   std::ifstream str(path_r.asString().c_str());
   std::string vendor;
   std::string id;
-  
+
   if ( str )
   {
     getline(str, _media_vendor);
@@ -55,11 +56,17 @@ bool SUSEMediaVerifier::isDesiredMedia(const media::MediaAccessRef &ref)
   std::ifstream str(media_file.asString().c_str());
   std::string vendor;
   std::string id;
-#warning check the stream status
   getline(str, vendor);
   getline(str, id);
 
-  return (vendor == _media_vendor && id == _media_id );
+  bool ret = ( vendor == _media_vendor && id == _media_id  );
+  if ( !ret ) {
+    DBG << "cached vendor: " << _media_vendor << endl;
+    DBG << "repo vendor: " << vendor << endl;
+    DBG << "cached id: " << _media_id << endl;
+    DBG << "repo id: " << id << endl;
+  }
+  return ret;
 }
 
 }


### PR DESCRIPTION
isDesiredMedia() media may fail, which ultimately causes a
MediaNotDesiredException to be thrown. To ease debugging, print the
values of the (cached) media id and vendor in zypper's log when running
with ZYPP_FULLLOG=1.

Also remove the superfluous CPP warning. ifstream.getline() throws an
exception in case something goes wrong while reading the file.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>


**An example log can be seen below. Having had this information could have saved some time while debugging https://github.com/openSUSE/docker-containers/issues/57:**

2017-07-01 13:55:34 <1> 4fa6b2226328(22) [zypp++] SUSEMediaVerifier.cc(isDesiredMedia):60 reading data from repository media: /var/tmp/AP_0xGuawE5/media.1/media
2017-07-01 13:55:34 <1> 4fa6b2226328(22) [zypp++] SUSEMediaVerifier.cc(isDesiredMedia):64 cached vendor: openSUSE
2017-07-01 13:55:34 <1> 4fa6b2226328(22) [zypp++] SUSEMediaVerifier.cc(isDesiredMedia):65 repo vendor: openSUSE
2017-07-01 13:55:34 <1> 4fa6b2226328(22) [zypp++] SUSEMediaVerifier.cc(isDesiredMedia):66 cached id: 20170622230716
2017-07-01 13:55:34 <1> 4fa6b2226328(22) [zypp++] SUSEMediaVerifier.cc(isDesiredMedia):67 repo id: 20170630123522