### PR TITLE
Write rpm -vv output into the log

### DIFF
--- a/doc/autoinclude/EnvironmentVariables.doc
+++ b/doc/autoinclude/EnvironmentVariables.doc
@@ -32,6 +32,8 @@
 \li \c ZYPP_MEDIA_CURL_DEBUG=<1|2> Log http headers, if \c 2 also log server responses.
 \li \c ZYPP_MEDIA_CURL_IPRESOLVE=<4|6> Tell curl to resolve names to IPv4/IPv6 addresses only.
 
+\li \c ZYPP_RPM_DEBUG=1 Log verbose output from all rpm commands.
+
 \subsection zypp-envars-mediabackend Selecting the mediabackend to use.
 
 \li \c ZYPP_MULTICURL=0 Turn off multicurl (metalink and zsync) and fall back to plain libcurl.

--- a/zypp/ZYppCallbacks.h
+++ b/zypp/ZYppCallbacks.h
@@ -556,6 +556,14 @@ namespace zypp
 	  , const std::string &/*reason*/
 	  , RpmLevel /*level*/
         ) {}
+
+        /** "rpmout/installpkg": Additional rpm output (sent immediately).
+	 * Data:
+	 * solvable : satSolvable processed
+	 * line     : std::reference_wrapper<const std::string>
+	 * lineno   : unsigned
+	 */
+	static const UserData::ContentType contentRpmout;
       };
 
       // progress for removing a resolvable
@@ -592,6 +600,11 @@ namespace zypp
           , Error /*error*/
 	  , const std::string &/*reason*/
         ) {}
+
+        /** "rpmout/removepkg": Additional rpm output (sent immediately).
+	 * For data \see \ref InstallResolvableReport::contentRpmout
+	 */
+        static const UserData::ContentType contentRpmout;
       };
 
       // progress for rebuilding the database

--- a/zypp/target/TargetCallbackReceiver.cc
+++ b/zypp/target/TargetCallbackReceiver.cc
@@ -42,6 +42,13 @@ namespace zypp
 	{
 	}
 
+	void RpmInstallPackageReceiver::report( const UserData & userData_r )
+	{
+	  if ( ! userData_r.haskey( "solvable" ) )
+	    userData_r.set( "solvable", _resolvable->satSolvable() );
+	  _report->report( userData_r );
+	}
+
         /** Start the operation */
         void RpmInstallPackageReceiver::start( const Pathname & name )
 	{
@@ -129,6 +136,13 @@ namespace zypp
 	}
 
         /** Start the operation */
+	void RpmRemovePackageReceiver::report( const UserData & userData_r )
+	{
+	  if ( ! userData_r.haskey( "solvable" ) )
+	    userData_r.set( "solvable", _resolvable->satSolvable() );
+	  _report->report( userData_r );
+	}
+
         void RpmRemovePackageReceiver::start( const std::string & name )
 	{
 	    _report->start( _resolvable );

--- a/zypp/target/TargetCallbackReceiver.h
+++ b/zypp/target/TargetCallbackReceiver.h
@@ -40,6 +40,9 @@ namespace zypp
 
 	virtual void reportend();
 
+	/** Forwards generic reports. */
+	void report( const UserData & userData_r ) override;
+
         /** Start the operation */
         virtual void start( const Pathname & name );
 
@@ -84,6 +87,9 @@ namespace zypp
 	virtual void reportend();
 
         /** Start the operation */
+	/** Forwards generic reports. */
+	void report( const UserData & userData_r ) override;
+
         virtual void start( const std::string & name );
 
         /**

--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -70,6 +70,17 @@ namespace zypp
   {
     bool IGotIt(); // in readonly-mode
   }
+  namespace env
+  {
+    inline bool ZYPP_RPM_DEBUG()
+    {
+      static bool val = [](){
+	const char * env = getenv("ZYPP_RPM_DEBUG");
+	return( env && str::strToBool( env, true ) );
+      }();
+      return val;
+    }
+  } // namespace env
 namespace target
 {
 namespace rpm
@@ -1354,7 +1365,8 @@ RpmDb::run_rpm (const RpmArgVec& opts,
   args.push_back(_root.asString().c_str());
   args.push_back("--dbpath");
   args.push_back(_dbPath.asString().c_str());
-
+  if ( env::ZYPP_RPM_DEBUG() )
+    args.push_back("-vv");
   const char* argv[args.size() + opts.size() + 1];
 
   const char** p = argv;
@@ -1427,7 +1439,11 @@ bool RpmDb::systemReadLine( std::string & line )
 	  }
 
 	  if ( ! ::ferror( inputfile ) || ::feof( inputfile ) )
+	  {
+	    if ( env::ZYPP_RPM_DEBUG() )
+	      L_DBG("RPM_DEBUG") << line << endl;
 	    return true; // complete line
+	  }
 	}
 	clearerr( inputfile );
       }


### PR DESCRIPTION
`ZYPP_RPM_DEBUG` environment variable to log verbose rpm output. Additionally offer output lines immediately via custom callback. 