### PR TITLE
RepoVariables: Add safe guard in case the caller does not own a zypp …

### DIFF
--- a/zypp/repo/RepoVariables.cc
+++ b/zypp/repo/RepoVariables.cc
@@ -400,6 +400,11 @@ namespace zypp
       private:
 	const std::string * _lookup( const std::string & name_r )
 	{
+	  // Safe guard in case the caller does not own a zypp instance. In this case
+	  // getZYpp()->getTarget() in checkOverride would create a zypp instance which
+	  // would clear the variables parsed so far.
+	  auto guard { getZYpp() };
+
 	  if ( empty() )	// at init / after reset
 	  {
 	    // load user definitions from vars.d


### PR DESCRIPTION
…instance

This exlains the issue of lost repo variables I experienced when using no ResPool at all in `zypp-NameReqPrv.` Zypper/YAST/etc. are not affected as they create and own a zypp instance. (yes, someday we sill get rid of our static instances. But just a hotifx today.)