### PR TITLE
Fix template with C linkage build error

### DIFF
--- a/zypp/parser/xml/libxmlfwd.h
+++ b/zypp/parser/xml/libxmlfwd.h
@@ -12,11 +12,8 @@
 #ifndef ZYPP_PARSER_XML_LIBXMLFWD_H
 #define ZYPP_PARSER_XML_LIBXMLFWD_H
 
-extern "C"
-{
 #include <libxml/xmlreader.h>
 #include <libxml/xmlerror.h>
-}
 
 #include <iosfwd>
 


### PR DESCRIPTION
Trying to build libzypp on Arch fails with:

```
In file included from /usr/include/c++/10.1.0/bits/unique_ptr.h:37,
                 from /usr/include/c++/10.1.0/memory:83,
                 from /usr/include/unicode/localpointer.h:45,
                 from /usr/include/unicode/uenum.h:23,
                 from /usr/include/unicode/ucnv.h:53,
                 from /usr/include/libxml2/libxml/encoding.h:31,
                 from /usr/include/libxml2/libxml/parser.h:810,
                 from /usr/include/libxml2/libxml/globals.h:18,
                 from /usr/include/libxml2/libxml/threads.h:35,
                 from /usr/include/libxml2/libxml/xmlmemory.h:218,
                 from /usr/include/libxml2/libxml/tree.h:1307,
                 from /usr/include/libxml2/libxml/xmlreader.h:14,
                 from /home/daan/projects/libzypp/src/libzypp-17.24.1/zypp/parser/xml/libxmlfwd.h:17,
                 from /home/daan/projects/libzypp/src/libzypp-17.24.1/zypp/parser/xml/libxmlfwd.cc:15:
/usr/include/c++/10.1.0/tuple:1342:3: error: template with C linkage
 1342 |   template <typename _Tp, typename... _Types>
      |   ^~~~~~~~
In file included from /home/daan/projects/libzypp/src/libzypp-17.24.1/zypp/parser/xml/libxmlfwd.cc:15:
/home/daan/projects/libzypp/src/libzypp-17.24.1/zypp/parser/xml/libxmlfwd.h:15:1: note: ‘extern "C"’ linkage started here
   15 | extern "C"
      | ^~~~~~~~~~
```

This change fixes the build. I searched the repo and the same change has been done in other places a long time ago.