### PR TITLE
commit: Run file conflict check on dry-run (best with download-only) …

### DIFF
--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1127,6 +1127,8 @@ namespace zypp
     {
       // ----------------------------------------------------------------- //
       ZYppCommitPolicy policy_r( policy_rX );
+      bool explicitDryRun = policy_r.dryRun();	// explicit dry run will trigger a fileconflict check, implicit (download-only) not.
+
       ShutdownLock lck("Zypp commit running.");
 
       // Fake outstanding YCP fix: Honour restriction to media 1
@@ -1346,12 +1348,20 @@ namespace zypp
 	  else
 	  {
 	    DBG << "dryRun/downloadOnly: Not installing/deleting anything." << endl;
+	    if ( explicitDryRun ) {
+	      // if cache is preloaded, check for file conflicts
+	      commitFindFileConflicts( policy_r, result );
+	    }
 	  }
 	}
       }
       else
       {
         DBG << "dryRun: Not downloading/installing/deleting anything." << endl;
+	if ( explicitDryRun ) {
+	  // if cache is preloaded, check for file conflicts
+	  commitFindFileConflicts( policy_r, result );
+	}
       }
 
       ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…([bsc#1140039](https://bugzilla.suse.com/show_bug.cgi?id=1140039))

If the package cache is already filled (or together with --download-only) you can check for file conflicts without actually installing some packages.