### PR TITLE
Request compressed rpm transfer

### DIFF
--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -736,6 +736,7 @@ void MediaCurl::setupEasy()
   SET_OPTION(CURLOPT_FOLLOWLOCATION, 1L);
   // 3 redirects seem to be too few in some cases (bnc #465532)
   SET_OPTION(CURLOPT_MAXREDIRS, 6L);
+  SET_OPTION(CURLOPT_ACCEPT_ENCODING, "");
 
   if ( _url.getScheme() == "https" )
   {


### PR DESCRIPTION
Request compressed rpm transfer, if server supports it. This can save 10-70% of transfer bandwidth, because (d)rpm metadata is uncompressed

E.g.
```bash
curl -L -v http://download.opensuse.org/update/leap/15.0/oss/noarch/kernel-source-vanilla-4.12.14-lp150.12.22.1_lp150.12.25.1.noarch.drpm | gzip -c1 | wc -c
```

compresses 11157036 bytes to 4161087

On the downside, it adds 32 byte to every HTTP request header
which would add 256 microseconds on a 1MBit/s line.

Also, none of the public openSUSE mirrors support compression of (d)rpm files yet and if they did, it could cause some server-side CPU load.

Note: Only tested downloading single rpm with `zypper in -d http://aw.lsmod.de/rpm/test.rpm`

Not yet tested with multicurl.