### PR TITLE
PoolQuery::addDependency add overload to define an individual Match::…

### DIFF
--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -287,6 +287,8 @@ namespace zypp
     void addDependency( const sat::SolvAttr & attr, const std::string & name, const Rel & op, const Edition & edition );
     /**  \overload also restricting architecture */
     void addDependency( const sat::SolvAttr & attr, const std::string & name, const Rel & op, const Edition & edition, const Arch & arch );
+    /**  \overload also use an individual Match::Mode for the \a name */
+    void addDependency( const sat::SolvAttr & attr, const std::string & name, const Rel & op, const Edition & edition, const Arch & arch, Match::Mode mode );
 
     /** \overload Query <tt>"name|global == edition"</tt>. */
     void addDependency( const sat::SolvAttr & attr, const std::string & name, const Edition & edition )


### PR DESCRIPTION
…Mode (bsc#1043166)

JFYI: The enhancement here will be needed to fix zypper search (bsc#1043166), that's why we refer to the bug number here in libzypp too. The commit policy for SLES requires a bug reference in the changelog to accept a submission. If this PR happens to be the only change in libzypp, we would otherwise not be able to release it in order to provide a fixed zypper. 