### PR TITLE
KeyManagerCtx: rewrite API to take the keyring when constructing the context

### DIFF
--- a/zypp/KeyManager.cc
+++ b/zypp/KeyManager.cc
@@ -321,9 +321,6 @@ std::list<PublicKeyData> KeyManagerCtx::readKeyFromFile(const Pathname &file)
 
 bool KeyManagerCtx::verify(const Pathname &file, const Pathname &signature)
 {
-  if ( !PathInfo( file ).isExist() || !PathInfo( signature ).isExist() )
-    return false;
-
   return _pimpl->verifySignaturesFprs(file, signature);
 }
 

--- a/zypp/KeyManager.h
+++ b/zypp/KeyManager.h
@@ -31,19 +31,34 @@ namespace zypp
 class KeyManagerCtx
 {
     public:
-        typedef shared_ptr<KeyManagerCtx> Ptr;
+	/** Creates a new KeyManagerCtx for PGP using a volatile temp. homedir/keyring.
+	 *
+	 * Mainly used with methods, which need a context but do not need a keyring
+	 * (like \ref readKeyFromFile or \ref readSignatureFingerprints).
+	 *
+	 * \note The underlying keyring is intentionally NOT the users keyring.
+	 * Think of it as a volatile keyring whose content may get cleared anytime.
+	 *
+	 * \throws KeyRingException if context can not be created or set up
+	 */
+	static KeyManagerCtx createForOpenPGP();
 
-        /** Creates a new KeyManagerCtx for PGP */
-        static Ptr createForOpenPGP();
+	/** Creates a new KeyManagerCtx for PGP using a custom homedir/keyring.
+	 *
+	 * \note If you explicitly pass an empty \c Pathname, no homedir/keyring
+	 * will be set and GPGME will use it's defaults.
+	 *
+	 * \throws KeyRingException if context can not be created or set up
+	 */
+	static KeyManagerCtx createForOpenPGP( const Pathname & keyring_r );
 
-        /** Changes the keyring directory */
-        bool setHomedir (const Pathname & keyring_r);
-        Pathname homedir ()const;
+	/** Return the homedir/keyring. */
+	Pathname homedir() const;
 
         /**  Returns a list of all public keys found in the current keyring */
         std::list<PublicKeyData> listKeys();
 
-        /** Returns a list of all \sa PublicKeyData found in \a file */
+        /** Returns a list of all \a PublicKeyData found in \a file */
         std::list<PublicKeyData> readKeyFromFile(const Pathname & file);
 
         /** Tries to verify \a file using \a signature, returns true on success */
@@ -62,12 +77,10 @@ class KeyManagerCtx
         std::list<std::string> readSignatureFingerprints(const Pathname & signature);
 
     private:
-      class Impl;
-
       KeyManagerCtx();
 
+      class Impl;
       RW_pointer<Impl> _pimpl; ///< Pointer to implementation
-
 };
 
 }

--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -393,6 +393,7 @@ namespace zypp
       : _dontUseThisPtrDirectly( new filesystem::TmpFile( sharedFile_r ) )
     { readFromFile(); }
 
+    // private from keyring
     Impl( const filesystem::TmpFile & sharedFile_r, const PublicKeyData & keyData_r )
       : _dontUseThisPtrDirectly( new filesystem::TmpFile( sharedFile_r ) )
       , _keyData( keyData_r )
@@ -404,6 +405,7 @@ namespace zypp
       }
     }
 
+    // private from keyring
     Impl( const PublicKeyData & keyData_r )
       : _keyData( keyData_r )
     {}
@@ -419,23 +421,12 @@ namespace zypp
       { return _hiddenKeys; }
 
     protected:
-      std::string _initHomeDir()	///< readFromFile helper to prepare the 'gpg --homedir'
-      { Pathname ret( zypp::myTmpDir() / "PublicKey" ); filesystem::assert_dir( ret ); return ret.asString(); }
-
       void readFromFile()
       {
         PathInfo info( path() );
         MIL << "Reading pubkey from " << info.path() << " of size " << info.size() << " and sha1 " << filesystem::checksum(info.path(), "sha1") << endl;
 
-        //@TODO is this still required? KeyManagerCtx creates a homedir on the fly
-        static std::string tmppath( _initHomeDir() );
-
-        KeyManagerCtx::Ptr ctx = KeyManagerCtx::createForOpenPGP();
-        if (!ctx || !ctx->setHomedir(tmppath)) {
-          ZYPP_THROW( Exception( std::string("Can't read public key data: Setting the keyring path failed!")) );
-        }
-
-        std::list<PublicKeyData> keys = ctx->readKeyFromFile(path());
+        std::list<PublicKeyData> keys = KeyManagerCtx::createForOpenPGP().readKeyFromFile( path() );
         switch ( keys.size() )
         {
           case 0:

--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -20,7 +20,6 @@
 
 #include <solv/solvversion.h>
 
-#include "zypp/base/String.h"
 #include "zypp/base/InputStream.h"
 #include "zypp/base/LogTools.h"
 #include "zypp/base/Gettext.h"
@@ -39,7 +38,6 @@
 #include "zypp/MediaSetAccess.h"
 #include "zypp/ExternalProgram.h"
 #include "zypp/ManagedFile.h"
-#include "zypp/KeyManager.h"
 
 #include "zypp/parser/RepoFileReader.h"
 #include "zypp/parser/ServiceFileReader.h"


### PR DESCRIPTION
Preparing the context and setting up the keyring must succeed, otherwise the calling methods are lost. `createForOpenPGP` was changed to prepare context and keyring in one go and to throw a `KeyRingException` on error.

Also dropped the outer `shared_ptr<KeyManagerCtx>` and let `createForOpenPGP` return the `KeyManagerCtx` directly.

The `KeyManager.cc` diff looks more complicated than the change actually is: 
- `Impl` stores the gpgme context, so it is now also responsible for releasing it.
- `createForOpenPGP` was changed to return a `KeyManagerCtx`, throw on error and immediately sets the homedir/keyring.
- `setHomedir()` was dropped.
- `listKeys()` temporarily sets `GPGME_KEYLIST_MODE_SIGS`.
- `readKeyFromFile()`  works around bsc#1140670 by using a temp. keyring if necessary (a version using `gpgme_op_keylist_from_data_start` once the bug is fixed is sketched)

