### PR TITLE
Try to the missing rpmDB compat symlink in case the rpm package got d…

### DIFF
--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -59,6 +59,9 @@ using namespace zypp::filesystem;
 
 #define WORKAROUNDRPMPWDBUG
 
+#undef ZYPP_BASE_LOGGER_LOGGROUP
+#define ZYPP_BASE_LOGGER_LOGGROUP "librpmDb"
+
 namespace zypp
 {
   namespace zypp_readonly_hack
@@ -329,6 +332,14 @@ void RpmDb::initDatabase( Pathname root_r, Pathname dbPath_r, bool doRebuild_r )
   {
     ERR << "Illegal root or dbPath: " << stringPath( root_r, dbPath_r ) << endl;
     ZYPP_THROW(RpmInvalidRootException(root_r, dbPath_r));
+  }
+
+  if ( dbPath_r == "/var/lib/rpm"
+    && ! PathInfo( root_r/"/var/lib/rpm" ).isExist()
+    && PathInfo( root_r/"/usr/lib/sysimage/rpm" ).isDir() )
+  {
+    WAR << "Rpm package was deleted? Injecting missing rpmdb compat symlink." << endl;
+    filesystem::symlink( "../../usr/lib/sysimage/rpm", root_r/"/var/lib/rpm" );
   }
 
   MIL << "Calling initDatabase: " << stringPath( root_r, dbPath_r )

--- a/zypp/target/rpm/librpmDb.cc
+++ b/zypp/target/rpm/librpmDb.cc
@@ -19,6 +19,9 @@
 #include "zypp/target/rpm/RpmHeader.h"
 #include "zypp/target/rpm/RpmException.h"
 
+#undef ZYPP_BASE_LOGGER_LOGGROUP
+#define ZYPP_BASE_LOGGER_LOGGROUP "librpmDb"
+
 using namespace std;
 
 namespace zypp
@@ -114,8 +117,8 @@ public:
 //
 ///////////////////////////////////////////////////////////////////
 
-Pathname         librpmDb::_defaultRoot  ( "/" );
-Pathname         librpmDb::_defaultDbPath( "/var/lib/rpm" );
+Pathname         librpmDb::_defaultRoot;	// Remembered arg to last dbAccess call
+Pathname         librpmDb::_defaultDbPath;	// Remembered arg to last dbAccess call
 librpmDb::constPtr librpmDb::_defaultDb;
 bool             librpmDb::_dbBlocked    ( true );
 


### PR DESCRIPTION
…eleted ([bsc#1122471](https://bugzilla.suse.com/show_bug.cgi?id=1122471)). Changing the rpmdb path in libzypp would not help, as tools refer to /var/lib/rpm as well.