### PR TITLE
Fix bsc#1176902: When kernel-rt has been installed, the purge-kernels service fails during boot

### DIFF
--- a/tests/zypp/PurgeKernels_test.cc
+++ b/tests/zypp/PurgeKernels_test.cc
@@ -276,6 +276,42 @@ namespace  {
           //{ "kernel-default-base-5.7.8-3.1.1.1.x86_64", false },
           }
       },
+      TestSample {
+        TESTS_SRC_DIR"/zypp/data/PurgeKernels/flavour",
+        "1-3-rt",
+        Arch("x86_64"),
+        "running",
+        {
+          { "kernel-rt-1-1.x86_64", false },
+          { "kernel-rt-devel-1-1.x86_64", false },
+          { "kernel-rt-devel-debuginfo-1-1.x86_64", false },
+          { "kernel-devel-rt-1-1.noarch", false },
+          { "kernel-syms-rt-1-1.x86_64", false },
+          { "kernel-source-rt-1-1.noarch", false },
+          { "kernel-rt-1-2.x86_64", false },
+          { "kernel-rt-devel-1-2.x86_64", false },
+          { "kernel-rt-devel-debuginfo-1-2.x86_64", false },
+          { "kernel-devel-rt-1-2.noarch", false },
+          { "kernel-syms-rt-1-2.x86_64", false },
+          { "kernel-rt-1-4.x86_64", false },
+          { "kernel-rt-devel-1-4.x86_64", false },
+          { "kernel-rt-devel-debuginfo-1-4.x86_64", false },
+          { "kernel-devel-rt-1-4.noarch", false },
+          { "kernel-syms-rt-1-4.x86_64", false },
+          { "kernel-rt-1-5.x86_64", false },
+          { "kernel-rt-devel-1-5.x86_64", false },
+          { "kernel-rt-devel-debuginfo-1-5.x86_64", false },
+          { "kernel-devel-rt-1-5.noarch", false },
+          { "kernel-syms-rt-1-5.x86_64", false },
+          // left over devel packages that need to go away too
+          { "kernel-devel-rt-1-1.2.noarch", false },
+          { "kernel-source-rt-1-1.2.noarch", false },
+          { "kernel-rt-devel-1-3.x86_64", false },
+          { "kernel-devel-rt-1-3.noarch", false },
+          { "kernel-rt-devel-1-3.x86_64", false },
+          { "kernel-rt-devel-debuginfo-1-3.x86_64", false },
+        }
+      },
     };
   }
 }

--- a/tests/zypp/data/PurgeKernels/flavour/@System.repo
+++ b/tests/zypp/data/PurgeKernels/flavour/@System.repo
@@ -1,0 +1,356 @@
+=Ver: 3.0
+=Pkg: glibc 1 1 x86_64
++Prv:
+glibc = 1-1
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-firmware <NULL> - noarch
++Prv:
+kernel-firmware = 20190312-lp151.2.3.1
+kernel-firmware = <NULL>
+-Prv:
+
+=Pkg: kernel-macros 1 0 noarch
++Prv:
+kernel-subpackage-macros
+kernel-macros = 1-0
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt 1 1 x86_64
++Prv:
+multiversion(kernel)
+kernel-rt-1-1
+kernel = 1-1
+kernel-uname-r = 1-1-rt
+kernel-rt = 1-1
+-Prv:
++Rec:
+kernel-firmware
+-Rec:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 1 x86_64
++Req:
+kernel-devel-rt = 1-1
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-1
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel-debuginfo 1 1 x86_64
++Prv:
+kernel-rt-devel-debuginfo = 1-1
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 1 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-1
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-source-rt 1 1 noarch
++Req:
+kernel-devel-rt = 1-1
+-Req:
++Prv:
+multiversion(kernel)
+kernel-source-rt = 1-1
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 1.2 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-1
+kernel-devel-rt = 1-1.2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-source-rt 1 1.2 noarch
++Req:
+kernel-devel-rt = 1-1.2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-source-rt = 1-1
+kernel-source-rt = 1-1.2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-syms-rt 1 1 x86_64
++Req:
+kernel-devel-rt = 1-1
+kernel-rt-devel = 1-1
+-Req:
++Prv:
+multiversion(kernel)
+kernel-syms-rt = 1-1
+-Prv:
+=Vnd: openSUSE
+
+=Tim: 1570603549
+=Pkg: kernel-rt 1 2 x86_64
++Prv:
+multiversion(kernel)
+kernel-rt-1-2
+kernel = 1-2
+kernel-uname-r = 1-2-rt
+kernel-rt = 1-2
+-Prv:
++Rec:
+kernel-firmware
+-Rec:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 2 x86_64
++Req:
+kernel-devel-rt = 1-2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-2
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel-debuginfo 1 2 x86_64
++Prv:
+kernel-rt-devel-debuginfo = 1-2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 2 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-syms-rt 1 2 x86_64
++Req:
+kernel-devel-rt = 1-2
+kernel-rt-devel = 1-2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-syms-rt = 1-2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt 1 3 x86_64
++Prv:
+multiversion(kernel)
+kernel-rt-1-3
+kernel = 1-3
+kernel-uname-r = 1-3-rt
+kernel-rt = 1-3
+-Prv:
++Rec:
+kernel-firmware
+-Rec:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 3 x86_64
++Req:
+kernel-devel-rt = 1-3
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-3
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 3.2 x86_64
++Req:
+kernel-devel-rt = 1-3.2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-3
+kernel-rt-devel = 1-3.2
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 3.2 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-3
+kernel-devel-rt = 1-3.2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-source-rt 1 3.2 noarch
++Req:
+kernel-devel-rt = 1-3.2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-source-rt = 1-3
+kernel-source-rt = 1-3.2
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel-debuginfo 1 3 x86_64
++Prv:
+kernel-rt-devel-debuginfo = 1-3
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 3 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-3
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-syms-rt 1 3 x86_64
++Req:
+kernel-devel-rt = 1-3
+kernel-rt-devel = 1-3
+-Req:
++Prv:
+multiversion(kernel)
+kernel-syms-rt = 1-3
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt 1 4 x86_64
++Prv:
+multiversion(kernel)
+kernel-rt-1-4
+kernel = 1-4
+kernel-uname-r = 1-4-rt
+kernel-rt = 1-4
+-Prv:
++Rec:
+kernel-firmware
+-Rec:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 4 x86_64
++Req:
+kernel-devel-rt = 1-4
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-4
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel-debuginfo 1 4 x86_64
++Prv:
+kernel-rt-devel-debuginfo = 1-4
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 4 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-4
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-syms-rt 1 4 x86_64
++Req:
+kernel-devel-rt = 1-4
+kernel-rt-devel = 1-4
+-Req:
++Prv:
+multiversion(kernel)
+kernel-syms-rt = 1-4
+-Prv:
+=Vnd: openSUSE
+=Tim: 1570603549
+
+=Pkg: kernel-rt 1 5 x86_64
++Prv:
+multiversion(kernel)
+kernel-rt-1-5
+kernel = 1-5
+kernel-uname-r = 1-5-rt
+ksym(foobar) = abdcfee
+kernel-rt = 1-5
+-Prv:
++Rec:
+kernel-firmware
+-Rec:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel 1 5 x86_64
++Req:
+kernel-devel-rt = 1-5
+-Req:
++Prv:
+multiversion(kernel)
+kernel-rt-devel = 1-5
+-Prv:
++Sup:
+kernel-rt & kernel-devel-rt
+-Sup:
+=Vnd: openSUSE
+
+=Pkg: kernel-rt-devel-debuginfo 1 5 x86_64
++Prv:
+kernel-rt-devel-debuginfo = 1-5
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-devel-rt 1 5 noarch
++Req:
+kernel-macros
+-Req:
++Prv:
+multiversion(kernel)
+kernel-devel-rt = 1-5
+-Prv:
+=Vnd: openSUSE
+
+=Pkg: kernel-syms-rt 1 5 x86_64
++Req:
+kernel-devel-rt = 1-5
+kernel-rt-devel = 1-5
+-Req:
++Prv:
+multiversion(kernel)
+kernel-syms-rt = 1-5
+-Prv:
+=Vnd: openSUSE
+=Tim: 1570603549

--- a/tests/zypp/data/PurgeKernels/flavour/zypp-control.yaml
+++ b/tests/zypp/data/PurgeKernels/flavour/zypp-control.yaml
@@ -1,0 +1,38 @@
+version: 1.0
+setup:
+  channels:
+    - alias: "@System"
+      url: []
+      path: ""
+      type: NONE
+      generated: 0
+      outdated: 0
+      priority: 99
+      file: "@System.repo"
+  arch: x86_64
+  locales:
+    - fate: ""
+      name: en_US
+    - fate: ""
+      name: de
+  autoinst:
+    []
+  modalias:
+    []
+  multiversion:
+    []
+  resolverFlags:
+    focus: Job
+    ignorealreadyrecommended: false
+    onlyRequires: false
+    forceResolve: false
+    cleandepsOnRemove: false
+    allowDowngrade: false
+    allowNameChange: false
+    allowArchChange: false
+    allowVendorChange: false
+    dupAllowDowngrade: false
+    dupAllowNameChange: false
+    dupAllowArchChange: false
+    dupAllowVendorChange: false
+trials: []

--- a/zypp/PurgeKernels.cc
+++ b/zypp/PurgeKernels.cc
@@ -545,6 +545,7 @@ namespace zypp {
 
       } else {
 
+        // if adapting the groups do not forget to explicitely handle the group when querying the matches
         const str::regex explicitelyHandled("kernel-syms(-.*)?|kernel(-.*)?-devel");
 
         MIL << "Not a kernel package, inspecting more closely " << std::endl;
@@ -562,11 +563,15 @@ namespace zypp {
           // getting no flavour for a kernel(-*)?-devel means we have the kernel-devel package otherwise the flavour specific one
           // ...yes this is horrible
           std::string flav;
-          if ( match.size() > 1 )  {
+
+          // first group match is a kernel-syms
+          if ( match.size() > 1 && match[1].size() )
+            flav = match[1].substr(1);
+          // second group match is a kernel-flavour-devel
+          else if ( match.size() > 2 &&  match[2].size() )
             flav = match[2].substr(1);
-          } else if ( installedKrnlPck.name() == "kernel-syms" ) {
+          else if ( installedKrnlPck.name() == "kernel-syms" )
             flav = "default";
-          }
 
           MIL << "Handling package explicitely due to name match."<< std::endl;
           addPackageToMap ( GroupInfo::RelatedBinaries, installedKrnlPck.name(), flav, installedKrnlPck );


### PR DESCRIPTION
Actually this would break with every flavour other than "default" 