### PR TITLE
Fix c++-11 compiler warning

### DIFF
--- a/zypp/base/ReferenceCounted.cc
+++ b/zypp/base/ReferenceCounted.cc
@@ -35,7 +35,6 @@ namespace zypp
       if ( _counter )
         {
           INT << "~ReferenceCounted: nonzero reference count" << std::endl;
-          throw std::out_of_range( "~ReferenceCounted: nonzero reference count" );
         }
     }
 


### PR DESCRIPTION
By default, destructors are noexcept as per c++-11 standards. So compiler will warn about thorw statement.