### PR TITLE
Check for not imported keys after multi key import from rpmdb

### DIFF
--- a/zypp/KeyRing.cc
+++ b/zypp/KeyRing.cc
@@ -91,6 +91,13 @@ namespace zypp
     return false;
   }
 
+  void KeyRingReport::reportNonImportedKeys(const std::set<Edition> &keys_r)
+  {
+    UserData data(KEYS_NOT_IMPORTED_REPORT);
+    data.set("Keys", keys_r);
+    report(data);
+  }
+
   namespace
   {
     ///////////////////////////////////////////////////////////////////

--- a/zypp/KeyRing.h
+++ b/zypp/KeyRing.h
@@ -71,6 +71,7 @@ namespace zypp
     };
 
     constexpr static const char * ACCEPT_PACKAGE_KEY_REQUEST = "KeyRingReport/AcceptPackageKey";
+    constexpr static const char *KEYS_NOT_IMPORTED_REPORT = "KeyRingReport/KeysNotImported";
 
     /**
      * Ask user to trust and/or import the key to trusted keyring.
@@ -114,6 +115,16 @@ namespace zypp
      *
      */
     bool askUserToAcceptPackageKey( const PublicKey &key_r, const KeyContext &keycontext_r = KeyContext() );
+
+    /**
+     * Notify the user about keys that were not imported from the
+     * rpm key database into zypp keyring
+     *
+     * The UserData object will have the following fields:
+     * std::set<Edition> "Keys"		 set of keys that were not imported
+     *
+     */
+     void reportNonImportedKeys( const std::set<Edition> &keys_r );
 
   };
 

--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -338,7 +338,11 @@ namespace zypp
   { return makeIterable( &(*_pimpl->_subkeys.begin()), &(*_pimpl->_subkeys.end()) ); }
 
   bool PublicKeyData::providesKey( const std::string & id_r ) const
-  { return( id_r == _pimpl->_id || _pimpl->hasSubkeyId( id_r ) ); }
+  {
+    if ( id_r.size() == 8 )	// as a convenience allow to test the 8byte short ID rpm uses as gpg-pubkey version
+      return str::endsWithCI( _pimpl->_id, id_r );
+    return( id_r == _pimpl->_id || _pimpl->hasSubkeyId( id_r ) );
+  }
 
   PublicKeyData::AsciiArt PublicKeyData::asciiArt() const
   { return AsciiArt( fingerprint() /* TODO: key algorithm could be added as top tile. */ ); }


### PR DESCRIPTION
After importing multiple keys from rpmdb check if all of them were expected. If not show it in the logs. 