### PR TITLE
Add setter functions for zypp cache related config values to ZConfig

### DIFF
--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -912,10 +912,20 @@ namespace zypp
         ? Pathname("/var/cache/zypp") : _pimpl->cfg_cache_path );
   }
 
+  void ZConfig::setRepoCachePath(const zypp::filesystem::Pathname &path_r)
+  {
+    _pimpl->cfg_cache_path = path_r;
+  }
+
   Pathname ZConfig::repoMetadataPath() const
   {
     return ( _pimpl->cfg_metadata_path.empty()
         ? (repoCachePath()/"raw") : _pimpl->cfg_metadata_path );
+  }
+
+  void ZConfig::setRepoMetadataPath(const zypp::filesystem::Pathname &path_r)
+  {
+    _pimpl->cfg_metadata_path = path_r;
   }
 
   Pathname ZConfig::repoSolvfilesPath() const
@@ -924,10 +934,20 @@ namespace zypp
         ? (repoCachePath()/"solv") : _pimpl->cfg_solvfiles_path );
   }
 
+  void ZConfig::setRepoSolvfilesPath(const zypp::filesystem::Pathname &path_r)
+  {
+    _pimpl->cfg_solvfiles_path = path_r;
+  }
+
   Pathname ZConfig::repoPackagesPath() const
   {
     return ( _pimpl->cfg_packages_path.empty()
         ? (repoCachePath()/"packages") : _pimpl->cfg_packages_path );
+  }
+
+  void ZConfig::setRepoPackagesPath(const zypp::filesystem::Pathname &path_r)
+  {
+    _pimpl->cfg_packages_path = path_r;
   }
 
   ///////////////////////////////////////////////////////////////////

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -144,11 +144,22 @@ namespace zypp
        */
       Pathname repoCachePath() const;
 
+      /**
+       * Set a new \a path as the default repo cache path
+       */
+      void setRepoCachePath ( const Pathname &path_r );
+
      /**
        * Path where the repo metadata is downloaded and kept (repoCachePath()/raw).
         * \ingroup g_ZC_REPOCACHE
       */
       Pathname repoMetadataPath() const;
+
+
+      /**
+       * Set a new \a path as the default repo cache path
+       */
+      void setRepoMetadataPath ( const Pathname &path_r );
 
      /**
        * Path where the repo solv files are created and kept (repoCachePath()/solv).
@@ -157,10 +168,20 @@ namespace zypp
       Pathname repoSolvfilesPath() const;
 
       /**
+       * Set a new \a path as the default repo cache path
+       */
+      void setRepoSolvfilesPath ( const Pathname &path_r );
+
+      /**
        * Path where the repo packages are downloaded and kept (repoCachePath()/packages).
         * \ingroup g_ZC_REPOCACHE
       */
       Pathname repoPackagesPath() const;
+
+      /**
+       * Set a new \a path as the default repo cache path
+       */
+      void setRepoPackagesPath ( const Pathname &path_r );
 
       /**
        * Path where the configfiles are kept (/etc/zypp).


### PR DESCRIPTION
This patch adds setter functions to support the fix for openSUSE/zypper#180 