### PR TITLE
Automatically fetch repository signing key from gpgkey url (bsc#1088037)

### DIFF
--- a/tests/lib/TestSetup.h
+++ b/tests/lib/TestSetup.h
@@ -92,7 +92,10 @@ class TestSetup
     { _ctor( rootdir_r, Arch_empty, options_r ); }
 
     ~TestSetup()
-    { USR << (_tmprootdir.path() == _rootdir ? "DELETE" : "KEEP") << " TESTSETUP below " << _rootdir << endl; }
+    {
+      USR << (_tmprootdir.path() == _rootdir ? "DELETE" : "KEEP") << " TESTSETUP below " << _rootdir << endl;
+      ZConfig::instance().setRepoManagerRoot( Pathname() );
+    }
 
   public:
     /** Whether directory \a path_r contains a solver testcase. */
@@ -402,6 +405,8 @@ class TestSetup
         if ( _options.testFlag( TSO_CLEANROOT ) )
           filesystem::clean_dir( _rootdir );
       }
+
+      ZConfig::instance().setRepoManagerRoot( _rootdir );
 
       if ( ! sysarch_r.empty() )
         ZConfig::instance().setSystemArchitecture( sysarch_r );

--- a/zypp/KeyRing.cc
+++ b/zypp/KeyRing.cc
@@ -226,6 +226,8 @@ namespace zypp
     PublicKeyData trustedPublicKeyExists( const std::string & id )
     { return publicKeyExists(id, trustedKeyRing());}
 
+    bool provideAndImportKeyFromRepositoryWorkflow (const std::string &id_r , const RepoInfo &info_r );
+
   private:
     bool verifyFile( const Pathname & file, const Pathname & signature, const Pathname & keyring );
     void importKey( const Pathname & keyfile, const Pathname & keyring );
@@ -418,101 +420,155 @@ namespace zypp
     // get the id of the signature (it might be a subkey id!)
     std::string id = readSignatureKeyId( signature );
 
-    // does key exists in trusted keyring
-    PublicKeyData trustedKeyData( publicKeyExists( id, trustedKeyRing() ) );
-    if ( trustedKeyData )
-    {
-      MIL << "Key is trusted: " << trustedKeyData << endl;
+    PublicKeyData foundKey;
+    Pathname whichKeyring;
 
-      // lets look if there is an updated key in the
-      // general keyring
-      PublicKeyData generalKeyData( publicKeyExists( id, generalKeyRing() ) );
-      if ( generalKeyData )
+    if ( !id.empty() ) {
+
+      // does key exists in trusted keyring
+      PublicKeyData trustedKeyData( publicKeyExists( id, trustedKeyRing() ) );
+      if ( trustedKeyData )
       {
-        // bnc #393160: Comment #30: Compare at least the fingerprint
-        // in case an attacker created a key the the same id.
-	//
-	// FIXME: bsc#1008325: For keys using subkeys, we'd actually need
-	// to compare the subkey sets, to tell whether a key was updated.
-	// because created() remains unchanged if the primary key is not touched.
-	// For now we wait until a new subkey signs the data and treat it as a
-	//  new key (else part below).
-        if ( trustedKeyData.fingerprint() == generalKeyData.fingerprint()
-	   && trustedKeyData.created() < generalKeyData.created() )
-        {
-          MIL << "Key was updated. Saving new version into trusted keyring: " << generalKeyData << endl;
-          importKey( exportKey( generalKeyData, generalKeyRing() ), true );
-	  trustedKeyData = publicKeyExists( id, trustedKeyRing() ); // re-read: invalidated by import?
-	}
-      }
+        MIL << "Key is trusted: " << trustedKeyData << endl;
 
+        // lets look if there is an updated key in the
+        // general keyring
+        PublicKeyData generalKeyData( publicKeyExists( id, generalKeyRing() ) );
+        if ( generalKeyData )
+        {
+          // bnc #393160: Comment #30: Compare at least the fingerprint
+          // in case an attacker created a key the the same id.
+	  //
+	  // FIXME: bsc#1008325: For keys using subkeys, we'd actually need
+	  // to compare the subkey sets, to tell whether a key was updated.
+	  // because created() remains unchanged if the primary key is not touched.
+	  // For now we wait until a new subkey signs the data and treat it as a
+	  //  new key (else part below).
+          if ( trustedKeyData.fingerprint() == generalKeyData.fingerprint()
+	     && trustedKeyData.created() < generalKeyData.created() )
+          {
+            MIL << "Key was updated. Saving new version into trusted keyring: " << generalKeyData << endl;
+            importKey( exportKey( generalKeyData, generalKeyRing() ), true );
+	    trustedKeyData = publicKeyExists( id, trustedKeyRing() ); // re-read: invalidated by import?
+	  }
+        }
+
+        foundKey = trustedKeyData;
+        whichKeyring = trustedKeyRing();
+      }
+      else
+      {
+        PublicKeyData generalKeyData( publicKeyExists( id, generalKeyRing() ) );
+        if ( generalKeyData )
+        {
+          PublicKey key( exportKey( generalKeyData, generalKeyRing() ) );
+          MIL << "Key [" << id << "] " << key.name() << " is not trusted" << endl;
+
+          // ok the key is not trusted, ask the user to trust it or not
+          KeyRingReport::KeyTrust reply = report->askUserToAcceptKey( key, context );
+          if ( reply == KeyRingReport::KEY_TRUST_TEMPORARILY ||
+              reply == KeyRingReport::KEY_TRUST_AND_IMPORT )
+          {
+            MIL << "User wants to trust key [" << id << "] " << key.name() << endl;
+
+            if ( reply == KeyRingReport::KEY_TRUST_AND_IMPORT )
+            {
+              MIL << "User wants to import key [" << id << "] " << key.name() << endl;
+              importKey( key, true );
+              whichKeyring = trustedKeyRing();
+            }
+            else
+              whichKeyring = generalKeyRing();
+
+            foundKey = generalKeyData;
+          }
+          else
+          {
+            MIL << "User does not want to trust key [" << id << "] " << key.name() << endl;
+            return false;
+          }
+        }
+        else if ( ! context.empty() )
+        {
+          // try to find the key in the repository info
+          if ( provideAndImportKeyFromRepositoryWorkflow( id, context.repoInfo() ) ) {
+            whichKeyring = trustedKeyRing();
+            foundKey = PublicKeyData( publicKeyExists( id, trustedKeyRing() ) );
+          }
+        }
+      }
+    }
+
+    if ( foundKey ) {
       // it exists, is trusted, does it validate?
-      report->infoVerify( filedesc, trustedKeyData, context );
-      if ( verifyFile( file, signature, trustedKeyRing() ) )
+      report->infoVerify( filedesc, foundKey, context );
+      if ( verifyFile( file, signature, whichKeyring ) )
       {
         return (sigValid_r=true);	// signature is actually successfully validated!
       }
       else
       {
-	bool res = report->askUserToAcceptVerificationFailed( filedesc, exportKey( trustedKeyData, trustedKeyRing() ), context );
+	bool res = report->askUserToAcceptVerificationFailed( filedesc, exportKey( foundKey, whichKeyring ), context );
 	MIL << "askUserToAcceptVerificationFailed: " << res << endl;
         return res;
       }
+    } else {
+      // signed with an unknown key...
+      MIL << "File [" << file << "] ( " << filedesc << " ) signed with unknown key [" << id << "]" << endl;
+      bool res = report->askUserToAcceptUnknownKey( filedesc, id, context );
+      MIL << "askUserToAcceptUnknownKey: " << res << endl;
+      return res;
     }
-    else
-    {
-      PublicKeyData generalKeyData( publicKeyExists( id, generalKeyRing() ) );
-      if ( generalKeyData )
-      {
-        PublicKey key( exportKey( generalKeyData, generalKeyRing() ) );
-        MIL << "Key [" << id << "] " << key.name() << " is not trusted" << endl;
 
-        // ok the key is not trusted, ask the user to trust it or not
-        KeyRingReport::KeyTrust reply = report->askUserToAcceptKey( key, context );
-        if ( reply == KeyRingReport::KEY_TRUST_TEMPORARILY ||
-            reply == KeyRingReport::KEY_TRUST_AND_IMPORT )
-        {
-          MIL << "User wants to trust key [" << id << "] " << key.name() << endl;
-
-          Pathname whichKeyring;
-          if ( reply == KeyRingReport::KEY_TRUST_AND_IMPORT )
-          {
-            MIL << "User wants to import key [" << id << "] " << key.name() << endl;
-            importKey( key, true );
-            whichKeyring = trustedKeyRing();
-          }
-          else
-            whichKeyring = generalKeyRing();
-
-          // does it validate?
-	  report->infoVerify( filedesc, generalKeyData, context );
-          if ( verifyFile( file, signature, whichKeyring ) )
-          {
-	    return (sigValid_r=true);	// signature is actually successfully validated!
-          }
-          else
-          {
-	    bool res = report->askUserToAcceptVerificationFailed( filedesc, key, context );
-	    MIL << "askUserToAcceptVerificationFailed: " << res << endl;
-	    return res;
-          }
-        }
-        else
-        {
-          MIL << "User does not want to trust key [" << id << "] " << key.name() << endl;
-          return false;
-        }
-      }
-      else
-      {
-        // signed with an unknown key...
-        MIL << "File [" << file << "] ( " << filedesc << " ) signed with unknown key [" << id << "]" << endl;
-	bool res = report->askUserToAcceptUnknownKey( filedesc, id, context );
-	MIL << "askUserToAcceptUnknownKey: " << res << endl;
-	return res;
-      }
-    }
     return false;
+  }
+
+  bool KeyRing::Impl::provideAndImportKeyFromRepositoryWorkflow(const std::string &id_r, const RepoInfo &info_r)
+  {
+    if ( id_r.empty() )
+      return false;
+
+    const ZConfig &conf = ZConfig::instance();
+    Pathname cacheDir = conf.repoManagerRoot() / conf.pubkeyCachePath();
+
+    Pathname myKey = info_r.provideKey( id_r, cacheDir );
+    if ( myKey.empty()  )
+      // if we did not find any keys, there is no point in checking again, break
+      return false;
+
+    callback::SendReport<KeyRingReport> report;
+
+    PublicKey key;
+    try {
+      key = PublicKey( myKey );
+    } catch ( const Exception &e ) {
+      ZYPP_CAUGHT(e);
+      return false;
+    }
+
+    if ( !key.isValid() ) {
+      ERR << "Key [" << id_r << "] from cache: " << cacheDir << " is not valid" << endl;
+      return false;
+    }
+
+    MIL << "Key [" << id_r << "] " << key.name() << " loaded from cache" << endl;
+
+    KeyContext context;
+    context.setRepoInfo( info_r );
+    if ( ! report->askUserToAcceptPackageKey( key, context ) ) {
+      return false;
+    }
+
+    MIL << "User wants to import key [" << id_r << "] " << key.name() << " from cache" << endl;
+    try {
+      importKey( key, true );
+    } catch ( const KeyRingException &e ) {
+      ZYPP_CAUGHT(e);
+      ERR << "Failed to import key: "<<id_r;
+      return false;
+    }
+
+    return true;
   }
 
   std::list<PublicKey> KeyRing::Impl::publicKeys( const Pathname & keyring )
@@ -648,6 +704,11 @@ namespace zypp
 
   bool KeyRing::verifyFileTrustedSignature( const Pathname & file, const Pathname & signature )
   { return _pimpl->verifyFileTrustedSignature( file, signature ); }
+
+  bool KeyRing::provideAndImportKeyFromRepositoryWorkflow(const std::string &id, const RepoInfo &info)
+  {
+    return _pimpl->provideAndImportKeyFromRepositoryWorkflow( id, info );
+  }
 
   void KeyRing::dumpPublicKey( const std::string & id, bool trusted, std::ostream & stream )
   { _pimpl->dumpPublicKey( id, trusted, stream ); }

--- a/zypp/KeyRing.h
+++ b/zypp/KeyRing.h
@@ -307,6 +307,12 @@ namespace zypp
 
     bool verifyFileTrustedSignature( const Pathname &file, const Pathname &signature );
 
+    /**
+     * Try to find the \a id in key cache or repository specified in \a info. Ask the user to trust
+     * the key if it was found
+     */
+    bool provideAndImportKeyFromRepositoryWorkflow ( const std::string &id , const RepoInfo &info );
+
     /** Dtor */
     ~KeyRing();
 

--- a/zypp/RepoInfo.cc
+++ b/zypp/RepoInfo.cc
@@ -501,8 +501,11 @@ namespace zypp
     _pimpl->gpgKeyUrls().raw().push_back( url_r );
   }
 
-  Pathname RepoInfo::provideKey(const std::string &keyID_r, const Pathname &targetDirectory_r)
+  Pathname RepoInfo::provideKey(const std::string &keyID_r, const Pathname &targetDirectory_r) const
   {
+    if ( keyID_r.empty() )
+      return Pathname();
+
     MIL << "Check for " << keyID_r << " at " << targetDirectory_r << endl;
     std::string keyIDStr( keyID_r.size() > 8 ? keyID_r.substr( keyID_r.size()-8 ) : keyID_r );	// print short ID in Jobreports
     filesystem::TmpDir tmpKeyRingDir;

--- a/zypp/RepoInfo.h
+++ b/zypp/RepoInfo.h
@@ -401,7 +401,7 @@ namespace zypp
       void setGpgKeyUrl( const Url &gpgkey );
 
       /** downloads all configured gpg keys into the defined directory */
-      Pathname provideKey(const std::string &keyID_r, const Pathname &targetDirectory_r );
+      Pathname provideKey(const std::string &keyID_r, const Pathname &targetDirectory_r ) const;
 
       /**
        * \short Whether packages downloaded from this repository will be kept in local cache


### PR DESCRIPTION
This patch makes sure libzypp will download signing keys from gpgkey entries to check repository signatures. Before it would only do that for package signatures.