### PR TITLE
rename: handle EXDEV error on OverlayFS

### DIFF
--- a/zypp/PathInfo.h
+++ b/zypp/PathInfo.h
@@ -598,7 +598,10 @@ namespace zypp
     int unlink( const Pathname & path );
 
     /**
-     * Like '::rename'. Renames a file, moving it between directories if required.
+     * Like '::rename'. Renames a file, moving it between directories if
+     * required. It falls back to using mv(1) in case errno is set to
+     * EXDEV, indicating a cross-device rename, which is likely to happen when
+     * oldpath and newpath are not on the same OverlayFS layer.
      *
      * @return 0 on success, errno on failure
      **/


### PR DESCRIPTION
The `rename(2)` systemcall doesn't succeed across devices, which is likely
to happen when using the overlay storage driver in Docker when trying to
rename between the upper and the lower layer. In such case, errno is
set to *EXDEV*.

Extend `PathInfo::rename` to handle the *EXDEV* errno case and fallback to
using `mv(1)`, which is explicitly mentioned in the kernel docs to deal
correctly with OverlayFS issues.

**Fixes:** https://github.com/openSUSE/docker-containers/issues/57
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>