### PR TITLE
Enable basic zchunk download if libsolv supports it

### DIFF
--- a/tests/repo/yum/YUMDownloader_test.cc
+++ b/tests/repo/yum/YUMDownloader_test.cc
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(yum_download)
 
   yum.download(media, localdir);
 
-#if ENABLE_ZCHUNK_COMPRESSION && defined(LIBSOLVEXT_FEATURE_ZCHUNK_COMPRESSION)
+#if defined(LIBSOLVEXT_FEATURE_ZCHUNK_COMPRESSION)
     const bool zchunk = true;
 #else
     const bool zchunk = false;

--- a/zypp/repo/yum/Downloader.cc
+++ b/zypp/repo/yum/Downloader.cc
@@ -105,7 +105,7 @@ namespace yum
 	return true;	// skip sqlitedb
 
       bool zchk { str::endsWith( typestr_r, "_zck" ) };
-#if ENABLE_ZCHUNK_COMPRESSION && defined(LIBSOLVEXT_FEATURE_ZCHUNK_COMPRESSION)
+#if defined(LIBSOLVEXT_FEATURE_ZCHUNK_COMPRESSION)
       const std::string & basetype { zchk ? typestr_r.substr( 0, typestr_r.size()-4 ) : typestr_r };
 #else
       if ( zchk )


### PR DESCRIPTION
This patch enables basic zchunk download support if the corresponding libsolv feature is enabled.
Basic support does not include optimized zchunk download but instead always downloads the full file.