### PR TITLE
SLE-5116 log patch status changes in history

### DIFF
--- a/tests/parser/HistoryLogReader_test.dat
+++ b/tests/parser/HistoryLogReader_test.dat
@@ -11,4 +11,4 @@
 discard\|one field
 discard|to fields but bad date
 2015-08-11 18:42:49|command|root@fibonacci|'/Local/ma/zypp/BUILD/zypper/src/zypper' 'in' '-f' 'xteddy'|
-2011-07-18 18:08:09|pstate|patch-name|2.6.37.6-0.5.1|noarch|repo-update|moderate|security|needed|satisfied
+2011-07-18 18:08:09|patch|patch-name|2.6.37.6-0.5.1|noarch|repo-update|moderate|security|needed|applied|

--- a/zypp/HistoryLog.cc
+++ b/zypp/HistoryLog.cc
@@ -332,7 +332,7 @@ namespace zypp
     }
   }
 
-  void HistoryLog::patchStateChange( const PoolItem & pi, const std::string &oldstate )
+  void HistoryLog::patchStateChange( const PoolItem & pi, ResStatus::ValidateValue oldstate )
   {
     if ( ! pi.isKind<Patch>() ) return;
     const Patch::constPtr p = asKind<Patch>(pi.resolvable());
@@ -346,8 +346,8 @@ namespace zypp
       << _sep << p->repoInfo().alias()					// 6 repo alias
       << _sep << p->severity()   					// 7 severity
       << _sep << p->category()  					// 8 category
-      << _sep << oldstate       					// 9 old state
-      << _sep << pi.patchStatusAsString()     				// 10 new state
+      << _sep << ResStatus::validateValueAsString( oldstate )		// 9 old state
+      << _sep << pi.status().validateValueAsString()			// 10 new state
       << _sep << str::escape(ZConfig::instance().userData(), _sep)	// 11 userdata
       << endl;
   }

--- a/zypp/HistoryLog.h
+++ b/zypp/HistoryLog.h
@@ -15,6 +15,7 @@
 #include <iosfwd>
 
 #include "zypp/Pathname.h"
+#include "zypp/ResStatus.h"
 
 namespace zypp
 {
@@ -128,7 +129,7 @@ namespace zypp
      *
      * \param oldstate info about the old state
      */
-    void patchStateChange ( const PoolItem & pi, const std::string &oldstate );
+    void patchStateChange( const PoolItem & pi, ResStatus::ValidateValue oldstate );
 
   };
   ///////////////////////////////////////////////////////////////////

--- a/zypp/HistoryLogData.cc
+++ b/zypp/HistoryLogData.cc
@@ -60,7 +60,7 @@ namespace zypp
       _table["ralias"]	= REPO_CHANGE_ALIAS_e;
       _table["rurl"]	= REPO_CHANGE_URL_e;
       _table["command"]	= STAMP_COMMAND_e;
-      _table["pstate"]	= PATCH_STATE_CHANGE_e;
+      _table["patch"]	= PATCH_STATE_CHANGE_e;
       _table["NONE"]	= _table["none"] = NONE_e;
     }
 
@@ -88,7 +88,7 @@ namespace zypp
       _table[REPO_CHANGE_ALIAS_e] = PairType( "ralias"	, "ralias " );
       _table[REPO_CHANGE_URL_e]   = PairType( "rurl"	, "rurl   " );
       _table[STAMP_COMMAND_e]     = PairType( "command"	, "command" );
-      _table[PATCH_STATE_CHANGE_e]= PairType( "pstate"  , "pstate " );
+      _table[PATCH_STATE_CHANGE_e]= PairType( "patch"   , "patch  " );
       _table[NONE_e]              = PairType( "NONE"	, "NONE   " );
     }
 

--- a/zypp/PoolItem.cc
+++ b/zypp/PoolItem.cc
@@ -100,17 +100,6 @@ namespace zypp
 	return isBroken() && status().isLocked();
       }
 
-      std::string patchStatusAsString() const
-      {
-        if ( isUndetermined() ) return "undetermined";
-        if ( isRelevant() )     return "relevant";
-        if ( isSatisfied() )    return "satisfied";
-        if ( isBroken() )       return "broken";
-        if ( isNeeded() )       return "needed";
-        if ( isUnwanted() )     return "unwanted";
-        return "none";
-      }
-
     private:
       mutable ResStatus     _status;
       ResObject::constPtr   _resolvable;
@@ -222,7 +211,6 @@ namespace zypp
   bool PoolItem::isBroken() const			{ return _pimpl->isBroken(); }
   bool PoolItem::isNeeded() const			{ return _pimpl->isNeeded(); }
   bool PoolItem::isUnwanted() const			{ return _pimpl->isUnwanted(); }
-  std::string PoolItem::patchStatusAsString() const     { return _pimpl->patchStatusAsString(); }
 
   void PoolItem::saveState() const			{ _pimpl->saveState(); }
   void PoolItem::restoreState() const			{ _pimpl->restoreState(); }

--- a/zypp/PoolItem.h
+++ b/zypp/PoolItem.h
@@ -77,6 +77,7 @@ namespace zypp
 
       /** Reset status. */
       ResStatus & statusReset() const;
+      //@}
 
 
       /** \name Status validation.
@@ -104,12 +105,8 @@ namespace zypp
 
       /** Broken (needed) but locked patches. */
       bool isUnwanted() const;
-
-      std::string patchStatusAsString () const;
-
       //@}
 
-      //@}
     public:
       /** Return the \ref ResPool the item belongs to. */
       ResPool pool() const;

--- a/zypp/ResPool.cc
+++ b/zypp/ResPool.cc
@@ -26,6 +26,10 @@ namespace zypp
 { /////////////////////////////////////////////////////////////////
 
   ///////////////////////////////////////////////////////////////////
+  // class ResPool
+  ///////////////////////////////////////////////////////////////////
+
+  ///////////////////////////////////////////////////////////////////
   //
   //	METHOD NAME : ResPool::instance
   //	METHOD TYPE : ResPool
@@ -66,10 +70,11 @@ namespace zypp
   ResPool::size_type ResPool::size() const
   { return _pimpl->size(); }
 
-
   PoolItem ResPool::find( const sat::Solvable & slv_r ) const
   { return _pimpl->find( slv_r ); }
 
+  ResPool::EstablishedStates ResPool::establishedStates() const
+  { return _pimpl->establishedStates(); }
 
   ResPool::size_type ResPool::knownRepositoriesSize() const
   { return _pimpl->knownRepositoriesSize(); }

--- a/zypp/ResStatus.cc
+++ b/zypp/ResStatus.cc
@@ -62,6 +62,37 @@ namespace zypp
     }
   }
 
+  namespace
+  {
+    // NOTE: Strings defined here are written to the history file
+    // and used by zypper. Do not change them!
+    static const char* strBROKEN = "needed";
+    static const char* strSATISFIED = "applied";
+    static const char* strNONRELEVANT = "not-needed";
+    static const char* strUNDETERMINED = "undetermined";
+  }
+
+  std::string ResStatus::validateValueAsString( ValidateValue val_r )
+  {
+    const char* ret = strUNDETERMINED;
+    switch ( val_r )
+    {
+      case BROKEN:	ret = strBROKEN; break;
+      case SATISFIED:	ret = strSATISFIED; break;
+      case NONRELEVANT:	ret = strNONRELEVANT; break;
+      case UNDETERMINED:break;// to avoid default:
+    }
+    return ret;
+  }
+
+  ResStatus::ValidateValue ResStatus::stringToValidateValue( const std::string & str_r )
+  {
+    ValidateValue ret = UNDETERMINED;
+    if      ( str_r == strBROKEN )      ret = BROKEN;
+    else if ( str_r == strSATISFIED )   ret = SATISFIED;
+    else if ( str_r == strNONRELEVANT ) ret = NONRELEVANT;
+    return ret;
+  }
 
   /******************************************************************
   **

--- a/zypp/ResStatus.h
+++ b/zypp/ResStatus.h
@@ -225,6 +225,15 @@ namespace zypp
     bool isNonRelevant() const
     { return fieldValueIs<ValidateField>( NONRELEVANT ); }
 
+    std::string validateValueAsString() const
+    { return validateValueAsString( validate() ); }
+
+    /** ValidateValue to string used in the history file. */
+    static std::string validateValueAsString( ValidateValue val_r );
+
+    /** ValidateValue from string used in the history file. */
+    static ValidateValue stringToValidateValue( const std::string & str_r );
+
   public:
     // These two are IMMUTABLE!
 

--- a/zypp/pool/PoolImpl.cc
+++ b/zypp/pool/PoolImpl.cc
@@ -20,6 +20,12 @@ using std::endl;
 namespace zypp
 { /////////////////////////////////////////////////////////////////
 
+  ResPool::EstablishedStates::~EstablishedStates()
+  {}
+
+  ResPool::EstablishedStates::ChangedPseudoInstalled ResPool::EstablishedStates::changedPseudoInstalled() const
+  { return _pimpl->changedPseudoInstalled(); }
+
   ///////////////////////////////////////////////////////////////////
   namespace pool
   { /////////////////////////////////////////////////////////////////

--- a/zypp/sat/Transaction.h
+++ b/zypp/sat/Transaction.h
@@ -165,6 +165,8 @@ namespace zypp
 	/** Pointer behind the last action step in transaction. */
 	action_iterator actionEnd() const;
 
+	/** Iterate the [filtered] transaction steps. */
+	Iterable<action_iterator> action( StepStages filter_r = StepStages() ) const;
 	//@}
 
       public:
@@ -391,6 +393,9 @@ namespace zypp
 	++cnt;
       return cnt;
     }
+
+    inline Iterable<Transaction::action_iterator> Transaction::action( StepStages filter_r ) const
+    { return makeIterable( actionBegin( filter_r ), actionEnd() ); }
 
      /////////////////////////////////////////////////////////////////
   } // namespace sat

--- a/zypp/solver/detail/SATResolver.cc
+++ b/zypp/solver/detail/SATResolver.cc
@@ -441,7 +441,7 @@ SATResolver::solving(const CapabilitySet & requires_caps,
 	  {
 	    if ( id < 0 )
 	      continue;
-	    sat::Solvable slv { id };
+	    sat::Solvable slv { (sat::detail::SolvableIdType)id };
 	    // get product buddies (they carry the weakremover)...
 	    static const Capability productCap { "product()" };
 	    if ( slv && slv.provides().matches( productCap ) )
@@ -484,7 +484,7 @@ SATResolver::solving(const CapabilitySet & requires_caps,
       if ( p < 0 )
 	continue;
 
-      sat::Solvable slv { p };
+      sat::Solvable slv { (sat::detail::SolvableIdType)p };
       if ( ! slv || slv.isSystem() )
 	continue;
 
@@ -895,7 +895,7 @@ void SATResolver::doUpdate()
       if ( p < 0 )
 	continue;
 
-      sat::Solvable solv { p };
+      sat::Solvable solv { (sat::detail::SolvableIdType)p };
       if ( ! solv || solv.isSystem() )
 	continue;
 


### PR DESCRIPTION
[SLE-5116](https://jira.suse.com/browse/SLE-5116)
Basically ResPool stores the computed patch status whenever the pool content changes (repo add/remove). Upon commit patches were the status is changed by the commit are remembered in the history.
Adapted the history type for patch status changes a bit.

Ready for review, just the last commit (https://github.com/openSUSE/libzypp/commit/932874f4ead400f5e335822a1d1978a25b6799a3) will need to be tuned in case the commit is aborted. In this case some patches may not have completed their status change. Need to figure out which and omit them in the history.