### PR TITLE
Patch: Identify well-known category names (bsc#117984)

### DIFF
--- a/zypp/Patch.cc
+++ b/zypp/Patch.cc
@@ -50,7 +50,12 @@ namespace zypp
   { return categoryEnum( category() ); }
 
   bool Patch::isCategory( const std::string & category_r ) const
-  { return( str::compareCI( category_r, category() ) == 0 ); }
+  {
+    // bsc#1179847: identify the wellknown categories
+    Category catenum = categoryEnum( category_r );
+    return ( catenum == CAT_OTHER && str::compareCI( category_r, category() ) == 0 )
+    || ( catenum == categoryEnum() );
+  }
 
   bool Patch::isCategory( Categories category_r ) const
   { return category_r.testFlag( categoryEnum() ); }


### PR DESCRIPTION
The result of Patch::isCategory should be the same, no matter if
strings or enum values are compared.