### PR TITLE
bsc#1178910 libzypp wrong dbpath enhanced

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <iterator>
 #include <stdio.h>
+#include <zypp/base/LogControl.h>
 #include <zypp/base/LogTools.h>
 #include <zypp/base/String.h>
 #include <zypp/base/Gettext.h>
@@ -396,6 +397,8 @@ namespace zypp
 
     pid_t cachepid = 0;
     FilterRunsInContainer runsInLXC;
+    MIL << "Silently scanning lsof output..." << endl;
+    zypp::base::LogControl::TmpLineWriter shutUp;	// suppress excessive readdir etc. logging in runsInLXC
     for( std::string line = source.receiveLine( 30 * 1000 ); ! line.empty(); line = source.receiveLine(  30 * 1000  ) )
     {
       // NOTE: line contains '\0' separeated fields!

--- a/zypp/target/rpm/librpmDb.cc
+++ b/zypp/target/rpm/librpmDb.cc
@@ -125,6 +125,10 @@ bool librpmDb::globalInit()
   initialized = true; // Necessary to be able to use exand().
   _rpmDefaultDbPath = expand( "%{_dbpath}" );
 
+  if ( _rpmDefaultDbPath.empty() ) {
+    _rpmDefaultDbPath = "/usr/lib/sysimage/";
+    WAR << "Looks like rpm has no %{_dbpath} set!?! Assuming " << _rpmDefaultDbPath << endl;
+  }
   MIL << "librpm init done: (_target:" << expand( "%{_target}" ) << ") (_dbpath:" << _rpmDefaultDbPath << ")" << endl;
   return initialized;
 }
@@ -162,6 +166,9 @@ librpmDb * librpmDb::newLibrpmDb()
   {
     ZYPP_THROW(GlobalRpmInitException());
   }
+
+  if ( _defaultDbPath.empty() )	// db_const_iterator access to /(default) without RpmDB/Tareget init.
+    _defaultDbPath = suggestedDbPath( _defaultRoot );
 
   // open rpmdb
   librpmDb * ret = 0;


### PR DESCRIPTION
[bsc#1178910](https://bugzilla.suse.com/show_bug.cgi?id=1178910)
Creating a librpmDb iterator before/without Target init finds the default dbpath unset and creates a database in /.

(The CheckAccessDeleted commit is unrelated. The numerous but superfluous log lines just caught my eye, because e.g. CheckAccessDeleted checks the installed lsof version and so triggers the above bug).