### PR TITLE
Fix bsc#1171224: Older kernel-devel packages are not properly purged.

### DIFF
--- a/tests/zypp/PurgeKernels_test.cc
+++ b/tests/zypp/PurgeKernels_test.cc
@@ -45,6 +45,12 @@ namespace  {
           { "kernel-default-devel-debuginfo-1-4.x86_64", false },
           { "kernel-devel-1-4.noarch", false },
           { "kernel-syms-1-4.x86_64", false },
+          // left over devel packages that need to go away too
+          { "kernel-devel-1-1.2.noarch", false },
+          { "kernel-source-1-1.2.noarch", false },
+          { "kernel-default-devel-1-3.2.x86_64", false },
+          { "kernel-devel-1-3.2.noarch", false },
+          { "kernel-source-1-3.2.noarch", false },
         }
       },
       //test that keeps only the running kernel
@@ -78,6 +84,12 @@ namespace  {
           { "kernel-devel-1-5.noarch", false },
           { "kernel-syms-1-5.x86_64", false },
           { "dummy-kmp-default-1-0.x86_64", false },
+          // left over devel packages that need to go away too
+          { "kernel-devel-1-1.2.noarch", false },
+          { "kernel-source-1-1.2.noarch", false },
+          { "kernel-default-devel-1-3.2.x86_64", false },
+          { "kernel-devel-1-3.2.noarch", false },
+          { "kernel-source-1-3.2.noarch", false },
         }
       },
       TestSample {
@@ -99,6 +111,12 @@ namespace  {
           { "kernel-devel-1-5.noarch", false },
           { "kernel-syms-1-5.x86_64", false },
           { "dummy-kmp-default-1-0.x86_64", false },
+          // left over devel packages that need to go away too
+          { "kernel-devel-1-1.2.noarch", false },
+          { "kernel-source-1-1.2.noarch", false },
+          { "kernel-default-devel-1-3.2.x86_64", false },
+          { "kernel-devel-1-3.2.noarch", false },
+          { "kernel-source-1-3.2.noarch", false },
         }
       },
       TestSample {

--- a/tests/zypp/data/PurgeKernels/simple/solver-system.xml
+++ b/tests/zypp/data/PurgeKernels/simple/solver-system.xml
@@ -144,6 +144,43 @@
 </package>
 
 <package>
+        <name>kernel-devel</name>
+        <vendor>openSUSE</vendor>
+        <history>
+        <update>
+                <arch>noarch</arch>
+                <version>1</version><release>1.2</release>
+        </update>
+        </history>
+        <provides>
+                <dep name='multiversion(kernel)' />
+                <dep name='kernel-devel' op='==' version='1' release='1.2' />
+        </provides>
+        <requires>
+                <dep name='kernel-macros' />
+        </requires>
+</package>
+
+
+<package>
+        <name>kernel-source</name>
+        <vendor>openSUSE</vendor>
+        <history>
+        <update>
+                <arch>noarch</arch>
+                <version>1</version><release>1.2</release>
+        </update>
+        </history>
+        <provides>
+                <dep name='kernel-source' op='==' version='1' release='1.2' />
+        </provides>
+        <requires>
+                <dep name='kernel-devel' op='==' version='1' release='1.2' />
+        </requires>
+</package>
+
+
+<package>
 	<name>kernel-syms</name>
 	<vendor>openSUSE</vendor>
 	<buildtime>1570603549</buildtime>
@@ -316,6 +353,64 @@
 		<dep name='packageand(kernel-default:kernel-devel)' />
 	</supplements>
 </package>
+
+<package>
+        <name>kernel-default-devel</name>
+        <vendor>openSUSE</vendor>
+        <history>
+        <update>
+                <arch>x86_64</arch>
+                <version>1</version><release>3.2</release>
+        </update>
+        </history>
+        <provides>
+                <dep name='multiversion(kernel)' />
+                <dep name='kernel-default-devel' op='==' version='1' release='3.2' />
+        </provides>
+        <requires>
+                <dep name='kernel-devel' op='==' version='1' release='3.2' />
+        </requires>
+        <supplements>
+                <dep name='packageand(kernel-default:kernel-devel)' />
+        </supplements>
+</package>
+
+<package>
+        <name>kernel-devel</name>
+        <vendor>openSUSE</vendor>
+        <history>
+        <update>
+                <arch>noarch</arch>
+                <version>1</version><release>3.2</release>
+        </update>
+        </history>
+        <provides>
+                <dep name='multiversion(kernel)' />
+                <dep name='kernel-devel' op='==' version='1' release='3.2' />
+        </provides>
+        <requires>
+                <dep name='kernel-macros' />
+        </requires>
+</package>
+
+<package>
+        <name>kernel-source</name>
+        <vendor>openSUSE</vendor>
+        <history>
+        <update>
+                <arch>noarch</arch>
+                <version>1</version><release>3.2</release>
+        </update>
+        </history>
+        <provides>
+                <dep name='kernel-source' op='==' version='1' release='3.2' />
+        </provides>
+        <requires>
+                <dep name='kernel-devel' op='==' version='1' release='3.2' />
+        </requires>
+</package>
+
+
 
 <package>
 	<name>kernel-default-devel-debuginfo</name>

--- a/zypp/PurgeKernels.cc
+++ b/zypp/PurgeKernels.cc
@@ -227,10 +227,11 @@ namespace zypp {
     q.setMatchExact();
 
     for ( auto installedSrcPck : q ) {
-
+      // For now print a message that we are removing a source package that has no corresponding kernel installed.
+      // This was changed due to bug #1171224 because orphaned kernel-source/devel packages were kept due to package
+      // rebuilds that did not obsolete the previously installed release, e.g. kernel-source-1-1.1 vs kernel-source-1-1.2
       if ( validEditions.find( installedSrcPck.edition() ) == validEditions.end() ) {
-        MIL << "Skipping source package " << installedSrcPck <<  " no corresponding kernel with the same version was installed." << std::endl;
-        continue;
+        MIL << "Trying to remove source package " << installedSrcPck <<  " no corresponding kernel with the same version was installed." << std::endl;
       }
 
       //if no package providing kernel-flavour = VERSION is installed , we are free to remove the package


### PR DESCRIPTION
This patch changes current behaviour to keep devel/source packages around if no corresponding kernel for them were removed in the first step to avoid building up a list of installed but orphaned devel/source packages. This happens due to package rebuilds that do not obsolete the previous release: kernel-source-1-1.1 vs kernel-source-1-1.2