### PR TITLE
RepoInfo: ignore legacy type= in a .repo file and let RepoManager pro…

### DIFF
--- a/zypp/parser/RepoFileReader.cc
+++ b/zypp/parser/RepoFileReader.cc
@@ -137,7 +137,7 @@ namespace zypp
           else if ( it->first == "path" )
             info.setPath( Pathname(it->second) );
           else if ( it->first == "type" )
-            info.setType(repo::RepoType(it->second));
+            ; // bsc#1177427 et.al.: type in a .repo file is legacy - ignore it and let RepoManager probe
           else if ( it->first == "autorefresh" )
             info.setAutorefresh( str::strToTrue( it->second ) );
           else if ( it->first == "mirrorlist" && !it->second.empty())


### PR DESCRIPTION
…be [bsc#1177427](http://bugzilla.opensuse.org/show_bug.cgi?id=1177427). Fixes openSUSE/zypper#357