### PR TITLE
Fix bsc 1174011

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,7 +79,7 @@ KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
+NamespaceIndentation: All
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: true

--- a/zypp/media/MediaUserAuth.cc
+++ b/zypp/media/MediaUserAuth.cc
@@ -90,7 +90,7 @@ std::ostream & CurlAuthData::dumpOn( std::ostream & str ) const
   return str;
 }
 
-long CurlAuthData::auth_type_str2long(std::string & auth_type_str)
+long CurlAuthData::auth_type_str2long( const std::string & auth_type_str )
 {
   curl_version_info_data *curl_info = curl_version_info(CURLVERSION_NOW);
 

--- a/zypp/media/MediaUserAuth.h
+++ b/zypp/media/MediaUserAuth.h
@@ -135,7 +135,7 @@ public:
    * \throws MediaException if an invalid authentication type name is
    *         encountered.
    */
-  static long auth_type_str2long(std::string & auth_type_str);
+  static long auth_type_str2long(const std::string &auth_type_str);
 
   /**
    * Converts a long of ORed CURLAUTH_* identifiers into a string of comma


### PR DESCRIPTION
This patch changes the default behaviour of libzypp handling authentication. 
Currently we would first try without authentication and wait for a server response with auth failed. 
The new behaviour proactively sends credentials if the URL specifes ?auth=basic and a username in the URL.
