### PR TITLE
Ma fate#325513 resolver namespaces

### DIFF
--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -75,7 +75,7 @@ BuildRequires:  pkgconfig
 BuildRequires:  pkg-config
 %endif
 
-BuildRequires:  libsolv-devel >= 0.7.1
+BuildRequires:  libsolv-devel >= 0.7.2
 %if 0%{?suse_version} >= 1100
 BuildRequires:  libsolv-tools
 %requires_eq    libsolv-tools

--- a/tests/data/TCNamespaceRecommends/solver-system.xml
+++ b/tests/data/TCNamespaceRecommends/solver-system.xml
@@ -1,0 +1,45 @@
+<channel><subchannel>
+
+<package>
+  <name>aspell</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>0</version><release>0</release>
+    </update>
+  </history>
+  <recommends>
+    <dep name='aspell-en' />
+    <dep name='recommended-pkg' />
+  </recommends>
+</package>
+
+<package>
+  <name>aspell-en</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>0</version><release>0</release>
+    </update>
+  </history>
+  <provides>
+    <dep name='locale(aspell:en)' />
+  </provides>
+  <supplements>
+    <!--- ignoring '(aspell and namespace:language(en))' -->
+  </supplements>
+</package>
+
+<package>
+  <name>glibc</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>0</version><release>0</release>
+    </update>
+  </history>
+  <provides>
+    <dep name='glibc' op='==' version='0' release='0' />
+  </provides>
+</package>
+</subchannel></channel>

--- a/tests/data/TCNamespaceRecommends/solver-test.xml
+++ b/tests/data/TCNamespaceRecommends/solver-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<test>
+<setup arch="x86_64">
+	<system file="solver-system.xml"/>
+	<!--
+	- alias       : update
+	- url         : http://foo.org/distribution/update
+	-->
+	<channel file="update.xml" name="update"/>
+	<locale name="en_US" />
+	<locale name="de" />
+</setup>
+</test>

--- a/tests/data/TCNamespaceRecommends/update.xml
+++ b/tests/data/TCNamespaceRecommends/update.xml
@@ -1,0 +1,75 @@
+<channel><subchannel>
+
+<package>
+  <name>aspell</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>1</version><release>1</release>
+    </update>
+  </history>
+  <recommends>
+    <dep name='aspell-en' />
+    <dep name='recommended-pkg' />
+  </recommends>
+</package>
+
+<package>
+  <name>aspell-en</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>1</version><release>1</release>
+    </update>
+  </history>
+  <provides>
+    <dep name='locale(aspell:en)' />
+  </provides>
+  <supplements>
+    <!--- ignoring '(aspell and namespace:language(en))' -->
+  </supplements>
+</package>
+
+<package>
+  <name>aspell-de</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>1</version><release>1</release>
+    </update>
+  </history>
+  <provides>
+    <dep name='locale(aspell:de)' />
+  </provides>
+  <supplements>
+    <!--- ignoring '(aspell and namespace:language(de))' -->
+  </supplements>
+</package>
+
+<package>
+  <name>aspell-fr</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>1</version><release>1</release>
+    </update>
+  </history>
+  <provides>
+    <dep name='locale(aspell:fr)' />
+  </provides>
+  <supplements>
+    <!--- ignoring '(aspell and namespace:language(de))' -->
+  </supplements>
+</package>
+
+<package>
+  <name>recommended-pkg</name>
+  <history>
+    <update>
+      <arch>x86_64</arch>
+      <version>1</version><release>1</release>
+    </update>
+  </history>
+</package>
+
+</subchannel></channel>

--- a/tests/zypp/CMakeLists.txt
+++ b/tests/zypp/CMakeLists.txt
@@ -39,6 +39,7 @@ ADD_TESTS(
   RepoManager
   RepoStatus
   ResKind
+  Resolver
   ResStatus
   Selectable
   SetRelationMixin

--- a/tests/zypp/Resolver_test.cc
+++ b/tests/zypp/Resolver_test.cc
@@ -1,0 +1,95 @@
+#include <boost/test/auto_unit_test.hpp>
+#define BOOST_CHECK_MODULE Resolver
+using namespace boost::unit_test;
+
+#include "TestSetup.h"
+#include "zypp/ResPool.h"
+#include "zypp/ResPoolProxy.h"
+#include "zypp/pool/PoolStats.h"
+#include "zypp/ui/Selectable.h"
+
+static TestSetup test;
+
+struct BAD_TESTCASE {};
+
+typedef std::set<PoolItem> PoolItemSet;
+
+constexpr const unsigned onlyRequires	= 0x1;
+constexpr const unsigned inrMode	= 0x2;
+
+PoolItemSet resolve( unsigned flags_r = 0 )
+{
+  test.resolver().setOnlyRequires            ( flags_r & onlyRequires );
+  test.resolver().setIgnoreAlreadyRecommended( ! ( flags_r & inrMode ) );
+  if ( ! test.resolver().resolvePool() )
+    throw BAD_TESTCASE();
+
+  return { make_filter_begin<resfilter::ByTransact>(test.pool()), make_filter_end<resfilter::ByTransact>(test.pool()) };
+}
+
+inline PoolItem getPi( const std::string & name_r, bool installed_r )
+{
+  for ( const auto & pi : test.pool().byName( name_r ) )
+  { if ( pi.isSystem() == installed_r ) return pi; }
+  throw BAD_TESTCASE();
+}
+inline PoolItem getIPi( const std::string & name_r )
+{ return getPi( name_r, true ); }
+inline PoolItem getAPi( const std::string & name_r )
+{ return getPi( name_r, false ); }
+
+/////////////////////////////////////////////////////////////////////////////
+// Pool content:
+PoolItem Ip;	// IA: aspell
+PoolItem Ap;
+PoolItem Ipen;	// IA: aspell-en	(wanted locale)
+PoolItem Apen;
+PoolItem Apde;	//  A: aspell-de	(wanted locale)
+PoolItem Apfr;	//  A: aspell-fr	(unwanted locale)
+PoolItem Aprec;	//  A: recommended-pkg	(by aspell)
+
+BOOST_AUTO_TEST_CASE(testcase_init)
+{
+  test.loadTestcaseRepos( TESTS_SRC_DIR"/data/TCNamespaceRecommends" );
+  Ip	= getIPi( "aspell" );
+  Ap	= getAPi( "aspell" );
+  Ipen	= getIPi( "aspell-en" );
+  Apen	= getAPi( "aspell-en" );
+  Apde	= getAPi( "aspell-de" );
+  Apfr	= getAPi( "aspell-fr" );
+  Aprec	= getAPi( "recommended-pkg" );
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+inline void BOOST_checkresult( const PoolItemSet & resolved_r, const PoolItemSet & expected_r )
+{ BOOST_CHECK_EQUAL( resolved_r, expected_r ); }
+
+
+BOOST_AUTO_TEST_CASE(install)
+{
+  Ap.status().setTransact( true, ResStatus::USER );
+  // Upadte aspell, add all recommends
+  BOOST_checkresult( resolve(), { Ap, Ip, Apde, Aprec } );
+  Ap.status().setTransact( false, ResStatus::USER );
+}
+
+BOOST_AUTO_TEST_CASE(installOnlyRequires)
+{
+  Ap.status().setTransact( true, ResStatus::USER );
+  // Upadte aspell, add only namespace recommends
+  BOOST_checkresult( resolve( onlyRequires ), { Ap, Ip, Apde } );
+  Ap.status().setTransact( false, ResStatus::USER );
+}
+
+BOOST_AUTO_TEST_CASE(inr)
+{
+  // Fillup all recommends
+  BOOST_checkresult( resolve( inrMode ), { Apde, Aprec } );
+}
+
+BOOST_AUTO_TEST_CASE(inrOnlyRequires)
+{
+  // Fillup only namespace recommends
+  BOOST_checkresult( resolve( inrMode|onlyRequires ), { Apde } );
+}

--- a/zypp.conf
+++ b/zypp.conf
@@ -344,9 +344,9 @@
 
 
 ##
-## Whether required packages are installed ONLY
-## So recommended packages, language packages and packages which depend
-## on hardware (modalias) will not be regarded.
+## Whether only required packages are installed.
+##
+## Recommended packages, will not be regarded.
 ##
 ## Valid values: boolean
 ## Default value: false

--- a/zypp/Resolver.cc
+++ b/zypp/Resolver.cc
@@ -86,10 +86,6 @@ namespace zypp
   void Resolver::setIgnoreAlreadyRecommended( bool yesno_r) { _pimpl->setIgnoreAlreadyRecommended( yesno_r ); }
   bool Resolver::ignoreAlreadyRecommended() const	{ return _pimpl->ignoreAlreadyRecommended(); }
 
-  void Resolver::setInr( ResolverNamespaces namespaces_r ) { _pimpl->setInr( namespaces_r ); }
-  void Resolver::resetInr()				{ setInr( ResolverNamespaces() ); }
-  ResolverNamespaces Resolver::inr() const		{ return _pimpl->inr(); }
-
   void Resolver::setOnlyRequires( bool yesno_r )	{ _pimpl->setOnlyRequires( yesno_r ); }
   void Resolver::resetOnlyRequires()			{ _pimpl->setOnlyRequires( indeterminate ); }
   bool Resolver::onlyRequires() const			{ return _pimpl->onlyRequires(); }

--- a/zypp/Resolver.h
+++ b/zypp/Resolver.h
@@ -189,15 +189,6 @@ namespace zypp
     bool ignoreAlreadyRecommended() const;
 
     /**
-     * Weak form of \ref ignoreAlreadyRecommended \c =false.
-     * Try to re-evaluate recommendations for specific namespaces only.
-     * \note May not support all namespaces.
-     */
-    void setInr( ResolverNamespaces namespaces_r );
-    void resetInr();
-    ResolverNamespaces inr() const;
-
-    /**
      * Setting whether required packages are installed ONLY
      * So recommended packages, language packages and packages which depend
      * on hardware (modalias) will not be regarded.

--- a/zypp/solver/detail/Resolver.cc
+++ b/zypp/solver/detail/Resolver.cc
@@ -76,7 +76,6 @@ std::ostream & Resolver::dumpOn( std::ostream & os ) const
   OUTS( _solveSrcPackages );
   OUTS( _cleandepsOnRemove );
   OUTS( _ignoreAlreadyRecommended );
-  OUTS( _inr );
   #undef OUT
   return os << "<resolver/>";
 }
@@ -95,8 +94,6 @@ Resolver::Resolver (const ResPool & pool)
     , _solveSrcPackages		( false )
     , _cleandepsOnRemove	( ZConfig::instance().solver_cleandepsOnRemove() )
     , _ignoreAlreadyRecommended	( true )
-    // _inr defaults to ResolverNamespaces()
-
 {
     sat::Pool satPool( sat::Pool::instance() );
     _satResolver = new SATResolver(_pool, satPool.get());
@@ -311,7 +308,6 @@ void Resolver::solverInit()
 
     _satResolver->setFixsystem			( isVerifyingMode() );
     _satResolver->setIgnorealreadyrecommended	( ignoreAlreadyRecommended() );
-    _satResolver->setInr			( inr() );
     _satResolver->setOnlyRequires		( onlyRequires() );
     _satResolver->setUpdatesystem		(_updateMode);
     _satResolver->setSolveSrcPackages		( solveSrcPackages() );

--- a/zypp/solver/detail/Resolver.h
+++ b/zypp/solver/detail/Resolver.h
@@ -95,7 +95,6 @@ class Resolver : private base::NonCopyable
     bool _cleandepsOnRemove;	// whether removing a package should also remove no longer needed requirements
 
     bool _ignoreAlreadyRecommended;   //ignore recommended packages that have already been recommended by the installed packages
-    ResolverNamespaces _inr;	// Try to re-evaluate recommendations for these namespaces
     //@}
 
     // Additional QueueItems which has to be regarded by the solver
@@ -167,9 +166,6 @@ class Resolver : private base::NonCopyable
     //@{
     bool ignoreAlreadyRecommended() const	{ return _ignoreAlreadyRecommended; }
     void setIgnoreAlreadyRecommended( bool yesno_r ) { _ignoreAlreadyRecommended = yesno_r; }
-
-    ResolverNamespaces inr() const		{ return _inr; }
-    void setInr( ResolverNamespaces namespaces_r ) { _inr = namespaces_r; }
 
     bool onlyRequires () const			{ return _onlyRequires; }
     void setOnlyRequires( TriBool state_r );

--- a/zypp/solver/detail/SATResolver.cc
+++ b/zypp/solver/detail/SATResolver.cc
@@ -170,7 +170,6 @@ SATResolver::dumpOn( std::ostream & os ) const
 	os << "  solveSrcPackages	= "	<< _solveSrcPackages << endl;
 	os << "  cleandepsOnRemove	= "	<< _cleandepsOnRemove << endl;
         os << "  fixsystem		= "	<< _fixsystem << endl;
-	os << "  inr namespace		= "	<< _inr << endl;
     } else {
 	os << "<NULL>";
     }
@@ -625,19 +624,9 @@ SATResolver::solverInit(const PoolItemList & weakItems)
     }
 
     // Ad rules for changed requestedLocales
-    const auto & trackedLocaleIds( myPool().trackedLocaleIds() );
-    if ( _inr.testFlag( ResolverNamespace::language ) )
     {
-      // inr mode
-      for ( const auto & locale : trackedLocaleIds.current() )
-      {
-	queue_push( &(_jobQueue), SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES );
-	queue_push( &(_jobQueue), Capability( ResolverNamespace::language, IdString(locale) ).id() );
-      }
-      // TODO cleanup not requested locale packages?
-    }
-    else
-    {
+      const auto & trackedLocaleIds( myPool().trackedLocaleIds() );
+
       // just track changed locakes
       for ( const auto & locale : trackedLocaleIds.added() )
       {

--- a/zypp/solver/detail/SATResolver.cc
+++ b/zypp/solver/detail/SATResolver.cc
@@ -192,7 +192,7 @@ SATResolver::SATResolver (const ResPool & pool, sat::detail::CPool *satPool)
     , _updatesystem(false)
     , _noupdateprovide		( false )
     , _dosplitprovides		( true )
-    , _onlyRequires(ZConfig::instance().solver_onlyRequires())
+    , _onlyRequires		(ZConfig::instance().solver_onlyRequires())
     , _ignorealreadyrecommended(true)
     , _distupgrade(false)
     , _distupgrade_removeunsupported(false)
@@ -405,7 +405,8 @@ SATResolver::solving(const CapabilitySet & requires_caps,
     solver_set_flag(_satSolver, SOLVER_FLAG_ALLOW_UNINSTALL,		_allowuninstall);
     solver_set_flag(_satSolver, SOLVER_FLAG_NO_UPDATEPROVIDE,		_noupdateprovide);
     solver_set_flag(_satSolver, SOLVER_FLAG_SPLITPROVIDES,		_dosplitprovides);
-    solver_set_flag(_satSolver, SOLVER_FLAG_IGNORE_RECOMMENDED, _onlyRequires);
+    solver_set_flag(_satSolver, SOLVER_FLAG_IGNORE_RECOMMENDED, 	false);		// resolve recommended namespaces
+    solver_set_flag(_satSolver, SOLVER_FLAG_ONLY_NAMESPACE_RECOMMENDED,	_onlyRequires);	//
     solver_set_flag(_satSolver, SOLVER_FLAG_DUP_ALLOW_DOWNGRADE,	_dup_allowdowngrade );
     solver_set_flag(_satSolver, SOLVER_FLAG_DUP_ALLOW_NAMECHANGE,	_dup_allownamechange );
     solver_set_flag(_satSolver, SOLVER_FLAG_DUP_ALLOW_ARCHCHANGE,	_dup_allowarchchange );
@@ -847,7 +848,8 @@ void SATResolver::doUpdate()
     solver_set_flag(_satSolver, SOLVER_FLAG_ALLOW_UNINSTALL,		_allowuninstall);
     solver_set_flag(_satSolver, SOLVER_FLAG_NO_UPDATEPROVIDE,		_noupdateprovide);
     solver_set_flag(_satSolver, SOLVER_FLAG_SPLITPROVIDES,		_dosplitprovides);
-    solver_set_flag(_satSolver, SOLVER_FLAG_IGNORE_RECOMMENDED, _onlyRequires);
+    solver_set_flag(_satSolver, SOLVER_FLAG_IGNORE_RECOMMENDED, 	false);		// resolve recommended namespaces
+    solver_set_flag(_satSolver, SOLVER_FLAG_ONLY_NAMESPACE_RECOMMENDED,	_onlyRequires);	//
 
     sat::Pool::instance().prepare();
 

--- a/zypp/solver/detail/SATResolver.h
+++ b/zypp/solver/detail/SATResolver.h
@@ -115,8 +115,6 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
     bool _cleandepsOnRemove:1;		// whether removing a package should also remove no longer needed requirements
 
   private:
-    ResolverNamespaces _inr;		// Try to re-evaluate recommendations for these namespaces
-  private:
     // ---------------------------------- methods
     std::string SATprobleminfoString (Id problem, std::string &detail, Id &ignoreId);
     void resetItemTransaction (PoolItem item);
@@ -177,9 +175,6 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
 
     bool ignorealreadyrecommended () const {return _ignorealreadyrecommended;}
     void setIgnorealreadyrecommended ( const bool ignorealreadyrecommended) { _ignorealreadyrecommended = ignorealreadyrecommended;}
-
-    ResolverNamespaces inr() const { return _inr; }
-    void setInr( ResolverNamespaces namespaces_r ) { _inr = namespaces_r; }
 
     bool distupgrade () const {return _distupgrade;}
     void setDistupgrade ( const bool distupgrade) { _distupgrade = distupgrade;}

--- a/zypp/solver/detail/SATResolver.h
+++ b/zypp/solver/detail/SATResolver.h
@@ -103,7 +103,7 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
     bool _updatesystem:1;		// update
     bool _noupdateprovide:1;		// true: update packages needs not to provide old package
     bool _dosplitprovides:1;		// true: consider legacy split provides
-    bool _onlyRequires:1;		// true: consider required packages only
+    bool _onlyRequires:1;		// true: consider required packages only (but recommended namespaces)
     bool _ignorealreadyrecommended:1;	// true: ignore recommended packages that were already recommended by the installed packages
     bool _distupgrade:1;
     bool _distupgrade_removeunsupported:1;

--- a/zypp/solver/detail/Testcase.cc
+++ b/zypp/solver/detail/Testcase.cc
@@ -308,7 +308,6 @@ class  HelixControl {
     void deleteResolvable( const PoolItem & pi_r );
     void addDependencies (const CapabilitySet &capRequire, const CapabilitySet &capConflict);
     void addUpgradeRepos( const std::set<Repository> & upgradeRepos_r );
-    void addInr( ResolverNamespaces namespaces_r );
 
     std::string filename () { return dumpFile; }
 };
@@ -464,12 +463,6 @@ void HelixControl::addUpgradeRepos( const std::set<Repository> & upgradeRepos_r 
   }
 }
 
-void HelixControl::addInr( ResolverNamespaces namespaces_r )
-{
-  if ( namespaces_r )
-    *file << "<inrNamespaces str=\"" << namespaces_r << "\" int=\"" << str::numstring((namespaces_r)) << "\"/>" << endl;
-}
-
 //---------------------------------------------------------------------------
 
 Testcase::Testcase()
@@ -601,7 +594,6 @@ bool Testcase::createTestcase(Resolver & resolver, bool dumpPool, bool runSolver
     control.addDependencies (SystemCheck::instance().requiredSystemCap(),
 			     SystemCheck::instance().conflictSystemCap());
     control.addUpgradeRepos( resolver.upgradeRepos() );
-    control.addInr( resolver.inr() );
 
     control.addTagIf( "distupgrade",	resolver.isUpgradeMode() );
     control.addTagIf( "update",	 	resolver.isUpdateMode() );


### PR DESCRIPTION
In the 1st iteration we unconditionally resolve namespaces, even if `no-recommends` is on.  Technically those namespaces (hardware,language,filesystem support) are recommends, but in fact they are more important than ordinary recommends.

Questionable whether there are usecases which actually require turning off the namespaces as well. If so, we can still offer additional switches...