### PR TITLE
Multicurl backend breaks with with unknown filesize (fixes #277)

### DIFF
--- a/zypp/media/MediaMultiCurl.cc
+++ b/zypp/media/MediaMultiCurl.cc
@@ -1413,6 +1413,16 @@ void MediaMultiCurl::doGetFileCopy( const Pathname & filename , const Pathname &
 	  MetaLinkParser mlp;
 	  mlp.parse(destNew);
 	  MediaBlockList bl = mlp.getBlockList();
+
+          /*
+           * gihub issue libzipp:#277 Multicurl backend breaks with MirrorCache and Metalink with unknown filesize.
+           * Fall back to a normal download if we have no knowledge about the filesize we want to download.
+           */
+          if ( !bl.haveFilesize() && expectedFileSize_r == 0 ) {
+            XXX << "No filesize in metalink file and no expected filesize, aborting multicurl." << std::endl;
+            ZYPP_THROW( MediaException("Multicurl requires filesize but none was provided.") );
+          }
+
 	  std::vector<Url> urls = mlp.getUrls();
 	  XXX << bl << endl;
 	  file = fopen((*destNew).c_str(), "w+e");


### PR DESCRIPTION
MultiCurl backend should fall back to a simple download in the case when we do not have a already known filesize and do not receive one from the Metalink data.

This patch implements the correct behaviour.