### PR TITLE
Show GPGME version in log

### DIFF
--- a/zypp/KeyManager.cc
+++ b/zypp/KeyManager.cc
@@ -48,8 +48,15 @@ std::ostream & operator<<( std::ostream & str, const GpgmeErr & obj )
 
 static void initGpgme ()
 {
-  gpgme_check_version(NULL);
-
+  const char *version = gpgme_check_version(NULL);
+  if ( version )
+  {
+    MIL << "Initialized libgpgme version: " << version << endl;
+  }
+  else
+  {
+    MIL << "Initialized libgpgme with unknown version" << endl;
+  }
 }
 
 namespace zypp


### PR DESCRIPTION
For easier debugging of libgpgme problems it will help us to list the loaded gpgme library version in the log file.