### PR TITLE
Ma fix pkgsigcheck

### DIFF
--- a/zypp/FileChecker.h
+++ b/zypp/FileChecker.h
@@ -94,7 +94,6 @@ namespace zypp
    {
      public:
        typedef SignatureCheckException ExceptionType;
-       typedef function<void ( const SignatureFileChecker & checker,  const Pathname & file )> OnSigValidated;
 
      public:
       /**

--- a/zypp/ProvideFilePolicy.h
+++ b/zypp/ProvideFilePolicy.h
@@ -14,16 +14,18 @@
 
 #include "zypp/base/Function.h"
 #include "zypp/base/Functional.h"
+#include "zypp/FileChecker.h"
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
-{ /////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////
-// CLASS NAME : ProvideFilePolicy
-  
-  /** Policy for \ref provideFile.
-    * Provides callback hook for progress reporting.
-    */
+{
+  ///////////////////////////////////////////////////////////////////
+  /// \class ProvideFilePolicy
+  /// \brief Policy for \ref provideFile and \ref RepoMediaAccess.
+  ///
+  /// Provides callback hook for progress reporting and an optional
+  /// \ref FileCecker passed down to the \ref Fetcher.
+  ///////////////////////////////////////////////////////////////////
   class ProvideFilePolicy
   {
   public:
@@ -38,9 +40,16 @@ namespace zypp
     bool progress( int value ) const;
 
   public:
-    typedef function<bool ()> FailOnChecksumErrorCB;	///< Legacy to remain bincompat
+    /** Add a \ref FileCecker passed down to the \ref Fetcher */
+    ProvideFilePolicy & fileChecker( FileChecker fileChecker_r )
+    { _fileChecker = std::move(fileChecker_r); return *this; }
+
+    /** The \ref FileCecker. */
+    const FileChecker & fileChecker() const
+    { return _fileChecker; }
+
   private:
-    FailOnChecksumErrorCB _failOnChecksumErrorCB;	///< Legacy to remain bincompat
+    FileChecker           _fileChecker;
     ProgressCB            _progressCB;
   };
 

--- a/zypp/repo/PackageProvider.cc
+++ b/zypp/repo/PackageProvider.cc
@@ -315,28 +315,8 @@ namespace zypp
 	      userData.set( "ResObject", roptr );	// a type for '_package->asKind<ResObject>()'...
 	      /*legacy:*/userData.set( "Package", roptr->asKind<Package>() );
 	      userData.set( "Localpath", ret.value() );
-#if ( 1 )
-	      bool pkgGpgCheckIsMandatory = info.pkgGpgCheckIsMandatory();
-	      if ( str::startsWith( VERSION, "16.15." ) )
-	      {
-		// BSC#1038984: For a short period of time, libzypp-16.15.x
-		// will silently accept unsigned packages IFF a repositories gpgcheck
-		// configuration is explicitly turned OFF like this:
-		//     gpgcheck      = 0
-		//     repo_gpgcheck = 0
-		//     pkg_gpgcheck  = 1
-		// This will allow some already released products to adapt to the behavioral
-		// changes introduced by fixing BSC#1038984, while systems with a default
-		// configuration (gpgcheck = 1) already benefit from the fix.
-		// With libzypp-16.16.x the above configuration will reject unsigned packages
-		// as it should.
-		if ( pkgGpgCheckIsMandatory && !info.gpgCheck() && !info.repoGpgCheck() )
-		  pkgGpgCheckIsMandatory = false;
-	      }
-	      RpmDb::CheckPackageResult res = packageSigCheck( ret, pkgGpgCheckIsMandatory, userData );
-#else
 	      RpmDb::CheckPackageResult res = packageSigCheck( ret, info.pkgGpgCheckIsMandatory(), userData );
-#endif
+
 	      // publish the checkresult, even if it is OK. Apps may want to report something...
 	      report()->pkgGpgCheck( userData );
 

--- a/zypp/repo/PackageProvider.cc
+++ b/zypp/repo/PackageProvider.cc
@@ -373,10 +373,9 @@ namespace zypp
 		case repo::DownloadResolvableReport::IGNORE:
 		  ZYPP_THROW(SkipRequestException("User requested skip of corrupted file"));
 		  break;
+		default:
 		case repo::DownloadResolvableReport::ABORT:
 		  ZYPP_THROW(AbortRequestException("User requested to abort"));
-		  break;
-		default:
 		  break;
 	      }
 	    }
@@ -401,11 +400,9 @@ namespace zypp
                       case repo::DownloadResolvableReport::IGNORE:
                         ZYPP_THROW(SkipRequestException("User requested skip of file", excpt));
                         break;
+                      default:
                       case repo::DownloadResolvableReport::ABORT:
                         ZYPP_THROW(AbortRequestException("User requested to abort", excpt));
-                        break;
-                      default:
-                        ZYPP_RETHROW( excpt );
                         break;
                 }
               }

--- a/zypp/repo/RepoProvideFile.cc
+++ b/zypp/repo/RepoProvideFile.cc
@@ -322,12 +322,10 @@ namespace zypp
         }
         catch ( const UserRequestException & excpt )
 	{
-	  ZYPP_CAUGHT( excpt );
 	  ZYPP_RETHROW( excpt );
 	}
         catch ( const FileCheckException & excpt )
 	{
-	  ZYPP_CAUGHT( excpt );
 	  ZYPP_RETHROW( excpt );
 	}
         catch ( const Exception &e )

--- a/zypp/repo/RepoProvideFile.cc
+++ b/zypp/repo/RepoProvideFile.cc
@@ -307,7 +307,7 @@ namespace zypp
           MIL << "Providing file of repo '" << repo_r.alias() << "' from " << url << endl;
           shared_ptr<MediaSetAccess> access = _impl->mediaAccessForUrl( url, repo_r );
 
-	  fetcher.enqueue( locWithPath );
+	  fetcher.enqueue( locWithPath, policy_r.fileChecker() );
 	  fetcher.start( destinationDir, *access );
 
 	  // reached if no exception has been thrown, so this is the correct file


### PR DESCRIPTION
Fixing [bsc#1091624](https://bugzilla.suse.com/show_bug.cgi?id=1091624)

The packages sig check code was moved into a FileChecker passed down to the Fetcher. This avoids the package being moved into the cache before the check has completed.
