### PR TITLE
Ma 1099982 searchrx

### DIFF
--- a/tests/zypp/CMakeLists.txt
+++ b/tests/zypp/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_TESTS(
   PathInfo
   Pathname
   PluginFrame
+  PoolQueryCC
   PoolQuery
   ProgressData
   PtrTypes

--- a/tests/zypp/PoolQueryCC_test.cc
+++ b/tests/zypp/PoolQueryCC_test.cc
@@ -1,0 +1,121 @@
+#include "TestSetup.h"
+#include <zypp/base/String.h>
+#include <zypp/base/LogTools.h>
+
+#include "zypp/PoolQuery.h"
+#include "zypp/PoolQueryUtil.tcc"
+
+#define BOOST_TEST_MODULE PoolQuery_CC
+
+using boost::unit_test::test_case;
+using std::cin;
+using std::cout;
+using std::cerr;
+using std::endl;
+using namespace zypp;
+
+static TestSetup test;
+
+/////////////////////////////////////////////////////////////////////////////
+template <class TCont>
+std::ostream & nlist( std::ostream & str, const TCont & set_r )
+{
+  str << "[" << set_r.size() << "]: ";
+  for ( const auto & solv : set_r )
+    str << " \"" << solv.name() << "\"";
+  return str << endl;
+}
+
+BOOST_AUTO_TEST_CASE(init)
+{
+  test.loadTargetHelix( TESTS_SRC_DIR "/zypp/data/PoolQueryCC/rxnames.xml" );
+  nlist( cout << "repo ", ResPool::instance() );
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Basic issue: Multiple match strings are compiled into a singe regex. The
+// semantic of the individual match strings must be preserved. I.e. a literal
+// "." must become "\.". Globbing patterns must match the whole string, so they
+// need to be anchored within the regex. Etc.
+/////////////////////////////////////////////////////////////////////////////
+static const unsigned qtestSIZEMISS	= unsigned(-1);
+static const unsigned qtestRXFAIL	= unsigned(-2);
+static const unsigned qtestRXFAILCOMB	= unsigned(-3);
+
+unsigned qtest( const std::string & pattern_r, Match::Mode mode_r, bool verbose_r = false )
+{
+  static constexpr const bool noMatchInvalidRegexException = false;
+
+  typedef std::set<sat::Solvable> Result;
+  PoolQuery q;
+  q.addAttribute(sat::SolvAttr::name);
+  switch ( mode_r )
+  {
+    case Match::STRING:		q.setMatchExact();	break;
+    case Match::SUBSTRING:	q.setMatchSubstring();	break;
+    case Match::OTHER:		q.setMatchWord();	break;	// OTHER missused for matchWord()
+    case Match::GLOB:		q.setMatchGlob();	break;
+    case Match::REGEX:		q.setMatchRegex();	break;
+    default:
+      throw( "unhandled match mode" );
+      break;
+  }
+  q.addString( pattern_r );
+  Result o;
+  try {
+    o = Result( q.begin(), q.end() );	// original query
+  }
+  catch ( const zypp::MatchInvalidRegexException & excpt )
+  {
+    cout << "Caught: " << excpt << endl;
+    return qtestRXFAIL;
+  }
+
+  q.addString( "more" );
+  try {
+    Result r( q.begin(), q.end() );	// compiles into RX (o|more)
+
+    BOOST_CHECK( o == r );
+    if ( o != r || verbose_r )
+    {
+      cout << '"' << pattern_r << "\"  " << mode_r << endl;
+      nlist( cout << "    o", o );
+      nlist( cout << "    r", r );
+      if ( ! verbose_r )
+	return qtestSIZEMISS;
+    }
+  }
+  catch ( const zypp::MatchInvalidRegexException & excpt )
+  {
+    BOOST_CHECK( noMatchInvalidRegexException );
+    cout << "Caught: " << excpt << endl;
+    return qtestRXFAILCOMB;
+  }
+
+  return o.size();
+}
+
+inline unsigned qtest( const std::string & pattern_r, bool verbose_r = false )
+{ return qtest( pattern_r, Match::SUBSTRING, verbose_r ); }
+
+/////////////////////////////////////////////////////////////////////////////
+BOOST_AUTO_TEST_CASE(pool_query_init)
+{
+  // NOTE: qtest( , Match::OTHER ) is missused for matchWord()
+  BOOST_CHECK_EQUAL( qtest( "?", Match::SUBSTRING ),	1 );
+  BOOST_CHECK_EQUAL( qtest( "?", Match::STRING ),	1 );
+  BOOST_CHECK_EQUAL( qtest( "?", Match::OTHER ),	0 );	// not word boundary
+  BOOST_CHECK_EQUAL( qtest( "?", Match::GLOB ),		15 );
+  BOOST_CHECK_EQUAL( qtest( "\\?", Match::GLOB ),	1 );
+  BOOST_CHECK_EQUAL( qtest( "?", Match::REGEX ),	qtestRXFAIL );
+  BOOST_CHECK_EQUAL( qtest( "\\?", Match::REGEX ),	1 );
+
+  BOOST_CHECK_EQUAL( qtest( "A", Match::SUBSTRING ),	4 );
+  BOOST_CHECK_EQUAL( qtest( "A", Match::OTHER ),	2 );
+  BOOST_CHECK_EQUAL( qtest( "A*", Match::OTHER ),	0 );
+  BOOST_CHECK_EQUAL( qtest( "*A", Match::OTHER ),	0 );
+  BOOST_CHECK_EQUAL( qtest( "A*", Match::GLOB ),	2 );
+  BOOST_CHECK_EQUAL( qtest( "*A", Match::GLOB ),	1 );
+}
+
+/////////////////////////////////////////////////////////////////////////////

--- a/tests/zypp/PoolQuery_test.cc
+++ b/tests/zypp/PoolQuery_test.cc
@@ -604,7 +604,6 @@ BOOST_AUTO_TEST_CASE(pool_query_recovery)
   q.addRepo("opensuse");
   q.addKind(ResKind::patch);
   q.setMatchRegex();
-  q.setRequireAll();
   q.setCaseSensitive();
   q.setUninstalledOnly();
   q.setEdition(Edition("0.8.3"),Rel::NE);

--- a/tests/zypp/StrMatcher_test.cc
+++ b/tests/zypp/StrMatcher_test.cc
@@ -103,6 +103,8 @@ BOOST_AUTO_TEST_CASE(StrMatcher_STRING)
   BOOST_CHECK( !m( "" ) );
   BOOST_CHECK( !m( "a" ) );
   BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( !m( "fault" ) );
+  BOOST_CHECK( !m( "defau" ) );
   BOOST_CHECK( !m( "default" ) );
 }
 
@@ -113,6 +115,7 @@ BOOST_AUTO_TEST_CASE(StrMatcher_STRINGSTART)
   BOOST_CHECK( !m( "a" ) );
   BOOST_CHECK( m( "fau" ) );
   BOOST_CHECK( m( "fault" ) );
+  BOOST_CHECK( !m( "defau" ) );
   BOOST_CHECK( !m( "default" ) );
 }
 
@@ -122,11 +125,60 @@ BOOST_AUTO_TEST_CASE(StrMatcher_STRINGEND)
   BOOST_CHECK( !m( "" ) );
   BOOST_CHECK( !m( "a" ) );
   BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( !m( "fault" ) );
   BOOST_CHECK( m( "defau" ) );
   BOOST_CHECK( !m( "default" ) );
 }
 
+BOOST_AUTO_TEST_CASE(StrMatcher_GLOB)
+{
+  // GLOB must match whole word
+  StrMatcher m( "f[a]u", Match::GLOB );
+  BOOST_CHECK( !m( "" ) );
+  BOOST_CHECK( !m( "a" ) );
+  BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( !m( "fault" ) );
+  BOOST_CHECK( !m( "defau" ) );
+  BOOST_CHECK( !m( "default" ) );
+}
+
 BOOST_AUTO_TEST_CASE(StrMatcher_REGEX)
+{
+  // REGEX matches substring (unless anchored)
+  StrMatcher m( "f[a]u", Match::REGEX );
+  BOOST_CHECK( !m( "" ) );
+  BOOST_CHECK( !m( "a" ) );
+  BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( m( "fault" ) );
+  BOOST_CHECK( m( "defau" ) );
+  BOOST_CHECK( m( "default" ) );
+
+  m.setSearchstring( "^f[a]u" );
+  BOOST_CHECK( !m( "" ) );
+  BOOST_CHECK( !m( "a" ) );
+  BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( m( "fault" ) );
+  BOOST_CHECK( !m( "defau" ) );
+  BOOST_CHECK( !m( "default" ) );
+
+  m.setSearchstring( "f[a]u$" );
+  BOOST_CHECK( !m( "" ) );
+  BOOST_CHECK( !m( "a" ) );
+  BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( !m( "fault" ) );
+  BOOST_CHECK( m( "defau" ) );
+  BOOST_CHECK( !m( "default" ) );
+
+  m.setSearchstring( "^f[a]u$" );
+  BOOST_CHECK( !m( "" ) );
+  BOOST_CHECK( !m( "a" ) );
+  BOOST_CHECK( m( "fau" ) );
+  BOOST_CHECK( !m( "fault" ) );
+  BOOST_CHECK( !m( "defau" ) );
+  BOOST_CHECK( !m( "default" ) );
+}
+
+BOOST_AUTO_TEST_CASE(StrMatcher_RX)
 {
   StrMatcher m( "fau" );
 

--- a/tests/zypp/data/PoolQuery/savedqueries
+++ b/tests/zypp/data/PoolQuery/savedqueries
@@ -6,7 +6,6 @@ query_string: ma*
 repo: opensuse
 type: patch
 match_type: regex
-require_all: on
 case_sensitive: on
 install_status: not-installed
 version: != 0.8.3

--- a/tests/zypp/data/PoolQueryCC/rxnames.xml
+++ b/tests/zypp/data/PoolQueryCC/rxnames.xml
@@ -1,0 +1,21 @@
+<channel>
+  <subchannel>
+    <package><name>.</name></package>
+    <package><name>?</name></package>
+    <package><name>*</name></package>
+    <package><name>+</name></package>
+    <package><name>[</name></package>
+    <package><name>]</name></package>
+    <package><name>(</name></package>
+    <package><name>)</name></package>
+    <package><name>{</name></package>
+    <package><name>}</name></package>
+    <package><name>|</name></package>
+    <package><name>^</name></package>
+    <package><name>$</name></package>
+    <package><name>\</name></package>
+    <package><name>A</name></package>
+    <package><name>AB</name></package>
+    <package><name>BAB</name></package>
+    <package><name>.A.</name></package>
+</subchannel></channel>

--- a/zypp/Locks.cc
+++ b/zypp/Locks.cc
@@ -257,7 +257,6 @@ void Locks::removeLock( const ResKind &kind_r, const IdString &name_r )
   q.addKind( kind_r );
   q.setMatchExact();
   q.setCaseSensitive(true);
-  q.requireAll();
   DBG << "remove lock by Selectable" << endl;
   removeLock(q);
 }

--- a/zypp/Pathname.cc
+++ b/zypp/Pathname.cc
@@ -249,7 +249,7 @@ namespace zypp
 	return "/";
       std::string rest( str::stripPrefix( path_r.asString(), root_r.asString() ) );
       if ( rest[0] == '/' )	// needs to be a dir prefix!
-	return std::move(rest);
+	return rest;
       return path_r;
     }
 

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -963,15 +963,11 @@ namespace zypp
     _pimpl->_op = op;
   }
 
-  void PoolQuery::setMatchSubstring()	{ _pimpl->_flags.setModeSubstring(); }
-  void PoolQuery::setMatchExact()	{ _pimpl->_flags.setModeString(); }
-  void PoolQuery::setMatchRegex()	{ _pimpl->_flags.setModeRegex(); }
-  void PoolQuery::setMatchGlob()	{ _pimpl->_flags.setModeGlob(); }
-  void PoolQuery::setMatchWord()
-  {
-    _pimpl->_match_word = true;
-    _pimpl->_flags.setModeRegex();
-  }
+  void PoolQuery::setMatchSubstring()	{ _pimpl->_flags.setModeSubstring();	_pimpl->_match_word = false; }
+  void PoolQuery::setMatchExact()	{ _pimpl->_flags.setModeString();	_pimpl->_match_word = false; }
+  void PoolQuery::setMatchRegex()	{ _pimpl->_flags.setModeRegex();	_pimpl->_match_word = false; }
+  void PoolQuery::setMatchGlob()	{ _pimpl->_flags.setModeGlob();		_pimpl->_match_word = false; }
+  void PoolQuery::setMatchWord()	{ _pimpl->_flags.setModeSubstring();	_pimpl->_match_word = true; }
 
   Match PoolQuery::flags() const
   { return _pimpl->_flags; }
@@ -1029,12 +1025,10 @@ namespace zypp
   { _pimpl->_flags.turn( Match::FILES, value ); }
 
   bool PoolQuery::matchExact() const		{ return _pimpl->_flags.isModeString(); }
-  bool PoolQuery::matchSubstring() const	{ return _pimpl->_flags.isModeSubstring(); }
+  bool PoolQuery::matchSubstring() const	{ return _pimpl->_flags.isModeSubstring() && !_pimpl->_match_word; }
   bool PoolQuery::matchGlob() const		{ return _pimpl->_flags.isModeGlob(); }
   bool PoolQuery::matchRegex() const		{ return _pimpl->_flags.isModeRegex(); }
-
-  bool PoolQuery::matchWord() const
-  { return _pimpl->_match_word; }
+  bool PoolQuery::matchWord() const		{ return _pimpl->_flags.isModeSubstring() && _pimpl->_match_word; }
 
   PoolQuery::StatusFilter PoolQuery::statusFilterFlags() const
   { return _pimpl->_status_flags; }

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -516,8 +516,10 @@ namespace zypp
     mutable AttrMatchList _attrMatchList;
 
   private:
-    /** Pass flags from \ref compile, as they may have been changed. */
-    string createRegex( const StrContainer & container, const Match & flags ) const;
+    /** Join patterns in \a container_r according to \a flags_r into a single \ref StrMatcher.
+     * The \ref StrMatcher returned will be a REGEX if more than one pattern was passed.
+     */
+    StrMatcher joinedStrMatcher( const StrContainer & container_r, const Match & flags_r ) const;
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -554,13 +556,8 @@ namespace zypp
   {
     _attrMatchList.clear();
 
-    Match cflags( _flags );
-    if ( cflags.mode() == Match::OTHER ) // this will never succeed...
-      ZYPP_THROW( MatchUnknownModeException( cflags ) );
-
-    /** Compiled search strings. */
-    string rcstrings;
-
+    if ( _flags.mode() == Match::OTHER ) // this will never succeed...
+      ZYPP_THROW( MatchUnknownModeException( _flags ) );
 
     // 'different'         - will have to iterate through all and match by ourselves (slow)
     // 'same'              - will pass the compiled string to dataiterator_init
@@ -585,11 +582,8 @@ namespace zypp
       StrContainer joined;
       invokeOnEach(_strings.begin(), _strings.end(), EmptyFilter(), MyInserter(joined));
       invokeOnEach(_attrs.begin()->second.begin(), _attrs.begin()->second.end(), EmptyFilter(), MyInserter(joined));
-      rcstrings = createRegex(joined, cflags);
-      if (joined.size() > 1) // switch to regex for multiple strings
-        cflags.setModeRegex();
-      _attrMatchList.push_back( AttrMatchData( _attrs.begin()->first,
-                                StrMatcher( rcstrings, cflags ) ) );
+
+      _attrMatchList.push_back( AttrMatchData( _attrs.begin()->first, joinedStrMatcher( joined, _flags ) ) );
     }
 
     // // MULTIPLE ATTRIBUTES
@@ -642,18 +636,15 @@ namespace zypp
         if (attrvals_empty)
         {
           invokeOnEach(_strings.begin(), _strings.end(), EmptyFilter(), MyInserter(joined));
-          rcstrings = createRegex(joined, cflags);
         }
         else
         {
           invokeOnEach(_strings.begin(), _strings.end(), EmptyFilter(), MyInserter(joined));
           invokeOnEach(_attrs.begin()->second.begin(), _attrs.begin()->second.end(), EmptyFilter(), MyInserter(joined));
-          rcstrings = createRegex(joined, cflags);
         }
-        if (joined.size() > 1) // switch to regex for multiple strings
-          cflags.setModeRegex();
+
         // May use the same StrMatcher for all
-        StrMatcher matcher( rcstrings, cflags );
+        StrMatcher matcher( joinedStrMatcher( joined, _flags ) );
         for_( ai, _attrs.begin(), _attrs.end() )
         {
           _attrMatchList.push_back( AttrMatchData( ai->first, matcher ) );
@@ -671,11 +662,8 @@ namespace zypp
           StrContainer joined;
           invokeOnEach(_strings.begin(), _strings.end(), EmptyFilter(), MyInserter(joined));
           invokeOnEach(ai->second.begin(), ai->second.end(), EmptyFilter(), MyInserter(joined));
-          string s = createRegex(joined, cflags);
-          if (joined.size() > 1) // switch to regex for multiple strings
-            cflags.setModeRegex();
-          _attrMatchList.push_back( AttrMatchData( ai->first,
-                                    StrMatcher( s, cflags ) ) );
+
+          _attrMatchList.push_back( AttrMatchData( ai->first, joinedStrMatcher( joined, _flags ) ) );
         }
       }
     }
@@ -695,14 +683,9 @@ namespace zypp
           if ( ! mstr.empty() )
             joined.insert( mstr );
 
-          cflags = _flags;
-          rcstrings = createRegex( joined, cflags );
-          if ( joined.size() > 1 ) // switch to regex for multiple strings
-            cflags.setModeRegex();
-
 	  // copy and exchange the StrMatcher
 	  AttrMatchData nattr( *it );
-	  nattr.strMatcher = StrMatcher( rcstrings, cflags ),
+	  nattr.strMatcher = joinedStrMatcher( joined, _flags );
           _attrMatchList.push_back( std::move(nattr) );
         }
         else
@@ -716,12 +699,7 @@ namespace zypp
     // If no attributes defined at all, then add 'query all'
     if ( _attrMatchList.empty() )
     {
-      cflags = _flags;
-      rcstrings = createRegex( _strings, cflags );
-      if ( _strings.size() > 1 ) // switch to regex for multiple strings
-        cflags.setModeRegex();
-      _attrMatchList.push_back( AttrMatchData( sat::SolvAttr::allAttr,
-                                StrMatcher( rcstrings, cflags ) ) );
+      _attrMatchList.push_back( AttrMatchData( sat::SolvAttr::allAttr, joinedStrMatcher( _strings, _flags ) ) );
     }
 
     // Finally check here, whether all involved regex compile.
@@ -755,24 +733,25 @@ namespace zypp
     return regexed;
   }
 
-  string PoolQuery::Impl::createRegex( const StrContainer & container, const Match & flags ) const
+  StrMatcher PoolQuery::Impl::joinedStrMatcher( const StrContainer & container_r, const Match & flags_r ) const
   {
+    USR << flags_r << " - " << container_r << endl;
 //! macro for word boundary tags for regexes
 #define WB (_match_word ? string("\\b") : string())
-    string rstr;
 
-    if (container.empty())
-      return rstr;
+    if ( container_r.empty() )
+      return StrMatcher( std::string(), flags_r );
 
-    if (container.size() == 1)
-    {
-      return WB + *container.begin() + WB;
-    }
+    if ( container_r.size() == 1 )
+      return StrMatcher( WB + *container_r.begin() + WB, flags_r );
 
     // multiple strings
+    Match retflags( flags_r );
+    retflags.setModeRegex();
+    std::string retstr;
 
-    bool use_wildcards = flags.isModeGlob();
-    StrContainer::const_iterator it = container.begin();
+    bool use_wildcards = flags_r.isModeGlob();
+    StrContainer::const_iterator it = container_r.begin();
     string tmp;
 
     if (use_wildcards)
@@ -780,28 +759,28 @@ namespace zypp
     else
       tmp = *it;
 
-    if ( flags.isModeString() || flags.isModeGlob() )
-      rstr = "^";
-    rstr += WB + "(" + tmp;
+    if ( flags_r.isModeString() || flags_r.isModeGlob() )
+      retstr = "^";
+    retstr += WB + "(" + tmp;
 
     ++it;
 
-    for (; it != container.end(); ++it)
+    for (; it != container_r.end(); ++it)
     {
       if (use_wildcards)
         tmp = wildcards2regex(*it);
       else
         tmp = *it;
 
-      rstr += "|" + tmp;
+      retstr += "|" + tmp;
     }
 
-    rstr += ")" + WB;
-    if ( flags.isModeString() || flags.isModeGlob() )
-      rstr += "$";
+    retstr += ")" + WB;
+    if ( flags_r.isModeString() || flags_r.isModeGlob() )
+      retstr += "$";
 
-    return rstr;
 #undef WB
+    return StrMatcher( retstr, retflags );
   }
 
   string PoolQuery::Impl::asString() const

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -418,7 +418,6 @@ namespace zypp
     Impl()
       : _flags( Match::SUBSTRING | Match::NOCASE | Match::SKIP_KIND )
       , _match_word(false)
-      , _require_all(false)
       , _status_flags(ALL)
     {}
 
@@ -441,7 +440,6 @@ namespace zypp
     /** Sat solver search flags */
     Match _flags;
     bool _match_word;
-    bool _require_all;
 
     /** Sat solver status flags */
     StatusFilter _status_flags;
@@ -468,7 +466,6 @@ namespace zypp
       OUTS( _uncompiledPredicated );
       OUTS( _flags.get() );
       OUTS( _match_word );
-      OUTS( _require_all );
       OUTS( _status_flags );
       OUTS( _edition );
       OUTS( _op.inSwitch() );
@@ -496,7 +493,6 @@ namespace zypp
 	      && _attrs == rhs._attrs
 	      && _uncompiledPredicated == rhs._uncompiledPredicated
 	      && _match_word == rhs._match_word
-	      && _require_all == rhs._require_all
 	      && _status_flags == rhs._status_flags
 	      && _edition == rhs._edition
 	      && _op == rhs._op
@@ -784,18 +780,9 @@ namespace zypp
     else
       tmp = *it;
 
-    if (_require_all)
-    {
-      if ( ! flags.isModeString() ) // not match exact
-        tmp += ".*" + WB + tmp;
-      rstr = "(?=" + tmp + ")";
-    }
-    else
-    {
-      if ( flags.isModeString() || flags.isModeGlob() )
-        rstr = "^";
-      rstr += WB + "(" + tmp;
-    }
+    if ( flags.isModeString() || flags.isModeGlob() )
+      rstr = "^";
+    rstr += WB + "(" + tmp;
 
     ++it;
 
@@ -806,29 +793,12 @@ namespace zypp
       else
         tmp = *it;
 
-      if (_require_all)
-      {
-        if ( ! flags.isModeString() ) // not match exact
-          tmp += ".*" + WB + tmp;
-        rstr += "(?=" + tmp + ")";
-      }
-      else
-      {
-        rstr += "|" + tmp;
-      }
+      rstr += "|" + tmp;
     }
 
-    if (_require_all)
-    {
-      if ( ! flags.isModeString() ) // not match exact
-        rstr += WB + ".*";
-    }
-    else
-    {
-      rstr += ")" + WB;
-      if ( flags.isModeString() || flags.isModeGlob() )
-        rstr += "$";
-    }
+    rstr += ")" + WB;
+    if ( flags.isModeString() || flags.isModeGlob() )
+      rstr += "$";
 
     return rstr;
 #undef WB
@@ -1038,10 +1008,6 @@ namespace zypp
   { _pimpl->_status_flags = flags; }
 
 
-  void PoolQuery::setRequireAll(bool require_all)
-  { _pimpl->_require_all = require_all; }
-
-
   const PoolQuery::StrContainer &
   PoolQuery::strings() const
   { return _pimpl->_strings; }
@@ -1091,9 +1057,6 @@ namespace zypp
   bool PoolQuery::matchWord() const
   { return _pimpl->_match_word; }
 
-  bool PoolQuery::requireAll() const
-  { return _pimpl->_require_all; }
-
   PoolQuery::StatusFilter PoolQuery::statusFilterFlags() const
   { return _pimpl->_status_flags; }
 
@@ -1120,6 +1083,9 @@ namespace zypp
   void PoolQuery::execute(ProcessResolvable fnc)
   { invokeOnEach( begin(), end(), fnc); }
 
+
+  /*DEPRECATED LEGACY:*/void PoolQuery::setRequireAll( bool ) {}
+  /*DEPRECATED LEGACY:*/bool PoolQuery::requireAll() const    { return false; }
 
   ///////////////////////////////////////////////////////////////////
   //
@@ -1155,7 +1121,7 @@ namespace zypp
     static const PoolQueryAttr kindAttr;
     static const PoolQueryAttr stringAttr;
     static const PoolQueryAttr stringTypeAttr;
-    static const PoolQueryAttr requireAllAttr;
+    static const PoolQueryAttr requireAllAttr;	// LEAGACY: attribute was defined but never implemented.
     static const PoolQueryAttr caseSensitiveAttr;
     static const PoolQueryAttr installStatusAttr;
     static const PoolQueryAttr editionAttr;
@@ -1168,7 +1134,7 @@ namespace zypp
   const PoolQueryAttr PoolQueryAttr::kindAttr( "type" );
   const PoolQueryAttr PoolQueryAttr::stringAttr( "query_string" );
   const PoolQueryAttr PoolQueryAttr::stringTypeAttr("match_type");
-  const PoolQueryAttr PoolQueryAttr::requireAllAttr("require_all");
+  const PoolQueryAttr PoolQueryAttr::requireAllAttr("require_all");	// LEAGACY: attribute was defined but never implemented.
   const PoolQueryAttr PoolQueryAttr::caseSensitiveAttr("case_sensitive");
   const PoolQueryAttr PoolQueryAttr::installStatusAttr("install_status");
   const PoolQueryAttr PoolQueryAttr::editionAttr("version");
@@ -1292,18 +1258,8 @@ namespace zypp
       }
       else if ( attribute==PoolQueryAttr::requireAllAttr )
       {
-        if ( str::strToTrue(attrValue) )
-        {
-          setRequireAll(true);
-        }
-        else if ( !str::strToFalse(attrValue) )
-        {
-          setRequireAll(false);
-        }
-        else
-        {
-          WAR << "unknown boolean value " << attrValue << endl;
-        }
+	// LEAGACY: attribute was defined but never implemented.
+	// Actually it should not occur outside our testcases.
       }
       else if ( attribute==PoolQueryAttr::caseSensitiveAttr )
       {
@@ -1438,19 +1394,6 @@ namespace zypp
     {
       str << "case_sensitive: ";
       if (caseSensitive())
-      {
-        str << "on" << delim;
-      }
-      else
-      {
-        str << "off" << delim;
-      }
-    }
-
-    if( requireAll() != q.requireAll() )
-    {
-      str << "require_all: ";
-      if (requireAll())
       {
         str << "on" << delim;
       }

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -601,16 +601,21 @@ namespace zypp
     {
       // check whether there are any per-attribute strings
       bool attrvals_empty = true;
-      for (AttrRawStrMap::const_iterator ai = _attrs.begin(); ai != _attrs.end(); ++ai)
-        if (!ai->second.empty())
-          for(StrContainer::const_iterator it = ai->second.begin();
-              it != ai->second.end(); it++)
-            if (!it->empty())
-            {
-              attrvals_empty = false;
-              goto attremptycheckend;
-            }
-attremptycheckend:
+      for_( ai, _attrs.begin(), _attrs.end() )
+      {
+        if ( ai->second.empty() )
+	  continue;
+	for_( it, ai->second.begin(), ai->second.end() )
+	{
+	  if ( !it->empty() )
+	  {
+	    attrvals_empty = false;
+	    break;
+	  }
+	}
+        if ( ! attrvals_empty )
+	  break;
+      }
 
       // chceck whether the per-attribute strings are all the same
       bool attrvals_thesame = true;

--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -371,7 +371,7 @@ namespace zypp
     void setMatchGlob();
     /** Set to use the query strings as regexes */
     void setMatchRegex();
-    /** Set to match words (uses regex) */
+    /** Set substring to match words */
     void setMatchWord();
     //void setLocale(const Locale & locale);
     //@}

--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -189,8 +189,7 @@ namespace zypp
      * This method can be used multiple times in which case the query strings
      * will be combined (together with strings added via addAttribute()) into
      * a regex. Searched attribute value will match this regex if <b>any</b>
-     * of these strings will match the value. This can be changed by
-     * (not yet implemented) \ref setRequireAll() method.
+     * of these strings will match the value.
      */
     void addString(const std::string & value);
 
@@ -202,8 +201,6 @@ namespace zypp
      * case the query strings will be combined (together with strings added
      * via addString()) into a regex. Searched attribute value will match
      * this regex if <b>any</b> of these strings will match the value.
-     * This can be changed by (not yet implemented) \ref setRequireAll()
-     * method.
      *
      * \note Though it is possible to use dependency attributes like
      * \ref Solv::Attr::provides here, note that the query string is
@@ -379,15 +376,6 @@ namespace zypp
     //void setLocale(const Locale & locale);
     //@}
 
-    /**
-     * Require that all of the values set by addString or addAttribute
-     * match the values of respective attributes.
-     *
-     * \todo doesn't work yet, don't use this function
-     */
-    void setRequireAll( bool require_all = true );
-
-
     /** \name getters */
     //@{
 
@@ -429,12 +417,6 @@ namespace zypp
      */
     Match::Mode matchMode() const
     { return flags().mode(); }
-
-    /**
-     * Whether all values added via addString() or addAttribute() are required
-     * to match the values of the respective attributes.
-     */
-    bool requireAll() const;
 
     StatusFilter statusFilterFlags() const;
     //@}
@@ -486,6 +468,12 @@ namespace zypp
      * \see \ref Match
      */
     void setFlags( const Match & flags );
+
+  public:
+    /** \deprecated Attribute was defined but never implemented/used. Will be removed in future versions. */
+    void setRequireAll( bool require_all = true ) ZYPP_DEPRECATED;
+    /** \deprecated Attribute was defined but never implemented/used. Will be removed in future versions. */
+    bool requireAll() const ZYPP_DEPRECATED;
 
   public:
     class Impl;

--- a/zypp/Product.cc
+++ b/zypp/Product.cc
@@ -31,20 +31,6 @@ namespace zypp
 
   namespace
   {
-    void fillList( std::list<Url> & ret_r, sat::Solvable solv_r, sat::SolvAttr attr_r )
-    {
-      sat::LookupAttr query( attr_r, solv_r );
-      for_( it, query.begin(), query.end() )
-      {
-        try // ignore malformed urls
-        {
-          ret_r.push_back( Url( it.asString() ) );
-        }
-        catch( const url::UrlException & )
-        {}
-      }
-    }
-
     void fillList( std::list<std::string> & ret_r, sat::Solvable solv_r, sat::SolvAttr attr_r )
     {
       sat::LookupAttr query( attr_r, solv_r );

--- a/zypp/base/String.h
+++ b/zypp/base/String.h
@@ -895,6 +895,15 @@ namespace zypp
           str_r += escape( next_r, sep_r );
       }
 
+      /** Return \a str_r with '\'-escaped chars occurring in \a special_r (and '\'). */
+      std::string bEscape( std::string str_r, const C_Str & special_r );
+
+      /** Escape plain STRING \a str_r for use in a regex (not anchored by "^" or "$"). */
+      std::string rxEscapeStr( std::string str_r );
+
+      /** Escape GLOB \a str_r for use in a regex (not anchored by "^" or "$"). */
+      std::string rxEscapeGlob( std::string str_r );
+
       //! \todo unsecape()
 
     //@}

--- a/zypp/media/MediaPlugin.cc
+++ b/zypp/media/MediaPlugin.cc
@@ -39,7 +39,7 @@ namespace zypp
     void MediaPlugin::releaseFrom( const std::string & ejectDev_r )
     {}
 
-    void MediaPlugin::getFile(const Pathname & filename_r , const ByteCount expectedFileSize_r) const
+    void MediaPlugin::getFile(const Pathname & filename_r , const ByteCount & expectedFileSize_r) const
     {}
 
     void MediaPlugin::getDir( const Pathname & dirname_r, bool recurse_r ) const

--- a/zypp/media/MediaPlugin.h
+++ b/zypp/media/MediaPlugin.h
@@ -36,7 +36,7 @@ namespace zypp
       protected:
 	virtual void attachTo( bool next_r = false );
 	virtual void releaseFrom( const std::string & ejectDev_r );
-	virtual void getFile( const Pathname & filename_r, const ByteCount expectedFileSize_r ) const;
+	virtual void getFile( const Pathname & filename_r, const ByteCount &expectedFileSize_r ) const;
 	virtual void getDir( const Pathname & dirname_r, bool recurse_r ) const;
 	virtual void getDirInfo( std::list<std::string> & retlist_r, const Pathname & dirname_r, bool dots_r = true ) const;
 	virtual void getDirInfo( filesystem::DirContent & retlist_r, const Pathname & dirname_r, bool dots_r = true ) const;

--- a/zypp/solver/detail/Testcase.cc
+++ b/zypp/solver/detail/Testcase.cc
@@ -285,7 +285,6 @@ class  HelixControl {
 		  const target::Modalias::ModaliasList & modaliasList,
 		  const std::set<std::string> & multiversionSpec,
 		  const std::string & systemPath);
-    HelixControl ();
     ~HelixControl ();
 
     void closeSetup()
@@ -392,12 +391,6 @@ HelixControl::HelixControl(const std::string & controlPath,
     }
 
     // setup continued outside....
-}
-
-HelixControl::HelixControl()
-    :dumpFile ("/var/log/YaST2/solverTestcase/solver-test.xml")
-{
-    HelixControl (dumpFile);
 }
 
 HelixControl::~HelixControl()


### PR DESCRIPTION
The initial commits are more or less cleanups. Most important are last 2, correctly escaping STRING and GLOB when compiled into a single REGEX.

Fixes [(bsc#1099982)](https://bugzilla.suse.com/show_bug.cgi?id=1099982).