### PR TITLE
Add missing includes for GCC 11 compatibility

### DIFF
--- a/zypp/RepoStatus.cc
+++ b/zypp/RepoStatus.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <optional>
 #include <set>
 #include <zypp/base/Logger.h>
 #include <zypp/base/String.h>

--- a/zypp/url/UrlBase.cc
+++ b/zypp/url/UrlBase.cc
@@ -23,6 +23,7 @@
 #include <arpa/inet.h>
 
 #include <iostream>
+#include <optional>
 
 // in the Estonian locale, a-z excludes t, for example. #302525
 // http://en.wikipedia.org/wiki/Estonian_alphabet


### PR DESCRIPTION
This fixes the build in Fedora 34+.