### PR TITLE
Ma fix fetcher checks

### DIFF
--- a/zypp/Fetcher.cc
+++ b/zypp/Fetcher.cc
@@ -27,8 +27,6 @@
 #include "zypp/parser/susetags/ContentFileReader.h"
 #include "zypp/parser/susetags/RepoIndex.h"
 
-using namespace std;
-
 #undef ZYPP_BASE_LOGGER_LOGGROUP
 #define ZYPP_BASE_LOGGER_LOGGROUP "zypp:fetcher"
 
@@ -108,7 +106,7 @@ namespace zypp
     OnMediaLocation location;
     Pathname deltafile;
     //CompositeFileChecker checkers;
-    list<FileChecker> checkers;
+    std::list<FileChecker> checkers;
     Flags flags;
   };
 
@@ -196,7 +194,7 @@ namespace zypp
        * on dest_dir
        * \throws Exception
        */
-      void validate( const OnMediaLocation &resource, const Pathname &dest_dir, const list<FileChecker> &checkers );
+      void validate( const OnMediaLocation &resource, const Pathname &dest_dir, const std::list<FileChecker> &checkers );
 
       /**
        * scan the directory and adds the individual jobs
@@ -222,13 +220,13 @@ namespace zypp
     Impl * clone() const
     { return new Impl( *this ); }
 
-    list<FetcherJob_Ptr>   _resources;
+    std::list<FetcherJob_Ptr>   _resources;
     std::set<FetcherIndex_Ptr,SameFetcherIndex> _indexes;
     std::set<Pathname> _caches;
     // checksums read from the indexes
-    map<string, CheckSum> _checksums;
+    std::map<std::string, CheckSum> _checksums;
     // cache of dir contents
-    map<string, filesystem::DirContent> _dircontent;
+    std::map<std::string, filesystem::DirContent> _dircontent;
 
     Fetcher::Options _options;
   };
@@ -382,7 +380,7 @@ namespace zypp
     return false;
   }
 
-    void Fetcher::Impl::validate( const OnMediaLocation &resource, const Pathname &dest_dir, const list<FileChecker> &checkers )
+    void Fetcher::Impl::validate( const OnMediaLocation &resource, const Pathname &dest_dir, const std::list<FileChecker> &checkers )
   {
     // no matter where did we got the file, try to validate it:
     Pathname localfile = dest_dir + resource.filename();
@@ -391,7 +389,7 @@ namespace zypp
     {
       MIL << "Checking job [" << localfile << "] (" << checkers.size() << " checkers )" << endl;
 
-      for ( list<FileChecker>::const_iterator it = checkers.begin();
+      for ( std::list<FileChecker>::const_iterator it = checkers.begin();
             it != checkers.end();
             ++it )
       {
@@ -755,7 +753,7 @@ namespace zypp
 
     downloadAndReadIndexList(media, dest_dir);
 
-    for ( list<FetcherJob_Ptr>::const_iterator it_res = _resources.begin(); it_res != _resources.end(); ++it_res )
+    for ( std::list<FetcherJob_Ptr>::const_iterator it_res = _resources.begin(); it_res != _resources.end(); ++it_res )
     {
 
       if ( (*it_res)->flags & FetcherJob::Directory )
@@ -844,7 +842,7 @@ namespace zypp
   /** \relates Fetcher::Impl Stream output */
   inline std::ostream & operator<<( std::ostream & str, const Fetcher::Impl & obj )
   {
-      for ( list<FetcherJob_Ptr>::const_iterator it_res = obj._resources.begin(); it_res != obj._resources.end(); ++it_res )
+      for ( std::list<FetcherJob_Ptr>::const_iterator it_res = obj._resources.begin(); it_res != obj._resources.end(); ++it_res )
       {
           str << *it_res;
       }

--- a/zypp/Fetcher.cc
+++ b/zypp/Fetcher.cc
@@ -535,12 +535,9 @@ namespace zypp
 
   void Fetcher::Impl::provideToDest( MediaSetAccess &media, const OnMediaLocation &resource, const Pathname &dest_dir, const Pathname &deltafile )
   {
-    bool got_from_cache = false;
 
-    // start look in cache
-    got_from_cache = provideFromCache(resource, dest_dir);
 
-    if ( ! got_from_cache )
+    if ( ! provideFromCache( resource, dest_dir ) )
     {
       MIL << "Not found in cache, downloading" << endl;
 

--- a/zypp/Fetcher.cc
+++ b/zypp/Fetcher.cc
@@ -184,11 +184,11 @@ namespace zypp
       void getDirectoryContent( MediaSetAccess &media, const OnMediaLocation &resource, filesystem::DirContent &content );
 
       /**
-       * tries to provide the file represented by job into dest_dir by
-       * looking at the cache. If success, returns true, and the desired
-       * file should be available on dest_dir
+       * Tries to locate the file represented by job by looking at
+       * the cache (matching checksum is mandatory). Returns the
+       * location of the cached file or an empty \ref Pathname.
        */
-      bool provideFromCache( const OnMediaLocation &resource, const Pathname &dest_dir );
+      Pathname locateInCache( const OnMediaLocation & resource_r, const Pathname & destDir_r );
       /**
        * Validates the provided file against its checkers.
        * \throws Exception
@@ -329,54 +329,34 @@ namespace zypp
 
   }
 
-  // tries to provide resource to dest_dir from any of the configured additional
-  // cache paths where the file may already be present. returns true if the
-  // file was provided from the cache.
-  bool Fetcher::Impl::provideFromCache( const OnMediaLocation &resource, const Pathname &dest_dir )
+  Pathname Fetcher::Impl::locateInCache( const OnMediaLocation & resource_r, const Pathname & destDir_r )
   {
-    Pathname dest_full_path = dest_dir + resource.filename();
+    Pathname ret;
+    // No checksum - no match
+    if ( resource_r.checksum().empty() )
+      return ret;
 
     // first check in the destination directory
-    if ( PathInfo(dest_full_path).isExist() )
+    Pathname cacheLocation = destDir_r / resource_r.filename();
+    if ( PathInfo(cacheLocation).isExist() && is_checksum( cacheLocation, resource_r.checksum() ) )
     {
-      if ( is_checksum( dest_full_path, resource.checksum() )
-           && (! resource.checksum().empty() ) )
-          return true;
+      swap( ret, cacheLocation );
+      return ret;
     }
 
     MIL << "start fetcher with " << _caches.size() << " cache directories." << endl;
-    for_ ( it_cache, _caches.begin(), _caches.end() )
+    for( const Pathname & cacheDir : _caches )
     {
-      // does the current file exists in the current cache?
-      Pathname cached_file = *it_cache + resource.filename();
-      if ( PathInfo( cached_file ).isExist() )
+      cacheLocation = cacheDir / resource_r.filename();
+      if ( PathInfo(cacheLocation).isExist() && is_checksum( cacheLocation, resource_r.checksum() ) )
       {
-        DBG << "File '" << cached_file << "' exist, testing checksum " << resource.checksum() << endl;
-         // check the checksum
-        if ( is_checksum( cached_file, resource.checksum() ) && (! resource.checksum().empty() ) )
-        {
-          // cached
-          MIL << "file " << resource.filename() << " found in previous cache. Using cached copy." << endl;
-          // checksum is already checked.
-          // we could later implement double failover and try to download if file copy fails.
-           // replicate the complete path in the target directory
-          if( dest_full_path != cached_file )
-          {
-            if ( assert_dir( dest_full_path.dirname() ) != 0 )
-              ZYPP_THROW( Exception("Can't create " + dest_full_path.dirname().asString()));
-
-            if ( filesystem::hardlinkCopy(cached_file, dest_full_path ) != 0 )
-            {
-              ERR << "Can't hardlink/copy " << cached_file + " to " + dest_dir << endl;
-              continue;
-            }
-          }
-          // found in cache
-          return true;
-        }
+	MIL << "file " << resource_r.filename() << " found in cache " << cacheDir << endl;
+	swap( ret, cacheLocation );
+	return ret;
       }
-    } // iterate over caches
-    return false;
+    }
+
+    return ret;
   }
 
   void Fetcher::Impl::validate( const Pathname & localfile_r, const std::list<FileChecker> & checkers_r )
@@ -527,52 +507,54 @@ namespace zypp
   {
     const OnMediaLocation & resource( jobp_r->location );
 
-    if ( ! provideFromCache( resource, destDir_r ) )
+    try
     {
-      MIL << "Not found in cache, downloading" << endl;
+      scoped_ptr<MediaSetAccess::ReleaseFileGuard> releaseFileGuard; // will take care provided files get released
 
-      // try to get the file from the net
-      try
+      // get cached file (by checksum) or provide from media
+      Pathname tmpFile = locateInCache( resource, destDir_r );
+      if ( tmpFile.empty() )
       {
-        Pathname tmp_file = media_r.provideFile(resource, resource.optional() ? MediaSetAccess::PROVIDE_NON_INTERACTIVE : MediaSetAccess::PROVIDE_DEFAULT, jobp_r->deltafile );
-        Pathname dest_full_path = destDir_r + resource.filename();
-
-        if ( assert_dir( dest_full_path.dirname() ) != 0 )
-              ZYPP_THROW( Exception("Can't create " + dest_full_path.dirname().asString()));
-
-        if ( filesystem::hardlinkCopy( tmp_file, dest_full_path ) != 0 )
-        {
-          if ( ! PathInfo(tmp_file).isExist() )
-              ERR << tmp_file << " does not exist" << endl;
-          if ( ! PathInfo(dest_full_path.dirname()).isExist() )
-              ERR << dest_full_path.dirname() << " does not exist" << endl;
-
-          media_r.releaseFile(resource); //not needed anymore, only eat space
-          ZYPP_THROW( Exception("Can't hardlink/copy " + tmp_file.asString() + " to " + destDir_r.asString()));
-        }
-
-        media_r.releaseFile(resource); //not needed anymore, only eat space
+	MIL << "Not found in cache, retrieving..." << endl;
+	tmpFile = media_r.provideFile( resource, resource.optional() ? MediaSetAccess::PROVIDE_NON_INTERACTIVE : MediaSetAccess::PROVIDE_DEFAULT, jobp_r->deltafile );
+	releaseFileGuard.reset( new MediaSetAccess::ReleaseFileGuard( media_r, resource ) ); // release it when we leave the block
       }
-      catch (Exception & excpt_r)
+
+      // The final destination: locateInCache also checks destFullPath!
+      // If we find a cache match (by checksum) at destFullPath, take
+      // care it gets deleted, in case the validation fails.
+      ManagedFile destFullPath( destDir_r / resource.filename() );
+      if ( tmpFile == destFullPath )
+	destFullPath.setDispose( filesystem::unlink );
+
+      // validate the file (throws if not valid)
+      validate( tmpFile, jobp_r->checkers );
+
+      // move it to the final destination
+      if ( tmpFile == destFullPath )
+	destFullPath.resetDispose();	// keep it!
+      else
       {
-        if ( resource.optional() )
-        {
-	    ZYPP_CAUGHT(excpt_r);
-            WAR << "optional resource " << resource << " could not be transferred" << endl;
-            return;
-        }
-        else
-        {
-	    excpt_r.remember("Can't provide " + resource.filename().asString() );
-            ZYPP_RETHROW(excpt_r);
-        }
+	if ( assert_dir( destFullPath->dirname() ) != 0 )
+	  ZYPP_THROW( Exception( "Can't create " + destFullPath->dirname().asString() ) );
+
+	if ( filesystem::hardlinkCopy( tmpFile, destFullPath ) != 0 )
+	  ZYPP_THROW( Exception( "Can't hardlink/copy " + tmpFile.asString() + " to " + destDir_r.asString() ) );
       }
     }
-    else
+    catch ( Exception & excpt )
     {
-      // We got the file from cache
-      // continue with next file
-        return;
+      if ( resource.optional() )
+      {
+	ZYPP_CAUGHT( excpt );
+	WAR << "optional resource " << resource << " could not be transferred." << endl;
+	return;
+      }
+      else
+      {
+	excpt.remember( "Can't provide " + resource.filename().asString() );
+	ZYPP_RETHROW( excpt );
+      }
     }
   }
 
@@ -780,13 +762,6 @@ namespace zypp
           autoaddIndexes(content, media, Pathname("/"), dest_dir);
       }
 
-      provideToDest( media, dest_dir, jobp );
-
-      // if the file was not transferred, and no exception, just
-      // return, as it was an optional file
-      if ( ! PathInfo(dest_dir + jobp->location.filename()).isExist() )
-          continue;
-
       // if the checksum is empty, but the checksum is in one of the
       // indexes checksum, then add a checker
       if ( jobp->location.checksum().empty() )
@@ -817,8 +792,9 @@ namespace zypp
           jobp->checkers.push_back(digest_check);
       }
 
-      // validate job, this throws if not valid
-      validate( dest_dir / jobp->location.filename(), jobp->checkers );
+      // Provide and validate the file. If the file was not transferred
+      // and no exception was thrown, it was an optional file.
+      provideToDest( media, dest_dir, jobp );
 
       if ( ! progress.incr() )
         ZYPP_THROW(AbortRequestException());

--- a/zypp/MediaSetAccess.h
+++ b/zypp/MediaSetAccess.h
@@ -218,6 +218,36 @@ namespace zypp
        */
       void releaseFile(const Pathname & file, unsigned media_nr = 1 );
 
+      ///////////////////////////////////////////////////////////////////
+      /// \class MediaSetAccess::ReleaseFileGuard
+      /// \brief Release a provided file upon destruction.
+      /// In case you don't want to wait until the \ref MediaSetAccess
+      /// itself goes out of scope.
+      /// \code
+      ///   MediaSetAccess media;
+      ///   OnMediaLocation loc;
+      ///   {
+      ///   	Pathname file = media.provideFile( loc );
+      ///   	ReleaseFileGuard guard( media, loc );
+      ///   }   // provided file is released here.
+      /// \endcode
+      /// \ingroup g_RAII
+      ///////////////////////////////////////////////////////////////////
+      struct ReleaseFileGuard
+      {
+	NON_COPYABLE( ReleaseFileGuard );
+	NON_MOVABLE( ReleaseFileGuard );
+	ReleaseFileGuard( MediaSetAccess & media_r, const OnMediaLocation & loc_r )
+	: _media( media_r )
+	, _loc( loc_r )
+	{}
+	~ReleaseFileGuard()
+	{ _media.releaseFile( _loc ); }
+      private:
+	MediaSetAccess & _media;
+	const OnMediaLocation & _loc;
+      };
+
       /**
        * Provides direcotry \a dir from media number \a media_nr.
        *

--- a/zypp/PathInfo.h
+++ b/zypp/PathInfo.h
@@ -734,7 +734,7 @@ namespace zypp
     /**
      * check files checksum
      *
-     * @return true if the checksum matchs
+     * @return true if the checksum matches (an empty Checksum always matches!)
      **/
     bool is_checksum( const Pathname & file, const CheckSum &checksum );
 


### PR DESCRIPTION
Rewrote Fetcher to move only validated files to the final destination.  A file already found at the final destination, but not validating, will be unlinked.

This behavior is desired to fix [bsc#1091624](https://bugzilla.suse.com/show_bug.cgi?id=1091624). Package signature check will be moved to the Fetcher, so we don't get unchecked Packages into the cache.



