### PR TITLE
Introduce ZConfig::repoManagerRoot to support having diverging target…

### DIFF
--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -628,6 +628,7 @@ namespace zypp
     Pathname cfg_known_repos_path;
     Pathname cfg_known_services_path;
     Pathname cfg_vars_path;
+    Pathname cfg_repo_mgr_root_path;
 
     Pathname cfg_vendor_path;
     Pathname cfg_multiversion_path;
@@ -817,6 +818,16 @@ namespace zypp
 
   Pathname ZConfig::systemRoot() const
   { return _autodetectSystemRoot(); }
+
+
+  Pathname ZConfig::repoManagerRoot() const
+  {
+    return ( _pimpl->cfg_repo_mgr_root_path.empty()
+             ? systemRoot() : _pimpl->cfg_repo_mgr_root_path );
+  }
+
+  void ZConfig::setRepoManagerRoot(const zypp::filesystem::Pathname &root)
+  { _pimpl->cfg_repo_mgr_root_path = root; }
 
   ///////////////////////////////////////////////////////////////////
   //

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -73,6 +73,16 @@ namespace zypp
        */
       Pathname systemRoot() const;
 
+      /** The RepoManager root directory.
+       *  Returns the same as \sa systemRoot() if not explicitely set.
+       */
+      Pathname repoManagerRoot() const;
+
+      /** Sets the RepoManager root directory.
+       *  \sa repoManagerRoot()
+       */
+      void setRepoManagerRoot ( const Pathname &root );
+
     public:
 
       /** The autodetected system architecture. */

--- a/zypp/media/MediaCIFS.cc
+++ b/zypp/media/MediaCIFS.cc
@@ -162,7 +162,7 @@ namespace zypp {
       std::string mountpoint( attachPoint().asString() );
 
       Mount mount;
-      CredentialManager cm;
+      CredentialManager cm(CredManagerOptions(ZConfig::instance().repoManagerRoot()));
 
       Mount::Options options( _url.getQueryParam("mountoptions") );
       string username = _url.getUsername();
@@ -403,7 +403,7 @@ namespace zypp {
     bool MediaCIFS::authenticate(AuthData & authdata, bool firstTry) const
     {
       //! \todo need a way to pass different CredManagerOptions here
-      CredentialManager cm(CredManagerOptions(ZConfig::instance().systemRoot()));
+      CredentialManager cm(CredManagerOptions(ZConfig::instance().repoManagerRoot()));
 
       // get stored credentials
       AuthData_Ptr cmcred = cm.getCred(_url);

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -1693,8 +1693,7 @@ string MediaCurl::getAuthHint() const
 bool MediaCurl::authenticate(const string & availAuthTypes, bool firstTry) const
 {
   //! \todo need a way to pass different CredManagerOptions here
-  Target_Ptr target = zypp::getZYpp()->getTarget();
-  CredentialManager cm(CredManagerOptions(target ? target->root() : ""));
+  CredentialManager cm(CredManagerOptions(ZConfig::instance().repoManagerRoot()));
   CurlAuthData_Ptr credentials;
 
   // get stored credentials

--- a/zypp/repo/RepoVariables.cc
+++ b/zypp/repo/RepoVariables.cc
@@ -403,7 +403,7 @@ namespace zypp
 	  if ( empty() )	// at init / after reset
 	  {
 	    // load user definitions from vars.d
-	    filesystem::dirForEach( ZConfig::instance().systemRoot() / ZConfig::instance().varsPath(),
+	    filesystem::dirForEach( ZConfig::instance().repoManagerRoot() / ZConfig::instance().varsPath(),
 				    filesystem::matchNoDots(), bind( &RepoVarsMap::parse, this, _1, _2 ) );
 	    // releasever_major/_minor are per default derived from releasever.
 	    // If releasever is userdefined, inject missing _major/_minor too.


### PR DESCRIPTION
… and repomanager root paths

Introduces a new function called ZConfig::repoManagerRoot required for openSUSE/zypper#157, so zypper can tell libZypp to use a different path for custom variable replacement