### PR TITLE
dup relaxed vendor check

### DIFF
--- a/tests/zypp/Vendor_test.cc
+++ b/tests/zypp/Vendor_test.cc
@@ -50,6 +50,13 @@ BOOST_AUTO_TEST_CASE(vendor_test1)
   BOOST_REQUIRE( !VendorAttr::instance().equivalent("opensuse as prefix", "SuSE as prefix") );
   BOOST_REQUIRE( !VendorAttr::instance().equivalent("opensuse",           "opensuse as prefix") );
   BOOST_REQUIRE( !VendorAttr::instance().equivalent("opensuse as prefix", "opensuse but different prefix") );
+
+  // bsc#1182629: relaxed equivalence just adds suse/opensuse
+  BOOST_REQUIRE( !VendorAttr::instance().relaxedEquivalent("SuSE as prefix","foreign") );
+  BOOST_REQUIRE( VendorAttr::instance().relaxedEquivalent("opensuse",           "SuSE as prefix") );
+  BOOST_REQUIRE( !VendorAttr::instance().relaxedEquivalent("opensuse as prefix", "SuSE as prefix") );
+  BOOST_REQUIRE( !VendorAttr::instance().relaxedEquivalent("opensuse",           "opensuse as prefix") );
+  BOOST_REQUIRE( !VendorAttr::instance().relaxedEquivalent("opensuse as prefix", "opensuse but different prefix") );
 }
 
 BOOST_AUTO_TEST_CASE(vendor_test2)

--- a/zypp/VendorAttr.cc
+++ b/zypp/VendorAttr.cc
@@ -58,6 +58,23 @@ namespace zypp
     bool equivalent( IdString lVendor, IdString rVendor ) const
     { return lVendor == rVendor || vendorMatchId( lVendor ) == vendorMatchId( rVendor ); }
 
+    /** Return whether two vendor strings should be treated as equivalent or are (suse/opensuse).*/
+    bool relaxedEquivalent( IdString lVendor, IdString rVendor ) const
+    {
+      if ( equivalent( lVendor, rVendor ) )
+	return true;
+
+      static const IdString suse { "suse" };
+      static const IdString opensuse { "opensuse" };
+      unsigned sid = vendorMatchId( suse );
+      unsigned oid = vendorMatchId( opensuse );
+      if ( sid == oid )
+	return false; // (suse/opensuse) are equivalent, so these are not
+
+      auto isSuse = [sid,oid]( unsigned v )-> bool { return v==sid || v==oid; };
+      return isSuse( vendorMatchId(lVendor) ) && isSuse( vendorMatchId(rVendor) );
+    }
+
     unsigned foreachVendorList( std::function<bool(VendorList)> fnc_r ) const
     {
       std::map<unsigned,VendorList> lists;
@@ -319,6 +336,19 @@ namespace zypp
 
   bool VendorAttr::equivalent( const PoolItem & lVendor, const PoolItem & rVendor ) const
   { return _pimpl->equivalent( lVendor.satSolvable().vendor(), rVendor.satSolvable().vendor() ); }
+
+
+  bool VendorAttr::relaxedEquivalent( IdString lVendor, IdString rVendor ) const
+  { return _pimpl->relaxedEquivalent( lVendor, rVendor );}
+
+  bool VendorAttr::relaxedEquivalent( const Vendor & lVendor, const Vendor & rVendor ) const
+  { return _pimpl->relaxedEquivalent( IdString( lVendor ), IdString( rVendor ) ); }
+
+  bool VendorAttr::relaxedEquivalent( sat::Solvable lVendor, sat::Solvable rVendor ) const
+  { return _pimpl->relaxedEquivalent( lVendor.vendor(), rVendor.vendor() ); }
+
+  bool VendorAttr::relaxedEquivalent( const PoolItem & lVendor, const PoolItem & rVendor ) const
+  { return _pimpl->relaxedEquivalent( lVendor.satSolvable().vendor(), rVendor.satSolvable().vendor() ); }
 
   //////////////////////////////////////////////////////////////////
 

--- a/zypp/VendorAttr.h
+++ b/zypp/VendorAttr.h
@@ -142,6 +142,15 @@ class VendorAttr
     /** \overload using \ref PoolItem */
     bool equivalent( const PoolItem & lVendor, const PoolItem & rVendor ) const;
 
+    /** Like \ref equivalent but always unifies suse and openSUSE vendor */
+    bool relaxedEquivalent( const Vendor & lVendor, const Vendor & rVendor ) const;
+    /** \overload using \ref IdStrings */
+    bool relaxedEquivalent( IdString lVendor, IdString rVendor ) const;
+    /** \overload using \ref sat::Solvable */
+    bool relaxedEquivalent( sat::Solvable lVendor, sat::Solvable rVendor ) const;
+    /** \overload using \ref PoolItem */
+    bool relaxedEquivalent( const PoolItem & lVendor, const PoolItem & rVendor ) const;
+
   public:
     /** Call \a fnc_r for each equivalent vendor list (return \c false to break).
      * \return The number of calls to \a fnc_r.


### PR DESCRIPTION
[bsc#1182629](https://bugzilla.suse.com/show_bug.cgi?id=1182629) Enable release packages to request a relaxed vendot check in dup.