### PR TITLE
Give posttrans script a parameter of 0

### DIFF
--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -120,7 +120,7 @@ namespace zypp
 	    }
 
 	    MIL << "EXECUTE posttrans: " << script << endl;
-	    ExternalProgram prog( (noRootScriptDir/script).asString(), ExternalProgram::Stderr_To_Stdout, false, -1, true, _root );
+	    ExternalProgram prog( (noRootScriptDir/script).asString() + " 0", ExternalProgram::Stderr_To_Stdout, false, -1, true, _root );
 
 	    str::Str collect;
 	    for( std::string line = prog.receiveLine(); ! line.empty(); line = prog.receiveLine() )


### PR DESCRIPTION
When running a posttrans script, according to https://en.opensuse.org/openSUSE:Packaging_scriptlet_snippets (and fedora's equivilant https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/ ) a posttrans script should be given the value '0' as a parameter. Right now libzypp gives no arguments.

Original issue was found when installing gitlab-ce. Its posttrans script is located at https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/config/templates/package-scripts/posttrans.erb (the important part is the bottom `case`). Roughly it checks if $1 is 0 (identifying it as rpm, though this script only runs for rpm anyways) and then runs its script. Since libzypp doesnt pass this on, it never triggers.

A test rpm can be found at http://hackerguild.com/thothonegan/libzypp/dummy-posttrans-test-0.0.1-1.x86_64.rpm (spec: http://hackerguild.com/thothonegan/libzypp/dummy-posttrans-test.spec ) that just outputs what value it receives when its installed. Here is the results both before and after this change, using zypper as the host on Tumbleweed. http://hackerguild.com/thothonegan/libzypp/result.png

As an aside, i noticed when testing that 'rpm' itself actually gave '1' for the parameter. This can kindof make sense, since its supposed to be the number of packages remaining on the system, but the docs say it should always be 0. For this pull request, I'm going with the docs/gitlab-ci but I could easily see an argument to reproduce what RPM is doing instead (though have not looked into why RPM is doing that).
