### PR TITLE
Expose pool_whatmatchesdep from zypp::sat::Pool

### DIFF
--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -71,7 +71,7 @@ BuildRequires:  pkgconfig
 BuildRequires:  pkg-config
 %endif
 
-BuildRequires:  libsolv-devel >= 0.7.2
+BuildRequires:  libsolv-devel >= 0.7.7
 %if 0%{?suse_version} >= 1100
 BuildRequires:  libsolv-tools
 %requires_eq    libsolv-tools

--- a/zypp/sat/Pool.cc
+++ b/zypp/sat/Pool.cc
@@ -119,6 +119,27 @@ namespace zypp
     Pool::SolvableIterator Pool::solvablesEnd() const
     { return SolvableIterator(); }
 
+    sat::Queue Pool::whatMatchesDep( const SolvAttr &attr, const Capability &cap ) const
+    {
+      sat::Queue q;
+      pool_whatmatchesdep( get(), attr.id(), cap.id(), q, 0);
+      return q;
+    }
+
+    Queue Pool::whatMatchesSolvable( const SolvAttr &attr, const Solvable &solv ) const
+    {
+      sat::Queue q;
+      pool_whatmatchessolvable( get(), attr.id(), static_cast<Id>( solv.id() ), q, 0 );
+      return q;
+    }
+
+    Queue Pool::whatContainsDep( const SolvAttr &attr, const Capability &cap ) const
+    {
+      sat::Queue q;
+      pool_whatcontainsdep( get(), attr.id(), cap.id(), q, 0 );
+      return q;
+    }
+
     Repository Pool::reposInsert( const std::string & alias_r )
     {
       Repository ret( reposFind( alias_r ) );

--- a/zypp/sat/Pool.h
+++ b/zypp/sat/Pool.h
@@ -192,6 +192,10 @@ namespace zypp
         WhatProvides whatProvides( Capability cap_r ) const
         { return WhatProvides( cap_r ); }
 
+        Queue whatMatchesDep( const SolvAttr &attr, const Capability &cap ) const;
+        Queue whatMatchesSolvable ( const SolvAttr &attr, const Solvable &solv ) const;
+        Queue whatContainsDep ( const SolvAttr &attr, const Capability &cap ) const;
+
       public:
         /** \name Requested locales. */
         //@{

--- a/zypp/sat/Solvable.cc
+++ b/zypp/sat/Solvable.cc
@@ -528,6 +528,18 @@ namespace zypp
       return ret;
     }
 
+    std::pair<bool, CapabilitySet> Solvable::matchesSolvable(const SolvAttr &attr, const Solvable &solv) const
+    {
+      sat::Queue capQueue;
+      int res = solvable_matchessolvable( get(), attr.id(), static_cast<Id>( solv.id() ), capQueue, 0 );
+
+      CapabilitySet caps;
+      if ( capQueue.size() )
+        std::for_each( capQueue.begin(), capQueue.end(), [ &caps ]( auto cap ){ caps.insert( Capability(cap) );});
+
+      return std::make_pair( res == 1, std::move(caps) );
+    }
+
     ///////////////////////////////////////////////////////////////////
     namespace
     {

--- a/zypp/sat/Solvable.h
+++ b/zypp/sat/Solvable.h
@@ -223,6 +223,8 @@ namespace zypp
       CapabilitySet valuesOfNamespace( const std::string & namespace_r ) const;
       //@}
 
+      std::pair<bool, CapabilitySet> matchesSolvable ( const SolvAttr &attr, const sat::Solvable &solv ) const;
+
     public:
       /** \name Locale support. */
       //@{


### PR DESCRIPTION
Extend zypp::sat::Pool by wrapping the pool_whatmatchesdep
functionality from libsolv. This is required to implement a reverse dependency search
in zypper (fixes openSUSE/zypper#214)