### PR TITLE
Fix downloading metalink of small files

### DIFF
--- a/zypp/media/MediaMultiCurl.cc
+++ b/zypp/media/MediaMultiCurl.cc
@@ -1122,7 +1122,8 @@ multifetchrequest::run(std::vector<Url> &urllist)
 		}
 	    }
 
-	  if ( _filesize > 0 && _fetchedgoodsize > _filesize ) {
+	  const int maxMetalinkSize = 16*1024*1024;
+	  if ( _filesize > 0 && _fetchedgoodsize > _filesize && (!_context || !_context->_customHeadersMetalink || _fetchedgoodsize > maxMetalinkSize) ) {
 	    ZYPP_THROW(MediaFileSizeExceededException(_baseurl, _filesize));
 	  }
 	}


### PR DESCRIPTION
In case of small file download metalink file may be bigger than actual file.
MediaMurtiCurl would report an exception for such files:
'Downloaded data exceeded the expected filesize'.
This fix checks whether metalink flag is set and then sets hard limit of 16Kb for handling metalink response.