### PR TITLE
Prevent the system from sleeping during a commit

### DIFF
--- a/zypp/CMakeLists.txt
+++ b/zypp/CMakeLists.txt
@@ -72,6 +72,7 @@ SET( zypp_SRCS
   ServiceInfo.cc
   Signature.cc
   SrcPackage.cc
+  ShutdownLock.cc
   SysContent.cc
   Target.cc
   TmpPath.cc

--- a/zypp/ExternalProgram.cc
+++ b/zypp/ExternalProgram.cc
@@ -171,12 +171,12 @@ namespace zypp {
 
 
 
-    void ExternalProgram::start_program( const char *const *argv,
+    void ExternalProgram::start_program(const char *const *argv,
 					 const Environment & environment,
 					 Stderr_Disposition stderr_disp,
 					 int stderr_fd,
 					 bool default_locale,
-					 const char * root )
+					 const char * root , bool switch_pgid)
     {
       pid = -1;
       _exitStatus = 0;
@@ -300,6 +300,8 @@ namespace zypp {
     	}
     	else
     	{
+            if ( switch_pgid )
+              setpgid( 0, 0);
     	    renumber_fd (to_external[0], 0); // set new stdin
     	    ::close(from_external[0]);	  // Belongs to father process
 

--- a/zypp/ExternalProgram.h
+++ b/zypp/ExternalProgram.h
@@ -225,10 +225,12 @@ namespace zypp {
       /** Remember execution errors like failed fork/exec. */
       std::string _execError;
 
+    protected:
+
       void start_program (const char *const *argv, const Environment & environment,
     			Stderr_Disposition stderr_disp = Normal_Stderr,
     			int stderr_fd = -1, bool default_locale = false,
-    			const char* root = NULL);
+    			const char* root = NULL, bool switch_pgid = false);
 
     };
 
@@ -297,6 +299,22 @@ namespace zypp {
 
     private:
       std::string _buffer;
+  };
+
+  /** ExternalProgram extended to change the progress group ID after forking.
+   * \see \ref ExternalProgram
+   */
+  class ExternalProgramWithSeperatePgid : public ExternalProgram
+  {
+    public:
+      ExternalProgramWithSeperatePgid (const char *const *argv,
+                   Stderr_Disposition stderr_disp = Normal_Stderr,
+                   int stderr_fd = -1, bool default_locale = false,
+                   const Pathname& root = "") : ExternalProgram()
+      {
+        start_program( argv, Environment(), stderr_disp, stderr_fd, default_locale, root.c_str(), true );
+      }
+
   };
 
 } // namespace zypp

--- a/zypp/ExternalProgram.h
+++ b/zypp/ExternalProgram.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "zypp/APIConfig.h"
 #include "zypp/base/ExternalDataSource.h"
 #include "zypp/Pathname.h"
 
@@ -304,7 +305,7 @@ namespace zypp {
   /** ExternalProgram extended to change the progress group ID after forking.
    * \see \ref ExternalProgram
    */
-  class ExternalProgramWithSeperatePgid : public ExternalProgram
+  class ZYPP_LOCAL ExternalProgramWithSeperatePgid : public ExternalProgram
   {
     public:
       ExternalProgramWithSeperatePgid (const char *const *argv,

--- a/zypp/ShutdownLock.cc
+++ b/zypp/ShutdownLock.cc
@@ -1,0 +1,32 @@
+#include "ShutdownLock_p.h"
+
+#include "zypp/ExternalProgram.h"
+#include <iostream>
+
+zypp::ShutdownLock::ShutdownLock(const std::string &reason)
+{
+  try {
+
+    std::string whyStr = str::form("--why=%s", reason.c_str());
+
+    const char* argv[] =
+    {
+      "/usr/bin/systemd-inhibit",
+      "--what=sleep:shutdown:idle",
+      "--who=zypp",
+      "--mode=block",
+      whyStr.c_str(),
+      "/usr/bin/cat",
+      NULL
+    };
+    _prog = shared_ptr<ExternalProgramWithSeperatePgid>( new ExternalProgramWithSeperatePgid( argv, ExternalProgram::Discard_Stderr ) );
+  } catch (...) {
+  }
+}
+
+zypp::ShutdownLock::~ShutdownLock()
+{
+  if (_prog) {
+    _prog->kill();
+  }
+}

--- a/zypp/ShutdownLock_p.h
+++ b/zypp/ShutdownLock_p.h
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------\
+|                          ____ _   __ __ ___                          |
+|                         |__  / \ / / . \ . \                         |
+|                           / / \ V /|  _/  _/                         |
+|                          / /__ | | | | | |                           |
+|                         /_____||_| |_| |_|                           |
+|                                                                      |
+\---------------------------------------------------------------------*/
+/** \file	zypp/ShutdownLock_p.h
+ *
+*/
+
+#ifndef ZYPP_SHUTDOWNLOCK_P_H_INCLUDED
+#define ZYPP_SHUTDOWNLOCK_P_H_INCLUDED
+
+#include <string>
+
+#include "zypp/APIConfig.h"
+#include "zypp/base/PtrTypes.h"
+
+namespace zypp
+{
+
+class ExternalProgramWithSeperatePgid;
+
+/**
+ * Attempts to create a lock to prevent the system
+ * from going into hibernate/shutdown. The lock is automatically
+ * released when the object is destroyed.
+ */
+class ZYPP_LOCAL ShutdownLock
+{
+public:
+   ShutdownLock( const std::string &reason );
+   ~ShutdownLock();
+
+private:
+   shared_ptr<ExternalProgramWithSeperatePgid> _prog;
+
+};
+
+}
+
+
+#endif

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -38,6 +38,7 @@
 #include "zypp/RepoStatus.h"
 #include "zypp/ExternalProgram.h"
 #include "zypp/Repository.h"
+#include "zypp/ShutdownLock_p.h"
 
 #include "zypp/ResFilters.h"
 #include "zypp/HistoryLog.h"
@@ -1095,6 +1096,7 @@ namespace zypp
     {
       // ----------------------------------------------------------------- //
       ZYppCommitPolicy policy_r( policy_rX );
+      ShutdownLock lck("Zypp commit running.");
 
       // Fake outstanding YCP fix: Honour restriction to media 1
       // at installation, but install all remaining packages if post-boot.


### PR DESCRIPTION
(fixes openSUSE/zypper#135)

This patch prevents the system from shutting down or hibernating when a zypper commit is running. 