### PR TITLE
Support buildnr with commit hash in purge-kernels (fixes bsc#1175342)

### DIFF
--- a/tests/zypp/PurgeKernels_test.cc
+++ b/tests/zypp/PurgeKernels_test.cc
@@ -230,7 +230,28 @@ namespace  {
         {
           { "kernel-source-1-1.noarch", false },
         }
-      }
+      },
+      TestSample {
+        TESTS_SRC_DIR"/zypp/data/PurgeKernels/fancybuildnr",
+        "5.8.1-3.g846658e-default",
+        Arch("x86_64"),
+        "latest,latest-1,running",
+        {
+          { "kernel-default-5.7.8-1.1.g8f507a0.x86_64", false },
+          { "kernel-default-5.7.9-1.1.ga010166.x86_64", false },
+          { "kernel-default-5.7.10-1.1.g6a1b5cf.x86_64", false },
+          { "kernel-default-5.7.10-3.1.gd1148b9.x86_64", false },
+          { "kernel-default-5.7.11-1.1.g5015994.x86_64", false },
+          { "kernel-default-5.7.12-1.1.g9c98feb.x86_64", false },
+          { "kernel-default-5.8.0-1.1.gd3bf2d6.x86_64", false },
+          { "kernel-default-5.8.0-2.1.g9bc0044.x86_64", false },
+          { "kernel-default-5.8.0-3.1.gd4e7682.x86_64", false },
+          { "kernel-default-5.8.1-1.1.ge6658c9.x86_64", false },
+          // those are running, latest and latest-1 , they should stay
+          //{ "kernel-default-5.8.1-2.1.g553537d.x86_64", false },
+          //{ "kernel-default-5.8.1-3.1.g846658e.x86_64", false },
+          }
+      },
     };
   }
 }

--- a/tests/zypp/data/PurgeKernels/fancybuildnr/solver-system.xml
+++ b/tests/zypp/data/PurgeKernels/fancybuildnr/solver-system.xml
@@ -1,0 +1,264 @@
+<channel><subchannel>
+<package>
+	<name>glibc</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	    <update>
+		    <arch>x86_64</arch>
+		    <version>1</version><release>1</release>
+	    </update>
+	</history>
+	<provides>
+		<dep name='glibc' op='==' version='1' release='1' />
+	</provides>
+</package>
+
+<package>
+	<name>kernel-firmware</name>
+    <provides>
+        <dep name='kernel-firmware' op='==' version='20190312' release='lp151.2.3.1' />
+    </provides>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.8</version><release>1.1.g8f507a0</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.8-1.1.g8f507a0' />
+		<dep name='kernel' op='==' version='5.7.8' release='1.1.g8f507a0' />
+		<dep name='kernel-uname-r' op='==' version='5.7.8-1.g8f507a0' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.9</version><release>1.1.ga010166</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.9-1.1.ga010166' />
+		<dep name='kernel' op='==' version='5.7.9' release='1.1.ga010166' />
+		<dep name='kernel-uname-r' op='==' version='5.7.9-1.ga010166' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.10</version><release>1.1.g6a1b5cf</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.10-1.1.g6a1b5cf' />
+		<dep name='kernel' op='==' version='5.7.10' release='1.1.g6a1b5cf' />
+		<dep name='kernel-uname-r' op='==' version='5.7.10-1.g6a1b5cf' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.10</version><release>3.1.gd1148b9</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.10-3.1.gd1148b9' />
+		<dep name='kernel' op='==' version='5.7.10' release='3.1.gd1148b9' />
+		<dep name='kernel-uname-r' op='==' version='5.7.10-3.gd1148b9' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.11</version><release>1.1.g5015994</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.11-1.1.g5015994' />
+		<dep name='kernel' op='==' version='5.7.11' release='1.1.g5015994' />
+		<dep name='kernel-uname-r' op='==' version='5.7.11-1.g5015994' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+	<name>kernel-default</name>
+	<vendor>openSUSE</vendor>
+	<history>
+	<update>
+		<arch>x86_64</arch>
+		<version>5.7.12</version><release>1.1.g9c98feb</release>
+	</update>
+	</history>
+	<provides>
+		<dep name='multiversion(kernel)' />
+		<dep name='kernel-default-5.7.12-1.1.g9c98feb' />
+		<dep name='kernel' op='==' version='5.7.12' release='1.1.g9c98feb' />
+		<dep name='kernel-uname-r' op='==' version='5.7.12-1.g9c98feb' release='default' />
+	</provides>
+	<recommends>
+		<dep name='kernel-firmware' />
+	</recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.0</version><release>1.1.gd3bf2d6</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.0-1.1.gd3bf2d6' />
+        <dep name='kernel' op='==' version='5.8.0' release='1.1.gd3bf2d6' />
+        <dep name='kernel-uname-r' op='==' version='5.8.0-1.gd3bf2d6' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.0</version><release>2.1.g9bc0044</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.0-2.1.g9bc0044' />
+        <dep name='kernel' op='==' version='5.8.0' release='2.1.g9bc0044' />
+        <dep name='kernel-uname-r' op='==' version='5.8.0-2.g9bc0044' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.0</version><release>3.1.gd4e7682</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.0-3.1.gd4e7682' />
+        <dep name='kernel' op='==' version='5.8.0' release='3.1.gd4e7682' />
+        <dep name='kernel-uname-r' op='==' version='5.8.0-3.gd4e7682' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.1</version><release>1.1.ge6658c9</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.1-1.1.ge6658c9' />
+        <dep name='kernel' op='==' version='5.8.1' release='1.1.ge6658c9' />
+        <dep name='kernel-uname-r' op='==' version='5.8.1-1.ge6658c9' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.1</version><release>2.1.g553537d</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.1-2.1.g553537d' />
+        <dep name='kernel' op='==' version='5.8.1' release='2.1.g553537d' />
+        <dep name='kernel-uname-r' op='==' version='5.8.1-2.g553537d' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+<package>
+    <name>kernel-default</name>
+    <vendor>openSUSE</vendor>
+    <history>
+    <update>
+        <arch>x86_64</arch>
+        <version>5.8.1</version><release>3.1.g846658e</release>
+    </update>
+    </history>
+    <provides>
+        <dep name='multiversion(kernel)' />
+        <dep name='kernel-default-5.8.1-3.1.g846658e' />
+        <dep name='kernel' op='==' version='5.8.1' release='3.1.g846658e' />
+        <dep name='kernel-uname-r' op='==' version='5.8.1-3.g846658e' release='default' />
+    </provides>
+    <recommends>
+        <dep name='kernel-firmware' />
+    </recommends>
+</package>
+
+</subchannel>
+</channel>

--- a/tests/zypp/data/PurgeKernels/fancybuildnr/solver-test.xml
+++ b/tests/zypp/data/PurgeKernels/fancybuildnr/solver-test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<test>
+<setup arch="x86_64">
+	<system file="solver-system.xml"/>
+	<locale name="en_US" />
+	<locale name="de" />
+</setup>
+</test>

--- a/zypp/PurgeKernels.cc
+++ b/zypp/PurgeKernels.cc
@@ -236,12 +236,21 @@ namespace zypp {
    */
   bool PurgeKernels::Impl::versionMatch( const Edition &a, const Edition &b )
   {
+    if ( a == b )
+      return true;
+
     // the build counter should not be considered here, so if there is one we cut it off
-    const auto dotOffset = b.release().find_last_of(".");
-    if ( dotOffset != std::string::npos ) {
-      return a == zypp::Edition( b.version(), b.release().substr( 0, dotOffset ), b.epoch() );
+    const str::regex buildCntRegex( "\\.[0-9]+($|\\.g[0-9a-f]{7}$)", str::regex::match_extended );
+
+    std::string versionStr = b.asString();
+    str::smatch matches;
+    if ( buildCntRegex.matches( versionStr.data(), matches ) ) {
+      if ( matches.size() >= 2 ) {
+        versionStr.replace( matches.begin(0), (matches.end(0) - matches.begin(0))+1, matches[1] );
+        return a == Edition(versionStr);
+      }
     }
-    return a == b;
+    return false;
   }
 
   /*!


### PR DESCRIPTION
This adds special behaviour for when a kernel version has the rebuild
counter before the kernel commit hash:

`kernel-default-<version>-<release>.<counter>.<hash>`
e.g.:
`kernel-default-5.8.0-3.1.gd4e7682`