### PR TITLE
bsc#1178910 fix rpm dbpath

### DIFF
--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -286,7 +286,8 @@ void RpmDb::initDatabase( Pathname root_r, bool doRebuild_r )
   if ( ! PathInfo( root_r/"/var/lib/rpm" ).isExist()
     && PathInfo( root_r/"/usr/lib/sysimage/rpm" ).isDir() )
   {
-    WAR << "Rpm package was deleted? Injecting missing rpmdb compat symlink." << endl;
+    WAR << "No /var/lib/rpm: Injecting missing rpmdb compat symlink." << endl;
+    filesystem::assert_dir( root_r/"/var/lib" );
     filesystem::symlink( "../../usr/lib/sysimage/rpm", root_r/"/var/lib/rpm" );
   }
 

--- a/zypp/target/rpm/RpmDb.h
+++ b/zypp/target/rpm/RpmDb.h
@@ -108,7 +108,7 @@ public:
   }
 
   /**
-   * Prepare access to the rpm database at \c/var/lib/rpm.
+   * Prepare access to the rpm database below \a root_r.
    *
    * An optional argument denotes the root directory for all operations. If
    * an empty Pathname is given the default (\c/) is used.

--- a/zypp/target/rpm/librpmDb.h
+++ b/zypp/target/rpm/librpmDb.h
@@ -63,15 +63,19 @@ private:
 
   /**
    * Current root directory for all operations.
-   * (initialy /)
+   * (initially /)
    **/
   static Pathname _defaultRoot;
 
   /**
    * Current directory (below root) that contains the rpmdb.
-   * (initialy /var/lib/rpm)
    **/
-  static const Pathname _defaultDbPath;
+  static Pathname _defaultDbPath;
+
+  /**
+   * %_dbpath configured in rpm config.
+   **/
+  static Pathname _rpmDefaultDbPath;
 
   /**
    * Current rpmdb handle.
@@ -146,6 +150,16 @@ public:
   {
     return _defaultDbPath;
   }
+
+  /**
+   * \return The preferred location of the rpmdb below \a root_r.
+   * It's the location of an already exising db, otherwise the
+   * default location sugested by rpms config.
+   *
+   * \throws RpmInvalidRootException if root is not an absolute path or
+   * no directory for the rpmdb can determined.
+   **/
+  static Pathname suggestedDbPath( const Pathname & root_r );
 
   /**
    * Adjust access to the given database location, making it the new


### PR DESCRIPTION
[bsc#1178910](https://bugzilla.opensuse.org/show_bug.cgi?id=1178910)
Prefere an existing database, but follow rpms configured _dbpath if non exists. Assert a compat symlink at /var/lib/rpm exists in case the db is located elsewhere.