### PR TITLE
Need to explitily cast of Tribool to boolean

### DIFF
--- a/zypp/RepoInfo.cc
+++ b/zypp/RepoInfo.cc
@@ -387,11 +387,11 @@ namespace zypp
 
 
   bool RepoInfo::repoGpgCheck() const
-  { return gpgCheck() || _pimpl->cfgRepoGpgCheck(); }
+  { return gpgCheck() || bool(_pimpl->cfgRepoGpgCheck()); }
 
   bool RepoInfo::repoGpgCheckIsMandatory() const
   {
-    bool ret = ( gpgCheck() && indeterminate(_pimpl->cfgRepoGpgCheck()) ) || _pimpl->cfgRepoGpgCheck();
+    bool ret = ( gpgCheck() && indeterminate(_pimpl->cfgRepoGpgCheck()) ) || bool(_pimpl->cfgRepoGpgCheck());
     if ( ret && _pimpl->internalUnsignedConfirmed() )	// relax if unsigned repo was confirmed in the past
       ret = false;
     return ret;
@@ -402,10 +402,10 @@ namespace zypp
 
 
   bool RepoInfo::pkgGpgCheck() const
-  { return _pimpl->cfgPkgGpgCheck() || ( gpgCheck() && !bool(validRepoSignature())/*enforced*/ ) ; }
+  { return bool(_pimpl->cfgPkgGpgCheck()) || ( gpgCheck() && !bool(validRepoSignature())/*enforced*/ ) ; }
 
   bool RepoInfo::pkgGpgCheckIsMandatory() const
-  { return _pimpl->cfgPkgGpgCheck() || ( gpgCheck() && indeterminate(_pimpl->cfgPkgGpgCheck()) && !bool(validRepoSignature())/*enforced*/ ); }
+  { return bool(_pimpl->cfgPkgGpgCheck()) || ( gpgCheck() && indeterminate(_pimpl->cfgPkgGpgCheck()) && !bool(validRepoSignature())/*enforced*/ ); }
 
   void RepoInfo::setPkgGpgCheck( TriBool value_r )
   { _pimpl->rawPkgGpgCheck( value_r ); }

--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -2243,7 +2243,7 @@ namespace zypp
 
 	// Make sure the service repo is created with the appropriate enablement
 	if ( ! indeterminate(toBeEnabled) )
-	  it->setEnabled( toBeEnabled );
+	  it->setEnabled( ( bool ) toBeEnabled );
 
         DBG << "Service adds repo " << it->alias() << " " << (it->enabled()?"enabled":"disabled") << endl;
         addRepository( *it );

--- a/zypp/repo/Applydeltarpm.cc
+++ b/zypp/repo/Applydeltarpm.cc
@@ -82,7 +82,7 @@ namespace zypp
           else
             WAR << "No executable " << prog << endl;
         }
-      return _last;
+      return ( bool ) _last;
     }
 
     /******************************************************************


### PR DESCRIPTION
Only explicit casts are allowed as of Boost 1.69

These are additional changes required for Tumbleweed with Boost 1.69.
https://github.com/openSUSE/libzypp/commit/867c6b3190dafcd07f0ac5d8eef39268cc925141 was incomplete.