### PR TITLE
Ma unwanted url rewrite

### DIFF
--- a/tests/zypp/Url_test.cc
+++ b/tests/zypp/Url_test.cc
@@ -65,17 +65,18 @@ BOOST_AUTO_TEST_CASE(test_url1)
     BOOST_CHECK_EQUAL( str, url.asString() );
     BOOST_CHECK_EQUAL( str, url.asCompleteString() );
 
-    // asString & asCompleteString should add empty authority
-    // "dvd://...", except we request to avoid it.
-    str = "dvd:/srv/ftp";
-    one = "dvd:///srv/ftp";
-    two = "dvd:///srv/ftp";
-    url = str;
+    // In general, schema without authority allows specifying an empty authority
+    // though it should not be printed (unless explicitly requested).
+    BOOST_CHECK_EQUAL( Url("dvd:/srv/ftp").asCompleteString(),   "dvd:/srv/ftp" );
+    BOOST_CHECK_EQUAL( Url("dvd:/srv/ftp").asString(),           "dvd:/srv/ftp" );
 
-    BOOST_CHECK_EQUAL( one, url.asString() );
-    BOOST_CHECK_EQUAL( two, url.asCompleteString() );
-    BOOST_CHECK_EQUAL( str, url.asString(zypp::url::ViewOptions() -
-                                 zypp::url::ViewOption::EMPTY_AUTHORITY));
+    BOOST_CHECK_EQUAL( Url("dvd:///srv/ftp").asCompleteString(), "dvd:/srv/ftp" );
+    BOOST_CHECK_EQUAL( Url("dvd:///srv/ftp").asString(),         "dvd:/srv/ftp" );
+
+    BOOST_CHECK_EQUAL( Url("dvd:///srv/ftp").asString(url::ViewOption::DEFAULTS+url::ViewOption::EMPTY_AUTHORITY),        "dvd:///srv/ftp" );
+    BOOST_CHECK_EQUAL( Url("dvd:///srv/ftp").asString(url::ViewOption::DEFAULTS-url::ViewOption::EMPTY_AUTHORITY),        "dvd:/srv/ftp" );
+
+    BOOST_CHECK_THROW( Url("dvd://authority/srv/ftp"), url::UrlNotAllowedException );
 
     // asString shouldn't print the password, asCompleteString should
     // further, the "//" at the begin of the path should become "/%2F"
@@ -159,7 +160,6 @@ BOOST_AUTO_TEST_CASE(test_url1)
 
     // OK, valid (no host, path is there)
     str = "cd:///some/path";
-    BOOST_CHECK_EQUAL( str, zypp::Url(str).asString());
     BOOST_CHECK( zypp::Url(str).isValid());
 }
 

--- a/tests/zypp/Url_test.cc
+++ b/tests/zypp/Url_test.cc
@@ -8,6 +8,8 @@
 #include "zypp/base/Exception.h"
 #include "zypp/base/String.h"
 
+#include "zypp/RepoInfo.h"
+
 #include "zypp/Url.h"
 #include <stdexcept>
 #include <iostream>
@@ -278,6 +280,24 @@ BOOST_AUTO_TEST_CASE( test_url5)
   std::string str( "file:/some/${var:+path}/${var:-with}/${vars}" );
   BOOST_CHECK_EQUAL( Url(str).asString(), str );
   BOOST_CHECK_EQUAL( Url(zypp::url::encode( str, URL_SAFE_CHARS )).asString(), str );
+}
+
+BOOST_AUTO_TEST_CASE(plugin_scriptpath)
+{
+  // plugin script path must not be rewritten
+  for ( const std::string & t : { "script", "script/", "/script", "/script/", "./script", "./script/" } )
+  {
+    BOOST_CHECK_EQUAL( Url("plugin:"+t).getPathName(),	t );
+  }
+
+  { // more cosmetic issue, but the RepoVarReplacer should
+    // not change the string representation (-> "plugin:/script")
+    Url u( "plugin:script?opt=val" );
+    RepoInfo i;
+    i.setBaseUrl( u );
+    BOOST_CHECK_EQUAL( u.asString(), i.url().asString() );
+  }
+
 }
 
 BOOST_AUTO_TEST_CASE(plugin_querystring_args)

--- a/zypp/Url.cc
+++ b/zypp/Url.cc
@@ -181,6 +181,10 @@ namespace zypp
 
         // =====================================
         ref.reset( new UrlBase());
+        // don't show empty authority
+        ref->setViewOptions( zypp::url::ViewOption::DEFAULTS -
+                             zypp::url::ViewOption::EMPTY_AUTHORITY);
+
         ref->config("with_authority",   "n");   // disallow host,...
         ref->config("require_pathname", "m");   // path is mandatory
         addUrlByScheme("hd",     ref);
@@ -189,9 +193,6 @@ namespace zypp
         addUrlByScheme("dir",    ref);
         addUrlByScheme("iso",    ref);
 
-        // don't show empty authority
-        ref->setViewOptions( zypp::url::ViewOption::DEFAULTS -
-                             zypp::url::ViewOption::EMPTY_AUTHORITY);
         addUrlByScheme("mailto", ref);
         addUrlByScheme("urn",    ref);
         addUrlByScheme("plugin", ref);	// zypp plugable media handler:

--- a/zypp/repo/RepoVariables.cc
+++ b/zypp/repo/RepoVariables.cc
@@ -548,7 +548,7 @@ namespace zypp
 
     Url RepoVariablesUrlReplacer::operator()( const Url & value ) const
     {
-      static const Url::ViewOptions toReplace = url::ViewOption::DEFAULTS - url::ViewOption::WITH_USERNAME - url::ViewOption::WITH_PASSWORD;
+      Url::ViewOptions toReplace = value.getViewOptions() - url::ViewOption::WITH_USERNAME - url::ViewOption::WITH_PASSWORD;
       const std::string & replaced( RepoVarExpand()( value.asString( toReplace ), RepoVarsMap::lookup ) );
       Url newurl;
       if ( !replaced.empty() )
@@ -556,6 +556,7 @@ namespace zypp
 	newurl = replaced;
 	newurl.setUsername( value.getUsername( url::E_ENCODED ), url::E_ENCODED );
 	newurl.setPassword( value.getPassword( url::E_ENCODED ), url::E_ENCODED );
+	newurl.setViewOptions( value.getViewOptions() );
       }
       return newurl;
     }


### PR DESCRIPTION
Some Url schemata per default suppressed printing an *empty authority*, as they do not allow defining an authority at all (mailto,plugin,...). The patch uses this default for more schemata without authority (dir, cd, iso,...). This changes their default string representation from e.g. `dir:///path` to `dir:/path`.

The RepoVariablesUrlReplacer accidentally amended the Urls default viewoption. The patch makes sure the returned Url has the same viewoptions as the original one. By now more a cosmetical issue if `plugin:foo` is suddenly printed as `plugin:/foo`, but the replacer should just substitute variables, nothing else.