### PR TITLE
[RPM4.4] Use definition of `rpm_count_t` from `/usr/include/rpm/rpmtypes.h`

### DIFF
--- a/zypp/target/rpm/BinHeader.cc
+++ b/zypp/target/rpm/BinHeader.cc
@@ -16,10 +16,6 @@ extern "C"
 #undef RPM_NULL_TYPE
 #define RPM_NULL_TYPE rpmTagType(0)
 typedef rpmuint32_t rpm_count_t;
-#else
-#ifdef _RPM_4_4
-typedef int32_t rpm_count_t;
-#endif
 #endif
 }
 


### PR DESCRIPTION
Depending on the version of RPM 4.X, this can be an `int32_t` type or an `uint32_t` type.

On recent versions of RPM >= 4.14 `rpm_count_t` is defined as `uint32_t`.

```
/builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc:21:17: error: conflicting declaration 'typedef int32_t rpm_count_t'
 typedef int32_t rpm_count_t;
                 ^~~~~~~~~~~
In file included from /usr/include/rpm/rpmio.h:16:0,
                 from /usr/include/rpm/rpmlib.h:13,
                 from /builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/librpm.h:25,
                 from /builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc:12:
/usr/include/rpm/rpmtypes.h:29:18: note: previous declaration as 'typedef uint32_t rpm_count_t'
 typedef uint32_t rpm_count_t;
                  ^~~~~~~~~~~
/builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc: In constructor 'zypp::target::rpm::HeaderEntryGetter::HeaderEntryGetter(headerToken_s* const&, rpmTag&)':
/builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc:82:7: error: '::headerGetEntry' has not been declared
   { ::headerGetEntry( h_r, tag_r, hTYP_t(&_type), &_val, &_cnt ); }
       ^~~~~~~~~~~~~~
/builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc:82:7: note: suggested alternative: 'headerIsEntry'
   { ::headerGetEntry( h_r, tag_r, hTYP_t(&_type), &_val, &_cnt ); }
       ^~~~~~~~~~~~~~
       headerIsEntry
/builddir/build/BUILD/libzypp-16.15.2/zypp/target/rpm/BinHeader.cc:82:35: error: 'hTYP_t' was not declared in this scope
   { ::headerGetEntry( h_r, tag_r, hTYP_t(&_type), &_val, &_cnt ); }
                                   ^~~~~~
make[2]: *** [zypp/CMakeFiles/zypp.dir/build.make:1866: zypp/CMakeFiles/zypp.dir/target/rpm/BinHeader.cc.o] Error 1
```