### PR TITLE
Boost.Tribool requires an explicit cast to bool

### DIFF
--- a/zypp/TriBool.h
+++ b/zypp/TriBool.h
@@ -68,7 +68,7 @@ namespace boost
 
       /** \relates TriBool whether 2 tribool have the same state (this is NOT ==) */
       inline bool sameTriboolState( tribool lhs, tribool rhs )
-      { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( lhs == rhs ) ); }
+      { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( bool )( lhs == rhs ) ); }
     }
 }
 #endif // ZYPP_TRIBOOL_H


### PR DESCRIPTION
operator== between boost::logic::tribool returns a tribool, which
requires an explicit cast to bool

This results in a build failure with upcoming Boost 1.69.0

https://build.opensuse.org/package/live_build_log/home:adamm:boost_test/libzypp/openSUSE_Tumbleweed/x86_64

```
[   64s] In file included from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ZConfig.h:27,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ZYpp.h:21,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ZYppFactory.h:18,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/misc/DefaultLoadSystem.cc:19:
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h: In function 'bool boost::logic::sameTriboolState(boost::logic::tribool, boost::logic::tribool)':
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h:71:80: error: cannot convert 'boost::logic::tribool' to 'bool' in return
[   64s]        { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( lhs == rhs ) ); }
[   64s]                                                                                 ^
[   64s] In file included from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/RepoInfo.h:23,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Repository.h:21,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/sat/SolvableType.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Resolvable.h:24,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ResObject.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/PoolItem.h:19,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/pool/PoolTraits.h:23,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/pool/PoolImpl.h:22,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/pool/PoolImpl.cc:15:
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h: In function 'bool boost::logic::sameTriboolState(boost::logic::tribool, boost::logic::tribool)':
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h:71:80: error: cannot convert 'boost::logic::tribool' to 'bool' in return
[   64s]        { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( lhs == rhs ) ); }
[   64s]                                                                                 ^
[   64s] In file included from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/RepoInfo.h:23,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Repository.h:21,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/sat/SolvableType.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Resolvable.h:24,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ResObject.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/pool/PoolStats.h:20,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/pool/PoolStats.cc:15:
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h: In function 'bool boost::logic::sameTriboolState(boost::logic::tribool, boost::logic::tribool)':
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h:71:80: error: cannot convert 'boost::logic::tribool' to 'bool' in return
[   64s]        { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( lhs == rhs ) ); }
[   64s]                                                                                 ^
[   64s] In file included from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/RepoInfo.h:23,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Repository.h:21,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/sat/SolvableType.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Resolvable.h:24,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/ResObject.h:17,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/Package.h:15,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/target/rpm/librpmDb.h:21,
[   64s]                  from /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/misc/CheckAccessDeleted.cc:27:
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h: In function 'bool boost::logic::sameTriboolState(boost::logic::tribool, boost::logic::tribool)':
[   64s] /home/abuild/rpmbuild/BUILD/libzypp-17.9.0/zypp/TriBool.h:71:80: error: cannot convert 'boost::logic::tribool' to 'bool' in return
[   64s]        { return( ( indeterminate(lhs) && indeterminate(rhs) ) || ( lhs == rhs ) ); }
[   64s]                                                                                 ^
```
