### PR TITLE
Refresh when repourls change

### DIFF
--- a/tests/zypp/RepoStatus_test.cc
+++ b/tests/zypp/RepoStatus_test.cc
@@ -15,18 +15,42 @@ using namespace zypp::filesystem;
 
 BOOST_AUTO_TEST_CASE(repostatus_test)
 {
-  TmpFile tmpPath;
-  TmpFile tmpPath2;
-  RepoStatus status;
-  RepoStatus fstatus( tmpPath );
-  RepoStatus fstatus2( tmpPath2 );
-  BOOST_CHECK_EQUAL( status.empty(), true );
-  BOOST_CHECK_EQUAL( (status&&status).empty(), true );
+  RepoStatus e;
+  RepoStatus E { "", 42 };	// empty refers to the checksum only, not to the timestamp!
+  RepoStatus a { "aa", 0 };
+  RepoStatus b { "bb", 1 };
+  RepoStatus c { "cc", 2 };
 
-  BOOST_CHECK_EQUAL( fstatus.empty(), false );
-  BOOST_CHECK_EQUAL( (fstatus&&status).empty(), false );
+  BOOST_CHECK_EQUAL( e.empty(), true );
+  BOOST_CHECK_EQUAL( e.timestamp(), 0 );
+  BOOST_CHECK_EQUAL( (e && e).empty(), true );
 
-  BOOST_CHECK_EQUAL( (fstatus&&status), (status&&fstatus) );
-  BOOST_CHECK_EQUAL( (fstatus&&fstatus2), (fstatus2&&fstatus) );
+  BOOST_CHECK_EQUAL( E.empty(), true );
+  BOOST_CHECK_EQUAL( E.timestamp(), 42 );
+  RepoStatus r { E && e };
+  BOOST_CHECK_EQUAL( r.empty(), true );
+  BOOST_CHECK_EQUAL( r.timestamp(), 42 );
+  r = e && E;
+  BOOST_CHECK_EQUAL( r.empty(), true );
+  BOOST_CHECK_EQUAL( r.timestamp(), 42 );
+  r = E && E;
+  BOOST_CHECK_EQUAL( r.empty(), true );
+  BOOST_CHECK_EQUAL( r.timestamp(), 42 );
 
+
+  BOOST_CHECK_EQUAL( a.empty(), false );
+  BOOST_CHECK_EQUAL( a.timestamp(), 0 );
+
+  r = e && a;
+  BOOST_CHECK_EQUAL( r.empty(), false );
+  BOOST_CHECK_EQUAL( r.timestamp(), a.timestamp() );	// max timestamp
+
+  r = a && b;
+  BOOST_CHECK_EQUAL( r, (b && a) );
+  BOOST_CHECK_EQUAL( r.timestamp(), b.timestamp() );	// max timestamp
+
+  r = a && b && c;
+  BOOST_CHECK_EQUAL( r, (a && b) && c );
+  BOOST_CHECK_EQUAL( r, a && (b && c) );
+  BOOST_CHECK_EQUAL( r.timestamp(), c.timestamp() );	// max timestamp
 }

--- a/zypp/RepoInfo.cc
+++ b/zypp/RepoInfo.cc
@@ -62,7 +62,7 @@ namespace zypp
 	else if ( PathInfo(path_r/"/cookie").isFile() )
 	{ ret = repo::RepoType::RPMPLAINDIR; }
       }
-      MIL << "Probed cached type " << ret << " at " << path_r << endl;
+      DBG << "Probed cached type " << ret << " at " << path_r << endl;
       return ret;
     }
   } // namespace

--- a/zypp/RepoStatus.h
+++ b/zypp/RepoStatus.h
@@ -21,6 +21,8 @@
 namespace zypp
 { /////////////////////////////////////////////////////////////////
 
+  class RepoInfo;
+
   ///////////////////////////////////////////////////////////////////
   /// \class RepoStatus
   /// \brief Track changing files or directories.
@@ -51,6 +53,9 @@ namespace zypp
      * in an empty status.
      */
     explicit RepoStatus( const Pathname & path_r );
+
+    /** Compute status of a \a RepoInfo to track changes requiring a refresh. */
+    explicit RepoStatus( const RepoInfo & info_r );
 
     /** Explicitly specify checksum string and timestamp to use. */
     RepoStatus( std::string checksum_r, Date timestamp_r );

--- a/zypp/RepoStatus.h
+++ b/zypp/RepoStatus.h
@@ -73,14 +73,14 @@ namespace zypp
     void saveToCookieFile( const Pathname & path_r ) const;
 
   public:
-    /** Whether the status is empty (default constucted) */
+    /** Whether the status is empty (empty checksum) */
     bool empty() const;
 
     /** The time the data were changed the last time */
     Date timestamp() const;
 
   public:
-    struct Impl;			///< Implementation
+    struct Impl;		///< Implementation
   private:
     RWCOW_pointer<Impl> _pimpl;	///< Pointer to implementation
   };


### PR DESCRIPTION
[bsc#1174016](https://bugzilla.suse.com/show_bug.cgi?id=1174016)

The 1st commit solely fixes RepoStatus operator&& to allow joining more then 2 status in arbitrary sequence.

The 2nd one encodes the repo URL in the status and so forces to check the server if local metadata status (incl. the current url) and solv cache status (incl. the url used when creating the cache) don't match.