### PR TITLE
Improve Italian traslation of the "breaking dependencies" message.

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -4439,7 +4439,7 @@ msgstr "Impossibile creare sat-pool."
 #: zypp/solver/detail/ProblemSolutionIgnore.cc:42
 #, c-format, boost-format
 msgid "break %s by ignoring some of its dependencies"
-msgstr "interrompi %s ignorando alcune delle sue dipendenze"
+msgstr "installa comunque %s ignorando alcune delle sue dipendenze"
 
 #: zypp/solver/detail/ProblemSolutionIgnore.cc:48
 msgid "generally ignore of some dependencies"


### PR DESCRIPTION
In Italian, "to break" can indeed be translated with "interrompere". But
that depends on the context, and this one here is really not the case.

Adopt a sentence which, albeit not a literal translation, sounds a lot
more natural and easier to understand.

FTR, this was reported (by me) as a bug here:
 https://bugzilla.opensuse.org/show_bug.cgi?id=1173529