### PR TITLE
Do no cleanup in custom cache dirs

### DIFF
--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -890,10 +890,15 @@ namespace zypp
       // we'd need somemagic file to identify zypp cache directories. Without this
       // we may easily remove user data (zypper --pkg-cache-dir . download ...)
       repoEscAliases.sort();
-      RepoManagerOptions defaultCache( _options.rootDir );
-      cleanupNonRepoMetadtaFolders( _options.repoRawCachePath,		defaultCache.repoRawCachePath,		repoEscAliases );
-      cleanupNonRepoMetadtaFolders( _options.repoSolvCachePath,		defaultCache.repoSolvCachePath,		repoEscAliases );
-      cleanupNonRepoMetadtaFolders( _options.repoPackagesCachePath,	defaultCache.repoPackagesCachePath,	repoEscAliases );
+      cleanupNonRepoMetadtaFolders( _options.repoRawCachePath,
+				    Pathname::assertprefix( _options.rootDir, ZConfig::instance().builtinRepoMetadataPath() ),
+				    repoEscAliases );
+      cleanupNonRepoMetadtaFolders( _options.repoSolvCachePath,
+				    Pathname::assertprefix( _options.rootDir, ZConfig::instance().builtinRepoSolvfilesPath() ),
+				    repoEscAliases );
+      cleanupNonRepoMetadtaFolders( _options.repoPackagesCachePath,
+				    Pathname::assertprefix( _options.rootDir, ZConfig::instance().builtinRepoPackagesPath() ),
+				    repoEscAliases );
     }
     MIL << "end construct known repos" << endl;
   }

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -312,6 +312,10 @@ namespace zypp
         : _parsedZyppConf         	( override_r )
         , cfg_arch                	( defaultSystemArchitecture() )
         , cfg_textLocale          	( defaultTextLocale() )
+        , cfg_cache_path		{ "/var/cache/zypp" }
+        , cfg_metadata_path		{ "" }	// empty - follows cfg_cache_path
+        , cfg_solvfiles_path		{ "" }	// empty - follows cfg_cache_path
+        , cfg_packages_path		{ "" }	// empty - follows cfg_cache_path
         , updateMessagesNotify		( "" )
         , repo_add_probe          	( false )
         , repo_refresh_delay      	( 10 )
@@ -387,19 +391,19 @@ namespace zypp
                 }
                 else if ( entry == "cachedir" )
                 {
-                  cfg_cache_path = Pathname(value);
+                  cfg_cache_path.restoreToDefault( value );
                 }
                 else if ( entry == "metadatadir" )
                 {
-                  cfg_metadata_path = Pathname(value);
+                  cfg_metadata_path.restoreToDefault( value );
                 }
                 else if ( entry == "solvfilesdir" )
                 {
-                  cfg_solvfiles_path = Pathname(value);
+                  cfg_solvfiles_path.restoreToDefault( value );
                 }
                 else if ( entry == "packagesdir" )
                 {
-                  cfg_packages_path = Pathname(value);
+                  cfg_packages_path.restoreToDefault( value );
                 }
                 else if ( entry == "configdir" )
                 {
@@ -633,10 +637,10 @@ namespace zypp
     Arch     cfg_arch;
     Locale   cfg_textLocale;
 
-    Pathname cfg_cache_path;
-    Pathname cfg_metadata_path;
-    Pathname cfg_solvfiles_path;
-    Pathname cfg_packages_path;
+    DefaultOption<Pathname> cfg_cache_path;	// Settings from the config file are also remembered
+    DefaultOption<Pathname> cfg_metadata_path;	// 'default'. Cleanup in RepoManager e.g needs to tell
+    DefaultOption<Pathname> cfg_solvfiles_path;	// whether settings in effect are config values or
+    DefaultOption<Pathname> cfg_packages_path;	// custom settings applied vie set...Path().
 
     Pathname cfg_config_path;
     Pathname cfg_known_repos_path;
@@ -916,8 +920,8 @@ namespace zypp
 
   Pathname ZConfig::repoCachePath() const
   {
-    return ( _pimpl->cfg_cache_path.empty()
-             ? Pathname("/var/cache/zypp") : _pimpl->cfg_cache_path );
+    return ( _pimpl->cfg_cache_path.get().empty()
+             ? Pathname("/var/cache/zypp") : _pimpl->cfg_cache_path.get() );
   }
 
   Pathname ZConfig::pubkeyCachePath() const
@@ -932,8 +936,8 @@ namespace zypp
 
   Pathname ZConfig::repoMetadataPath() const
   {
-    return ( _pimpl->cfg_metadata_path.empty()
-        ? (repoCachePath()/"raw") : _pimpl->cfg_metadata_path );
+    return ( _pimpl->cfg_metadata_path.get().empty()
+        ? (repoCachePath()/"raw") : _pimpl->cfg_metadata_path.get() );
   }
 
   void ZConfig::setRepoMetadataPath(const zypp::filesystem::Pathname &path_r)
@@ -943,8 +947,8 @@ namespace zypp
 
   Pathname ZConfig::repoSolvfilesPath() const
   {
-    return ( _pimpl->cfg_solvfiles_path.empty()
-        ? (repoCachePath()/"solv") : _pimpl->cfg_solvfiles_path );
+    return ( _pimpl->cfg_solvfiles_path.get().empty()
+        ? (repoCachePath()/"solv") : _pimpl->cfg_solvfiles_path.get() );
   }
 
   void ZConfig::setRepoSolvfilesPath(const zypp::filesystem::Pathname &path_r)
@@ -954,14 +958,26 @@ namespace zypp
 
   Pathname ZConfig::repoPackagesPath() const
   {
-    return ( _pimpl->cfg_packages_path.empty()
-        ? (repoCachePath()/"packages") : _pimpl->cfg_packages_path );
+    return ( _pimpl->cfg_packages_path.get().empty()
+        ? (repoCachePath()/"packages") : _pimpl->cfg_packages_path.get() );
   }
 
   void ZConfig::setRepoPackagesPath(const zypp::filesystem::Pathname &path_r)
   {
     _pimpl->cfg_packages_path = path_r;
   }
+
+  Pathname ZConfig::builtinRepoCachePath() const
+  { return _pimpl->cfg_cache_path.getDefault().empty() ? Pathname("/var/cache/zypp") : _pimpl->cfg_cache_path.getDefault(); }
+
+  Pathname ZConfig::builtinRepoMetadataPath() const
+  { return _pimpl->cfg_metadata_path.getDefault().empty() ? (builtinRepoCachePath()/"raw") : _pimpl->cfg_metadata_path.getDefault(); }
+
+  Pathname ZConfig::builtinRepoSolvfilesPath() const
+  { return _pimpl->cfg_solvfiles_path.getDefault().empty() ? (builtinRepoCachePath()/"solv") : _pimpl->cfg_solvfiles_path.getDefault(); }
+
+  Pathname ZConfig::builtinRepoPackagesPath() const
+  { return _pimpl->cfg_packages_path.getDefault().empty() ? (builtinRepoCachePath()/"packages") : _pimpl->cfg_packages_path.getDefault(); }
 
   ///////////////////////////////////////////////////////////////////
 

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -236,9 +236,12 @@ namespace zypp
 	typedef Tp value_type;
 
 	/** No default ctor, explicit initialisation! */
-	Option( const value_type & initial_r )
-	  : _val( initial_r )
+	Option( value_type initial_r )
+	  : _val( std::move(initial_r) )
 	{}
+
+	Option & operator=( value_type newval_r )
+	{ set( std::move(newval_r) ); return *this; }
 
 	/** Get the value.  */
 	const value_type & get() const
@@ -249,12 +252,8 @@ namespace zypp
         { return _val; }
 
 	/** Set a new value.  */
-	void set( const value_type & newval_r )
-	{ _val = newval_r; }
-
-        /** Non-const reference to set a new value. */
-        value_type & ref()
-        { return _val; }
+	void set( value_type newval_r )
+	{ _val = std::move(newval_r); }
 
 	private:
 	  value_type _val;
@@ -267,25 +266,29 @@ namespace zypp
 	typedef Tp         value_type;
 	typedef Option<Tp> option_type;
 
-        DefaultOption( const value_type & initial_r )
-          : Option<Tp>( initial_r ), _default( initial_r )
-        {}
+	explicit DefaultOption( value_type initial_r )
+	: Option<Tp>( initial_r )
+	, _default( std::move(initial_r) )
+	{}
+
+	DefaultOption & operator=( value_type newval_r )
+	{ this->set( std::move(newval_r) ); return *this; }
 
 	/** Reset value to the current default. */
 	void restoreToDefault()
 	{ this->set( _default.get() ); }
 
 	/** Reset value to a new default. */
-	void restoreToDefault( const value_type & newval_r )
-	{ setDefault( newval_r ); restoreToDefault(); }
+	void restoreToDefault( value_type newval_r )
+	{ setDefault( std::move(newval_r) ); restoreToDefault(); }
 
 	/** Get the current default value. */
 	const value_type & getDefault() const
 	{ return _default.get(); }
 
 	/** Set a new default value. */
-	void setDefault( const value_type & newval_r )
-	{ _default.set( newval_r ); }
+	void setDefault( value_type newval_r )
+	{ _default.set( std::move(newval_r) ); }
 
 	private:
 	  option_type _default;

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -922,8 +922,7 @@ namespace zypp
 
   Pathname ZConfig::pubkeyCachePath() const
   {
-    return ( _pimpl->cfg_cache_path.empty()
-             ? Pathname("/var/cache/zypp/pubkeys") : _pimpl->cfg_cache_path/"pubkeys" );
+    return repoCachePath()/"pubkeys";
   }
 
   void ZConfig::setRepoCachePath(const zypp::filesystem::Pathname &path_r)

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -33,6 +33,8 @@
 namespace zypp
 { /////////////////////////////////////////////////////////////////
 
+  class RepoManager;
+
   ///////////////////////////////////////////////////////////////////
   //
   //	CLASS NAME : ZConfig
@@ -182,6 +184,7 @@ namespace zypp
         * \ingroup g_ZC_REPOCACHE
       */
       Pathname repoPackagesPath() const;
+
 
       /**
        * Set a new \a path as the default repo cache path
@@ -540,10 +543,22 @@ namespace zypp
       std::string multiversionKernels() const;
 
       //@}
+
     public:
       class Impl;
       /** Dtor */
       ~ZConfig();
+  private:
+      friend class RepoManager;
+      /** The builtin config file value. */
+      Pathname builtinRepoCachePath() const;
+      /** The builtin config file value. */
+      Pathname builtinRepoMetadataPath() const;
+      /** The builtin config file value. */
+      Pathname builtinRepoSolvfilesPath() const;
+      /** The builtin config file value. */
+      Pathname builtinRepoPackagesPath() const;
+
   private:
       friend class Impl;
       /** Default ctor. */

--- a/zypp/base/Logger.h
+++ b/zypp/base/Logger.h
@@ -16,22 +16,19 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////
-#ifdef ZYPP_NDEBUG
-#define OSDLOG( MSG )
-#define OSMLOG( L, MSG )
-#define TRACELEAVE
-#else
+#ifndef ZYPP_NDEBUG
 namespace zypp
 {
   namespace debug
-  {
-    void osdlog( const std::string & msg_r, unsigned level_r );	// LogControl.cc
+  { // impl in LogControl.cc
 
-    struct TraceLeave	// LogControl.cc
+    // Log code loacaton and block leave
+    // Indent if nested
+    struct TraceLeave
     {
       TraceLeave( const TraceLeave & ) =delete;
       TraceLeave & operator=( const TraceLeave & ) =delete;
-      TraceLeave( const char * file_r, const char *  fnc_r, int line_r );
+      TraceLeave( const char * file_r, const char * fnc_r, int line_r );
       ~TraceLeave();
     private:
       static unsigned _depth;
@@ -39,11 +36,26 @@ namespace zypp
       const char *    _fnc;
       int             _line;
     };
+#define TRACE ::zypp::debug::TraceLeave _TraceLeave( __FILE__, __FUNCTION__, __LINE__ )
+
+    // OnScreenDebug messages colored to stderr
+    struct Osd
+    {
+      Osd( int = 0 );
+      ~Osd();
+
+      template<class Tp>
+      Osd & operator<<( Tp && val )
+      { _str << std::forward<Tp>(val); return *this; }
+
+      Osd & operator<<( std::ostream& (*iomanip)( std::ostream& ) );
+
+    private:
+      std::ostream & _str;
+    };
+#define OSD ::zypp::debug::Osd()
   }
 }
-#define OSDLOG( MSG )    ::zypp::debug::osdlog( MSG, 0 )
-#define OSMLOG( L, MSG ) ::zypp::debug::osdlog( MSG, L )
-#define TRACELEAVE       ::zypp::debug::TraceLeave _TraceLeave( __FILE__, __FUNCTION__, __LINE__ )
 #endif // ZYPP_NDEBUG
 ///////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
[bsc#1182936](https://bugzilla.opensuse.org/show_bug.cgi?id=1182936)
Values read from the config file are remembered as default so RM can check whether a cachepath was later amended.