### PR TITLE
Rpmhead download

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -171,6 +171,25 @@ IMPL_PTR_TYPE(MediaSetAccess);
     return op.result;
   }
 
+  Pathname MediaSetAccess::provideFileHead(const OnMediaLocation &resource_r, const ByteCount minBytes_r, ProvideFileOptions options_r)
+  {
+    Pathname result;
+    auto op = [ &minBytes_r, &result ] ( media::MediaAccessId media, const Pathname &file ) {
+      media::MediaManager media_mgr;
+      media_mgr.provideFileHead(media, file ,minBytes_r);
+      result = media_mgr.localPath(media, file);
+    };
+    provide( op, resource_r, options_r, Pathname() );
+    return result;
+  }
+
+  Pathname MediaSetAccess::provideFileHead(const Pathname &file_r, const ByteCount minBytes_r, unsigned mediaNr_r, ProvideFileOptions options_r)
+  {
+    OnMediaLocation resource;
+    resource.setLocation(file_r, mediaNr_r);
+    return provideFileHead( resource, minBytes_r, options_r );
+  }
+
   ManagedFile MediaSetAccess::provideFileFromUrl(const Url &file_url, ProvideFileOptions options)
   {
     Url url(file_url);

--- a/zypp/MediaSetAccess.h
+++ b/zypp/MediaSetAccess.h
@@ -173,6 +173,51 @@ namespace zypp
       Pathname provideFile(const Pathname & file, unsigned media_nr = 1, ProvideFileOptions options = PROVIDE_DEFAULT );
 
       /**
+       * Provides at least the first n bytes of \a file_r from media \a mediaNr_r.
+       *
+       * \param resource location of the file on media
+       * \param minBytes the first n bytes to provide at least, can be ignored by backed
+       * \return local pathname of the requested file
+       *
+       * \note interaction with the user does not ocurr if
+       * \ref ProvideFileOptions::NON_INTERACTIVE is set.
+       *
+       * \note OnMediaLocation::optional() hint has no effect on the transfer.
+       *
+       * \throws MediaException if a problem occured and user has chosen to
+       *         abort the operation. The calling code should take care
+       *         to quit the current operation.
+       * \throws SkipRequestException if a problem occured and user has chosen
+       *         to skip the current operation. The calling code should continue
+       *         with the next one, if possible.
+       * \see zypp::media::MediaManager::provideFile()
+       */
+      Pathname provideFileHead(const OnMediaLocation & resource_r, const ByteCount minBytes_r, ProvideFileOptions options_r = PROVIDE_DEFAULT );
+
+      /**
+       * Provides at least the first n bytes of \a file from media \a media_nr.
+       *
+       * \param file path to the file relative to media URL
+       * \param minBytes the first n bytes to provide at least, can be ignored by backed
+       * \param media_nr the media number in the media set
+       * \return local pathname of the requested file
+       *
+       * \note interaction with the user does not ocurr if
+       * \ref ProvideFileOptions::NON_INTERACTIVE is set.
+       *
+       * \note OnMediaLocation::optional() hint has no effect on the transfer.
+       *
+       * \throws MediaException if a problem occured and user has chosen to
+       *         abort the operation. The calling code should take care
+       *         to quit the current operation.
+       * \throws SkipRequestException if a problem occured and user has chosen
+       *         to skip the current operation. The calling code should continue
+       *         with the next one, if possible.
+       * \see zypp::media::MediaManager::provideFile()
+       */
+      Pathname provideFileHead(const Pathname & file_r, const ByteCount minBytes_r, unsigned mediaNr_r = 1, ProvideFileOptions options_r = PROVIDE_DEFAULT );
+
+      /**
        * Provides \a file from \a url.
        *
        * \param absolute url to the file

--- a/zypp/Package.h
+++ b/zypp/Package.h
@@ -16,12 +16,38 @@
 #include "zypp/PackageKeyword.h"
 #include "zypp/Changelog.h"
 #include "zypp/VendorSupportOptions.h"
+#include "zypp/Callback.h"
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 { /////////////////////////////////////////////////////////////////
 
   DEFINE_PTR_TYPE(Package);
+
+
+  /** Callbacks for rpm header downloads on demand.
+   *
+   * Per default all methods answer \c false.
+  */
+  struct PackageHeadReport : public callback::ReportBase
+  {
+
+    const char * ACCEPT_PACKAGE_HEAD_DOWNLOAD = "PackageHeadReport/AskAboutPackageHeadDownload";
+
+    /**
+    * Ask user if the RPM header for \a packageName_r should be downloaded
+    *
+    * The UserData object will have the following fields:
+    * "PackageName"		The name of the package header to be downloaded
+    *
+    * Userdata accepted:
+    * "Response"			bool user can either accept or deny the request
+    *
+    * \note this is a non virtual function and will use ReportBase::report to send the report.
+    *
+    */
+    bool askUserAboutPackageHeadDownload ( const std::string &packageName_r );
+  };
 
   ///////////////////////////////////////////////////////////////////
   //
@@ -128,6 +154,9 @@ namespace zypp
     /** Whether the package is cached. */
     bool isCached() const
     { return ! cachedLocation().empty(); }
+
+    /** End of the RPM header in the package file. */
+    ByteCount headerend() const;
 
   protected:
     friend Ptr make<Self>( const sat::Solvable & solvable_r );

--- a/zypp/media/MediaAccess.cc
+++ b/zypp/media/MediaAccess.cc
@@ -346,6 +346,15 @@ MediaAccess::provideFile( const Pathname & filename ) const
   _handler->provideFile( filename );
 }
 
+void MediaAccess::provideFileHead(const Pathname &filename_r, const ByteCount minBytes_r) const
+{
+  if ( !_handler ) {
+    ZYPP_THROW(MediaNotOpenException("provideFile(" + filename_r.asString() + ")"));
+  }
+
+  _handler->provideFileHead( filename_r, minBytes_r );
+}
+
 void
 MediaAccess::setDeltafile( const Pathname & filename ) const
 {

--- a/zypp/media/MediaAccess.h
+++ b/zypp/media/MediaAccess.h
@@ -222,6 +222,19 @@ namespace zypp {
 	void provideFile( const Pathname & filename ) const;
 
 	/**
+	 * Use concrete handler to provide the first n bytes of file denoted by path below
+	 * 'attach point'. Filename is interpreted relative to the
+	 * attached url and a path prefix is preserved. The partial file is stored in the
+	 * specified target path
+	 *
+	 * \throws MediaException
+	 *
+	 **/
+	void provideFileHead( const Pathname &filename_r, const ByteCount minBytes_r) const;
+
+
+
+	/**
 	 * Remove filename below attach point IFF handler downloads files
 	 * to the local filesystem. Never remove anything from media.
 	 *

--- a/zypp/media/MediaCurl.h
+++ b/zypp/media/MediaCurl.h
@@ -54,6 +54,7 @@ class MediaCurl : public MediaHandler
     virtual void attachTo (bool next = false);
     virtual void releaseFrom( const std::string & ejectDev );
     virtual void getFile( const Pathname & filename ) const;
+    virtual void getFileHead( const Pathname & filename, const ByteCount minBytes ) const override;
     virtual void getDir( const Pathname & dirname, bool recurse_r ) const;
     virtual void getDirInfo( std::list<std::string> & retlist,
                              const Pathname & dirname, bool dots = true ) const;
@@ -83,6 +84,13 @@ class MediaCurl : public MediaHandler
      *
      */
     virtual void getFileCopy( const Pathname & srcFilename, const Pathname & targetFilename) const;
+    /**
+     *
+     * \throws MediaException
+     *
+     */
+    void getFileHeadCopy(const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r) const override;
+
 
     /**
      *
@@ -90,6 +98,7 @@ class MediaCurl : public MediaHandler
      *
      */
     virtual void doGetFileCopy( const Pathname & srcFilename, const Pathname & targetFilename, callback::SendReport<DownloadProgressReport> & _report, RequestOptions options = OPTION_NONE ) const;
+    void doGetFileHeadCopy( const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r, callback::SendReport<DownloadProgressReport> &report_r, RequestOptions options_r = OPTION_NONE ) const;
 
 
     virtual bool checkAttachPoint(const Pathname &apoint) const;
@@ -149,7 +158,7 @@ class MediaCurl : public MediaHandler
      */
     void evaluateCurlCode( const zypp::Pathname &filename, CURLcode code, bool timeout ) const;
 
-    void doGetFileCopyFile( const Pathname & srcFilename, const Pathname & dest, FILE *file, callback::SendReport<DownloadProgressReport> & _report, RequestOptions options = OPTION_NONE ) const;
+    void doGetFileCopyFile( const Pathname & srcFilename_r, const Pathname & dest_r, const ByteCount minBytes_r, FILE *file_r, callback::SendReport<DownloadProgressReport> & report_r, RequestOptions options_r = OPTION_NONE ) const;
 
   private:
     /**

--- a/zypp/media/MediaHandler.cc
+++ b/zypp/media/MediaHandler.cc
@@ -1004,6 +1004,17 @@ void MediaHandler::provideFileCopy( Pathname srcFilename,
   DBG << "provideFileCopy(" << srcFilename << "," << targetFilename  << ")" << endl;
 }
 
+void MediaHandler::provideFileHeadCopy(const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r ) const
+{
+  if ( !isAttached() ) {
+    INT << "Media not_attached on provideFileHeadCopy(" << srcFilename_r
+        << "," << targetFilename_r << minBytes_r.asString() << ")" << endl;
+    ZYPP_THROW(MediaNotAttachedException(url()));
+  }
+  getFileHeadCopy( srcFilename_r, targetFilename_r, minBytes_r ); // pass to concrete handler
+  DBG << "provideFilePartCopy(" << srcFilename_r << "," << targetFilename_r  << "," << minBytes_r << ")" << endl;
+}
+
 void MediaHandler::provideFile( Pathname filename ) const
 {
   if ( !isAttached() ) {
@@ -1012,6 +1023,17 @@ void MediaHandler::provideFile( Pathname filename ) const
   }
 
   getFile( filename ); // pass to concrete handler
+  DBG << "provideFile(" << filename << ")" << endl;
+}
+
+void MediaHandler::provideFileHead(const Pathname &filename, const ByteCount minBytes_r) const
+{
+  if ( !isAttached() ) {
+    INT << "Error: Not attached on provideFileHead(" << filename << ", " << minBytes_r << ")" << endl;
+    ZYPP_THROW(MediaNotAttachedException(url()));
+  }
+
+  getFileHead( filename, minBytes_r ); // pass to concrete handler
   DBG << "provideFile(" << filename << ")" << endl;
 }
 
@@ -1245,6 +1267,11 @@ void MediaHandler::getFile( const Pathname & filename ) const
       ZYPP_THROW(MediaFileNotFoundException(url(), filename));
 }
 
+void MediaHandler::getFileHead(const Pathname &filename_r, const ByteCount minBytes_r) const
+{
+  getFile( filename_r );
+}
+
 
 void MediaHandler::getFileCopy ( const Pathname & srcFilename, const Pathname & targetFilename ) const
 {
@@ -1255,7 +1282,10 @@ void MediaHandler::getFileCopy ( const Pathname & srcFilename, const Pathname & 
   }
 }
 
-
+void MediaHandler::getFileHeadCopy(const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r) const
+{
+  getFileCopy( srcFilename_r, targetFilename_r );
+}
 
 ///////////////////////////////////////////////////////////////////
 //

--- a/zypp/media/MediaHandler.h
+++ b/zypp/media/MediaHandler.h
@@ -358,7 +358,24 @@ class MediaHandler {
 	 * \throws MediaException
 	 *
 	 **/
-	virtual void getFile( const Pathname & filename ) const = 0;
+	virtual void getFile( const Pathname & filename ) const;
+
+	/**
+	 * Call concrete handler to provide at least the specified number of
+	 * bytes of file below attach point.
+	 *
+	 * If \a minBytes is set to zero, the full file is downloaded
+	 *
+	 * Default implementation provided, that returns whether a file
+	 * is located at 'localRoot + filename'.
+	 *
+	 * Asserted that media is attached.
+	 *
+	 * \throws MediaException
+	 *
+	 **/
+	virtual void getFileHead( const Pathname & filename_r, const ByteCount minBytes_r ) const;
+
 
         /**
          * Call concrete handler to provide a file under a different place
@@ -372,6 +389,20 @@ class MediaHandler {
 	 *
          **/
         virtual void getFileCopy( const Pathname & srcFilename, const Pathname & targetFilename ) const;
+
+
+        /**
+         * Call concrete handler to provide at least the number of bytes
+         * specified of a file under a different place
+         * in the file system (usually not under attach point) as a copy.
+         * Media must be attached before by callee.
+         *
+         * Default implementation provided that calls getFileCopy(srcFilename, targetFilename)
+	 *
+	 * \throws MediaException
+	 *
+         **/
+        virtual void getFileHeadCopy( const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r ) const;
 
 
 	/**
@@ -574,6 +605,17 @@ class MediaHandler {
 	void provideFile( Pathname filename ) const;
 
 	/**
+	 * Use concrete handler to provide at least the specified nr of bytes of
+	 * file denoted by path below
+	 * 'localRoot'. Filename is interpreted relative to the
+	 * attached url and a path prefix is preserved.
+	 *
+	 * \throws MediaException
+	 *
+	 **/
+	void provideFileHead(const Pathname &filename_r, const ByteCount minBytes_r ) const;
+
+	/**
 	 * Call concrete handler to provide a copy of a file under a different place
          * in the file system (usually not under attach point) as a copy.
          * Media must be attached before by callee.
@@ -585,6 +627,23 @@ class MediaHandler {
 	 *
 	 **/
         void provideFileCopy( Pathname srcFilename, Pathname targetFilename) const;
+
+        /**
+	 * Call concrete handler to provide at least the number of bytes specified
+	 * of a file under a different place in the file system (usually not under attach point)
+	 * as a copy.
+         * Media must be attached before by callee.
+         * Depending on the handler backend this might simply provide the full file
+         *
+         * @param srcFilename    Filename of source file on the media
+         * @param targetFilename Filename for the target in the file system
+         * @param minBytes       Provide at least specifiednr of bytes
+	 *
+	 * \throws MediaException
+	 *
+	 **/
+	void provideFileHeadCopy( const Pathname &srcFilename_r, const Pathname &targetFilename_r, const ByteCount minBytes_r ) const;
+
 
 	/**
 	 * Use concrete handler to provide directory denoted

--- a/zypp/media/MediaManager.cc
+++ b/zypp/media/MediaManager.cc
@@ -682,6 +682,19 @@ namespace zypp
       ref.handler->provideFile(filename);
     }
 
+    void MediaManager::provideFileHead(MediaAccessId accessId_r,
+                                   const Pathname &filename_r,
+                                   const ByteCount minBytes_r) const
+    {
+      MutexLock glock(g_Mutex);
+
+      ManagedMedia &ref( m_impl->findMM(accessId_r));
+
+      ref.checkDesired(accessId_r);
+
+      ref.handler->provideFileHead( filename_r, minBytes_r );
+    }
+
     // ---------------------------------------------------------------
     void
     MediaManager::setDeltafile(MediaAccessId   accessId,

--- a/zypp/media/MediaManager.h
+++ b/zypp/media/MediaManager.h
@@ -762,6 +762,31 @@ namespace zypp
       void
       provideFile(MediaAccessId   accessId,
                   const Pathname &filename ) const;
+      /**
+       * Get at least the first number of bytes of a file denoted by relative path below of the
+       * 'attach point' of the specified media and the path prefix on the media.
+       *
+       * \note The media backend might not support partial file downloads, in that case the full file
+       *       is provided
+       *
+       * \param accessId  The media access id to use.
+       * \param filename  The filename to provide, relative to localRoot().
+       * \param minBytes  The minmum numbers of bytes to provide
+       *
+       * \throws MediaNotOpenException in case of invalid access id.
+       * \throws MediaNotAttachedException in case, that the media is not attached.
+       * \throws MediaNotDesiredException in case, that the media verification failed.
+       * \throws MediaNotAFileException in case, that the requested filename is not a file.
+       * \throws MediaFileNotFoundException in case, that the requested filenamedoes not exists.
+       * \throws MediaWriteException in case, that the file can't be copied from from remote source.
+       * \throws MediaSystemException in case a system operation fails.
+       * \throws MediaException derived exception, depending on the url (handler).
+       */
+
+      void
+      provideFileHead(MediaAccessId   accessId_r,
+                  const Pathname &filename_r,
+                  const ByteCount minBytes_r) const;
 
       /**
        * FIXME: see MediaAccess class.

--- a/zypp/media/MediaMultiCurl.cc
+++ b/zypp/media/MediaMultiCurl.cc
@@ -1338,7 +1338,7 @@ void MediaMultiCurl::doGetFileCopy( const Pathname & filename , const Pathname &
   curl_easy_setopt(_curl, CURLOPT_PRIVATE, file);
   try
     {
-      MediaCurl::doGetFileCopyFile(filename, dest, file, report, options);
+      MediaCurl::doGetFileCopyFile(filename, dest, ByteCount(), file, report, options);
     }
   catch (Exception &ex)
     {
@@ -1455,7 +1455,7 @@ void MediaMultiCurl::doGetFileCopy( const Pathname & filename , const Pathname &
 	  file = fopen(destNew.c_str(), "w+e");
 	  if (!file)
 	    ZYPP_THROW(MediaWriteException(destNew));
-	  MediaCurl::doGetFileCopyFile(filename, dest, file, report, options | OPTION_NO_REPORT_START);
+	  MediaCurl::doGetFileCopyFile(filename, dest, ByteCount(), file, report, options | OPTION_NO_REPORT_START);
 	}
     }
 

--- a/zypp/media/MediaMultiCurl.h
+++ b/zypp/media/MediaMultiCurl.h
@@ -45,7 +45,7 @@ public:
   MediaMultiCurl(const Url &url_r, const Pathname & attach_point_hint_r);
   ~MediaMultiCurl();
 
-  virtual void doGetFileCopy( const Pathname & srcFilename, const Pathname & targetFilename, callback::SendReport<DownloadProgressReport> & _report, RequestOptions options = OPTION_NONE ) const;
+  virtual void doGetFileCopy( const Pathname & srcFilename, const Pathname & targetFilename, callback::SendReport<DownloadProgressReport> & _report, RequestOptions options = OPTION_NONE ) const override;
 
   void multifetch(const Pathname &filename, FILE *fp, std::vector<Url> *urllist, callback::SendReport<DownloadProgressReport> *report = 0, MediaBlockList *blklist = 0, off_t filesize = off_t(-1)) const;
 

--- a/zypp/sat/Solvable.h
+++ b/zypp/sat/Solvable.h
@@ -33,6 +33,13 @@ namespace zypp
   class CpeId;
   class Date;
   class OnMediaLocation;
+  namespace target
+  {
+    namespace rpm
+    {
+      class RpmHeader;
+    }
+  }
   ///////////////////////////////////////////////////////////////////
   namespace sat
   {
@@ -372,6 +379,13 @@ namespace zypp
        * download e.g. an rpm (path, checksum, downloadsize, etc.).
        */
       OnMediaLocation lookupLocation() const;
+      //@}
+
+    public:
+      /** \name Attribute updates. */
+      //@{
+      /** Replace the SOLVABLE_FILELIST by data in \a rpmHeader_r (\c nullptr clears the list). */
+      void updateFilelistFrom( const intrusive_ptr<const target::rpm::RpmHeader> & rpmHeader_r );
       //@}
 
     public:

--- a/zypp/sat/detail/PoolMember.h
+++ b/zypp/sat/detail/PoolMember.h
@@ -29,6 +29,7 @@ extern "C"
   struct _Solvable;
   struct _Solver;
   struct _Transaction;
+  struct _Repodata;
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -64,6 +65,7 @@ namespace zypp
       typedef ::_Solvable	CSolvable;	///< Wrapped libsolv C data type exposed as backdoor
       typedef ::_Solver		CSolver;	///< Wrapped libsolv C data type exposed as backdoor
       typedef ::_Transaction	CTransaction;	///< Wrapped libsolv C data type exposed as backdoor
+      typedef ::_Repodata	CRepodata;	///< Wrapped libsolv C data type exposed as backdoor
     } // namespace detail
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/target/rpm/RpmHeader.cc
+++ b/zypp/target/rpm/RpmHeader.cc
@@ -904,6 +904,13 @@ std::list<std::string> RpmHeader::tag_filenames() const
   return ret;
 }
 
+void RpmHeader::raw_filenames( stringList & basenames_r, stringList & dirnames_r, intList & dirindexes_r ) const
+{
+  string_list( RPMTAG_BASENAMES, basenames_r );
+  string_list( RPMTAG_DIRNAMES, dirnames_r );
+  int_list( RPMTAG_DIRINDEXES, dirindexes_r );
+}
+
 ///////////////////////////////////////////////////////////////////
 //
 //

--- a/zypp/target/rpm/RpmHeader.h
+++ b/zypp/target/rpm/RpmHeader.h
@@ -170,6 +170,10 @@ public:
           */
   std::list<FileInfo> tag_fileinfos() const;
 
+  /** return the raw data building the filelist.
+   * File \c i is built by <tt>dirnames[dirindexes[i]] + basenames[i]</tt>. */
+  void raw_filenames( stringList & basenames_r, stringList & dirnames_r, intList & dirindexes_r ) const;
+
   Changelog tag_changelog() const;
 
 public:


### PR DESCRIPTION
Teaches libzypp to download the RPM header of a package when the required information is not available. This makes it possible to see filelists and changelog from a not yet installed or upgradable package.