### PR TITLE
Minor logging issue regarding gpg keys

### DIFF
--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -1253,6 +1253,8 @@ namespace
       WAR << path_r << " (" << requireGPGSig_r << " -> " << ret << ")" << endl;
       WAR << vresult;
     }
+    else
+      DBG << path_r << " [0-Signature is OK]" << endl;
     return ret;
   }
 


### PR DESCRIPTION
Mainly prevent any sichcheck error logging when we do not verify. In that case we just want to get the keys signing a message. The message file itself is /dev/null, so reporting 'bad signature' errors in the log is confusing.