### PR TITLE
MediaSetAccess: Close media handles on destruction

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -47,7 +47,9 @@ IMPL_PTR_TYPE(MediaSetAccess);
   {
     try
     {
-      release();
+      media::MediaManager manager;
+      for ( const auto & mm : _medias )
+	manager.close( mm.second );
     }
     catch(...) {} // don't let exception escape a dtor.
   }


### PR DESCRIPTION
It's a pity that MediaAccessId is an unsigned and not some shared_ptr.
Releasing the media on destruction is not enough. The MediaAccess handle
stays in the MediaManagers mediaMap waiting forever to be re-attached. The
map grows and is populated with dead handles, if the media is not closed
before the last MediaAccessId vanishes.

This also closes all the the open sockets we saw in https://github.com/openSUSE/libzypp/pull/179.