### PR TITLE
bsc#1116995 leaking fds in curl backends

### DIFF
--- a/zypp/AutoDispose.h
+++ b/zypp/AutoDispose.h
@@ -194,6 +194,45 @@ namespace zypp
     inline std::ostream & operator<<( std::ostream & str, const AutoDispose<Tp> & obj )
     { return str << obj.value(); }
 
+
+  ///////////////////////////////////////////////////////////////////
+  /// \class AutoFD
+  /// \brief \ref AutoDispose\<int>  calling \c ::close
+  /// \ingroup g_RAII
+  ///////////////////////////////////////////////////////////////////
+  struct AutoFD : public AutoDispose<int>
+  {
+    AutoFD( int fd_r = -1 ) : AutoDispose<int>( fd_r, [] ( int fd_r ) { if ( fd_r != -1 ) ::close( fd_r ); } ) {}
+  };
+
+  ///////////////////////////////////////////////////////////////////
+  /// \class AutoFILE
+  /// \brief \ref AutoDispose\<FILE*> calling \c ::fclose
+  /// \see \ref AutoDispose
+  /// \ingroup g_RAII
+  ///////////////////////////////////////////////////////////////////
+  struct AutoFILE : public AutoDispose<FILE*>
+  {
+    AutoFILE( FILE* file_r = nullptr ) : AutoDispose<FILE*>( file_r, [] ( FILE* file_r ) { if ( file_r ) ::fclose( file_r ); } ) {}
+  };
+
+  ///////////////////////////////////////////////////////////////////
+  /// \class AutoFREE<Tp>
+  /// \brief \ref AutoDispose\<Tp*> calling \c ::free
+  /// \ingroup g_RAII
+  ///////////////////////////////////////////////////////////////////
+  template <typename Tp>
+  struct AutoFREE : public AutoDispose<Tp*>
+  {
+    AutoFREE( Tp* ptr_r = nullptr ) : AutoDispose<Tp*>( ptr_r, [] ( Tp* ptr_r ) { if ( ptr_r ) ::free( ptr_r ); } ) {}
+    AutoFREE( void* ptr_r ) : AutoFREE( static_cast<Tp*>(ptr_r) ) {}
+  };
+
+  template <>
+  struct AutoFREE<void> : public AutoDispose<void*>
+  {
+    AutoFREE( void* ptr_r = nullptr ) : AutoDispose<void*>( ptr_r, [] ( void* ptr_r ) { if ( ptr_r ) ::free( ptr_r ); } ) {}
+  };
   /////////////////////////////////////////////////////////////////
 } // namespace zypp
 ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
To test run eg. `watch ls -l /proc/\$\(cat /var/run/zypp.pid\)/fd` in a root shell to monitor the file descriptors in use. Then in an other window `rm -r /var/cache/zypp/raw/; zypper dup --dry-run --force-resolution` until the summary appears.
The PR so far fixes the open FDs to `/dev/null` from the curl backend, but it looks like the multicurl backend misses to close some sockets. Will look after it.