### PR TITLE
Provide more information about problems

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+---
+Language: Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping: 
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros: 
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories: 
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+  - Regex: '^(<|"(gtest|isl|json)/)'
+    Priority: 3
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepLineBreaksForNonEmptyLines: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000000
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+Standard: Cpp11
+TabWidth: 8
+UseTab: Never
+...

--- a/zypp/ResolverProblem.cc
+++ b/zypp/ResolverProblem.cc
@@ -70,9 +70,16 @@ namespace zypp
     , _details( std::move(details) )
     {}
 
+    Impl( std::string && description, std::string && details, std::vector<std::string> &&completeProblemInfo )
+        : _description( std::move(description) )
+          , _details( std::move(details) )
+          , _completeProblemInfo ( std::move(completeProblemInfo) )
+    {}
+
     std::string		_description;
     std::string		_details;
     ProblemSolutionList	_solutions;
+    std::vector<std::string> _completeProblemInfo;
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -94,6 +101,10 @@ namespace zypp
   : _pimpl( new Impl( std::move(description), std::move(details) ) )
   {}
 
+  ResolverProblem::ResolverProblem( std::string description, std::string details, std::vector<std::string> &&completeProblemInfo )
+      : _pimpl( new Impl( std::move(description), std::move(details), std::move(completeProblemInfo) ) )
+  {}
+
   ResolverProblem::~ResolverProblem()
   {}
 
@@ -107,6 +118,8 @@ namespace zypp
   const ProblemSolutionList & ResolverProblem::solutions() const
   { return _pimpl->_solutions; }
 
+  const std::vector<std::string> & ResolverProblem::completeProblemInfo() const
+  { return _pimpl->_completeProblemInfo; }
 
   void ResolverProblem::setDescription( std::string description )
   { _pimpl->_description = std::move(description); }

--- a/zypp/ResolverProblem.h
+++ b/zypp/ResolverProblem.h
@@ -11,6 +11,7 @@
 
 #include <list>
 #include <string>
+#include <vector>
 
 #include "zypp/ProblemTypes.h"
 #include "zypp/ProblemSolution.h"
@@ -31,6 +32,8 @@ namespace zypp
     ResolverProblem( std::string description );
     /** Constructor. */
     ResolverProblem( std::string description, std::string details );
+    /** Constructor. */
+    ResolverProblem( std::string description, std::string details, std::vector<std::string> &&completeProblemInfo );
 
     /** Destructor. */
     ~ResolverProblem();
@@ -46,6 +49,11 @@ namespace zypp
      * or an empty string if there are no useful details.
      **/
     const std::string & details() const;
+
+    /**
+     * Return a one-line description for each problematic rule in the problem tree
+     **/
+    const std::vector<std::string> & completeProblemInfo() const;
 
     /**
      * Return the possible solutions to this problem.

--- a/zypp/solver/detail/SATResolver.h
+++ b/zypp/solver/detail/SATResolver.h
@@ -117,6 +117,8 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
   private:
     // ---------------------------------- methods
     std::string SATprobleminfoString (Id problem, std::string &detail, Id &ignoreId);
+    std::string SATproblemRuleInfoString (Id rule, std::string &detail, Id &ignoreId);
+    std::vector<std::string> SATgetCompleteProblemInfoStrings ( Id problem );
     void resetItemTransaction (PoolItem item);
 
     // Create a SAT solver and reset solver selection in the pool (Collecting


### PR DESCRIPTION
Libsolv offers more information about problems than we currently show
to the user. This patch enables libzypp to get the full set of
information. Also it removes some duplicate code from libzypp that is
already present in libsolv.