### PR TITLE
Ignore /var, /tmp and /proc in zypper ps (bsc#1096617)

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -232,10 +232,10 @@ namespace zypp
     {
       static const char * black[] = {
           "/SYSV"
-        , "/var/run/"
-        , "/var/lib/sss/"
+        , "/var/"
         , "/dev/"
-        , "/var/lib/gdm"
+        , "/tmp/"
+        , "/proc/"
       };
       for_( it, arrayBegin( black ), arrayEnd( black ) )
       {


### PR DESCRIPTION
This patch makes zypper ignore additional directories that are not relevant for "zypper ps". Since we only want to detect files that are removed by package changes/removals we don't need to care about directories where packages usually do not own files. 