### PR TITLE
Fix c++-11 compiler warning

### DIFF
--- a/zypp/base/ReferenceCounted.cc
+++ b/zypp/base/ReferenceCounted.cc
@@ -30,7 +30,7 @@ namespace zypp
     : _counter( 0 )
     {}
 
-    ReferenceCounted::~ReferenceCounted()
+    ReferenceCounted::~ReferenceCounted() noexcept(false)
     {
       if ( _counter )
         {

--- a/zypp/base/ReferenceCounted.cc
+++ b/zypp/base/ReferenceCounted.cc
@@ -30,12 +30,11 @@ namespace zypp
     : _counter( 0 )
     {}
 
-    ReferenceCounted::~ReferenceCounted() noexcept(false)
+    ReferenceCounted::~ReferenceCounted()
     {
       if ( _counter )
         {
           INT << "~ReferenceCounted: nonzero reference count" << std::endl;
-          throw std::out_of_range( "~ReferenceCounted: nonzero reference count" );
         }
     }
 


### PR DESCRIPTION
By default destructors are noexcept in c++-11 so gcc compiler will give warning.
Fix applied.