### PR TITLE
Add infrastructure to flag specific packages to trigger a reboot needed hint (fate#326451)

### DIFF
--- a/zypp/sat/Pool.cc
+++ b/zypp/sat/Pool.cc
@@ -243,6 +243,9 @@ namespace zypp
     Queue Pool::autoInstalled() const				{ return myPool().autoInstalled(); }
     void Pool::setAutoInstalled( const Queue & autoInstalled_r ){ myPool().setAutoInstalled( autoInstalled_r ); }
 
+    Queue Pool::rebootNeededIdents() const				{ return myPool().rebootNeededIdents(); }
+    void Pool::setRebootNeededIdents( const Queue & rebootNeeded_r ){ myPool().setRebootNeededIdents( rebootNeeded_r ); }
+
    /******************************************************************
     **
     **	FUNCTION NAME : operator<<

--- a/zypp/sat/Pool.h
+++ b/zypp/sat/Pool.h
@@ -265,6 +265,12 @@ namespace zypp
 	void setAutoInstalled( const Queue & autoInstalled_r );
         //@}
 
+        /** Get ident list of all solvables that trigger the "reboot needed" flag. */
+        Queue rebootNeededIdents() const;
+
+	/** Set ident list of all solvables that trigger the "reboot needed" flag. */
+	void setRebootNeededIdents( const Queue & rebootNeeded_r );
+
       public:
         /** Expert backdoor. */
         detail::CPool * get() const;

--- a/zypp/sat/Solvable.cc
+++ b/zypp/sat/Solvable.cc
@@ -387,6 +387,11 @@ namespace zypp
       return myPool().isOnSystemByAuto( ident_r );
     }
 
+    bool Solvable::identTriggersRebootHint ( const IdString &ident_r )
+    {
+      return myPool().triggersRebootNeededHint( ident_r );
+    }
+
     bool Solvable::multiversionInstall() const
     {
       NO_SOLVABLE_RETURN( false );

--- a/zypp/sat/Solvable.h
+++ b/zypp/sat/Solvable.h
@@ -136,6 +136,11 @@ namespace zypp
       /** \overload static version */
       static bool identIsAutoInstalled( const IdString & ident_r );
 
+      /** Whether installing or upgrading a solvable with the same \ref ident will trigger the reboot needed hint. */
+      bool identTriggersRebootHint() const
+      { return identTriggersRebootHint( ident() ); }
+      static bool identTriggersRebootHint ( const IdString &ident_r );
+
       /** Whether different versions of this package can be installed at the same time.
        * Per default \c false. \see also \ref ZConfig::multiversion.
        */

--- a/zypp/sat/SolvableType.h
+++ b/zypp/sat/SolvableType.h
@@ -80,6 +80,7 @@ namespace zypp
       bool		onSystemByAuto() const			{ return satSolvable().onSystemByAuto(); }
       bool		identIsAutoInstalled() const		{ return satSolvable().identIsAutoInstalled(); }
       bool		multiversionInstall() const		{ return satSolvable().multiversionInstall(); }
+      bool              identTriggersRebootHint() const         { return satSolvable().identTriggersRebootHint(); }
 
       Date		buildtime() const			{ return satSolvable().buildtime(); }
       Date		installtime() const			{ return satSolvable().installtime(); }

--- a/zypp/sat/detail/PoolImpl.h
+++ b/zypp/sat/detail/PoolImpl.h
@@ -306,6 +306,18 @@ namespace zypp
 
           bool isOnSystemByAuto( IdString ident_r ) const
           { return _autoinstalled.contains( ident_r.id() ); }
+
+          /** Get ident list of all solvables that trigger the "reboot needed" flag. */
+	  StringQueue rebootNeededIdents() const
+	  { return _rebootNeeded; }
+
+	  /** Set ident list of all solvables that trigger the "reboot needed" flag. */
+	  void setRebootNeededIdents( const StringQueue & rebootNeeded_r )
+	  { _rebootNeeded = rebootNeeded_r; }
+
+	  bool triggersRebootNeededHint( IdString ident_r ) const
+          { return _rebootNeeded.contains( ident_r.id() ); }
+
           //@}
 
 	public:
@@ -336,6 +348,9 @@ namespace zypp
 
           /**  */
 	  sat::StringQueue _autoinstalled;
+
+	  /** database of all identifiers that will trigger the "reboot needed" flag */
+	  sat::StringQueue _rebootNeeded;
 
 	  /** filesystems mentioned in /etc/sysconfig/storage */
 	  mutable scoped_ptr<std::set<std::string> > _requiredFilesystemsPtr;


### PR DESCRIPTION
This patch adds the infrastructure to provide a "zypper reboot-needed" type of command. It introduces a new set of config files in /var/lib/zypp that can be used to tweak the behaviour. 