### PR TITLE
Allow custom user agent string via zypp.conf download.user_agent (zypper#382)

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -152,6 +152,16 @@
 # repo.refresh.locales = en, de
 
 ##
+## Custom user agent string to send to a HTTP server.
+##
+## Valid values: String suitable as user agent HTTP header
+##
+## If not defined or empty the builtin default telling the zypp
+## version, distribution and architecture is used.
+##
+# download.user_agent =
+
+##
 ## Maximum number of concurrent connections to use per transfer
 ##
 ## Valid values: Integer

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -458,6 +458,10 @@ namespace zypp
 		  download_mediaMountdir.restoreToDefault( Pathname(value) );
                 }
 
+                else if ( entry == "download.user_agent" )
+                {
+                  download_user_agent = value;
+                }
                 else if ( entry == "download.max_concurrent_connections" )
                 {
                   str::strtonum(value, download_max_concurrent_connections);
@@ -668,6 +672,7 @@ namespace zypp
     DefaultOption<bool> download_media_prefer_download;
     DefaultOption<Pathname> download_mediaMountdir;
 
+    std::string download_user_agent;
     int download_max_concurrent_connections;
     int download_min_download_speed;
     int download_max_download_speed;
@@ -1054,6 +1059,9 @@ namespace zypp
 
   void ZConfig::set_default_download_media_prefer_download()
   { _pimpl->download_media_prefer_download.restoreToDefault(); }
+
+  std::string ZConfig::download_user_agent() const
+  { return _pimpl->download_user_agent; }
 
   long ZConfig::download_max_concurrent_connections() const
   { return _pimpl->download_max_concurrent_connections; }

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -261,6 +261,12 @@ namespace zypp
        */
       void repoLabelIsAlias( bool yesno_r );
 
+
+      /**
+       * A custom user agent string to send to a HTTP server.
+       */
+      std::string download_user_agent() const;
+
       /**
        * Maximum number of concurrent connections for a single transfer
        */

--- a/zypp/media/CurlHelper.cc
+++ b/zypp/media/CurlHelper.cc
@@ -10,6 +10,8 @@
 #include <zypp/media/MediaException.h>
 #include <list>
 
+#define  TRANSFER_TIMEOUT_MAX   60 * 60
+
 using std::endl;
 using namespace zypp;
 

--- a/zypp/media/CurlHelper.cc
+++ b/zypp/media/CurlHelper.cc
@@ -321,22 +321,6 @@ const char * distributionFlavorHeader()
   return _value.c_str();
 }
 
-const char * agentString()
-{
-  // we need to add the release and identifier to the
-  // agent string.
-  // The target could be not initialized, and then this information
-  // is guessed.
-  static const std::string _value(
-    str::form(
-      "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s"
-      , curl_version_info(CURLVERSION_NOW)->version
-      , Target::targetDistribution( Pathname()/*guess root*/ ).c_str()
-      )
-    );
-  return _value.c_str();
-}
-
 void curlEscape( std::string & str_r,
   const char char_r, const std::string & escaped_r ) {
   for ( std::string::size_type pos = str_r.find( char_r );

--- a/zypp/media/CurlHelper.h
+++ b/zypp/media/CurlHelper.h
@@ -20,7 +20,6 @@
 
 #define  CONNECT_TIMEOUT        60
 #define  TRANSFER_TIMEOUT_MAX   60 * 60
-#define  DETECT_DIR_INDEX       0
 
 #define EXPLICITLY_NO_PROXY "_none_"
 

--- a/zypp/media/CurlHelper.h
+++ b/zypp/media/CurlHelper.h
@@ -19,7 +19,6 @@
 #include <zypp/media/TransferSettings.h>
 
 #define  CONNECT_TIMEOUT        60
-#define  TRANSFER_TIMEOUT_MAX   60 * 60
 
 #define EXPLICITLY_NO_PROXY "_none_"
 

--- a/zypp/media/CurlHelper.h
+++ b/zypp/media/CurlHelper.h
@@ -18,8 +18,6 @@
 #include <zypp/Url.h>
 #include <zypp/media/TransferSettings.h>
 
-#define  CONNECT_TIMEOUT        60
-
 #define EXPLICITLY_NO_PROXY "_none_"
 
 #undef CURLVERSION_AT_LEAST
@@ -57,12 +55,6 @@ const char * anonymousIdHeader();
  * from the target, which we pass in the http header
  */
 const char * distributionFlavorHeader();
-
-/**
- * initialized only once, this gets the agent string
- * which also includes the curl version
- */
-const char * agentString();
 
 void curlEscape( std::string & str_r,  const char char_r, const std::string & escaped_r );
 std::string curlEscapedPath( std::string path_r );

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -971,49 +971,6 @@ bool MediaCurl::doGetDoesFileExist( const Pathname & filename ) const
 
 ///////////////////////////////////////////////////////////////////
 
-
-#if DETECT_DIR_INDEX
-bool MediaCurl::detectDirIndex() const
-{
-  if(_url.getScheme() != "http" && _url.getScheme() != "https")
-    return false;
-  //
-  // try to check the effective url and set the not_a_file flag
-  // if the url path ends with a "/", what usually means, that
-  // we've received a directory index (index.html content).
-  //
-  // Note: This may be dangerous and break file retrieving in
-  //       case of some server redirections ... ?
-  //
-  bool      not_a_file = false;
-  char     *ptr = NULL;
-  CURLcode  ret = curl_easy_getinfo( _curl,
-				     CURLINFO_EFFECTIVE_URL,
-				     &ptr);
-  if ( ret == CURLE_OK && ptr != NULL)
-  {
-    try
-    {
-      Url         eurl( ptr);
-      std::string path( eurl.getPathName());
-      if( !path.empty() && path != "/" && *path.rbegin() == '/')
-      {
-	DBG << "Effective url ("
-	    << eurl
-	    << ") seems to provide the index of a directory"
-	    << endl;
-	not_a_file = true;
-      }
-    }
-    catch( ... )
-    {}
-  }
-  return not_a_file;
-}
-#endif
-
-///////////////////////////////////////////////////////////////////
-
 void MediaCurl::doGetFileCopy(const Pathname & filename , const Pathname & target, callback::SendReport<DownloadProgressReport> & report, const ByteCount &expectedFileSize_r, RequestOptions options ) const
 {
     Pathname dest = target.absolutename();
@@ -1220,13 +1177,6 @@ void MediaCurl::doGetFileCopyFile(const Pathname & filename , const Pathname & d
         ZYPP_RETHROW(e);
       }
     }
-
-#if DETECT_DIR_INDEX
-    if (!ret && detectDirIndex())
-      {
-	ZYPP_THROW(MediaNotAFileException(_url, filename));
-      }
-#endif // DETECT_DIR_INDEX
 }
 
 ///////////////////////////////////////////////////////////////////

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -292,11 +292,6 @@ void MediaCurl::setupEasy()
   }
   vol_settings.addHeader("Pragma:");
 
-  _settings.setTimeout(ZConfig::instance().download_transfer_timeout());
-  _settings.setConnectTimeout(CONNECT_TIMEOUT);
-
-  _settings.setUserAgentString(agentString());
-
   // fill some settings from url query parameters
   try
   {

--- a/zypp/media/MediaCurl.h
+++ b/zypp/media/MediaCurl.h
@@ -162,8 +162,6 @@ class MediaCurl : public MediaHandler
 
     bool authenticate(const std::string & availAuthTypes, bool firstTry) const;
 
-    bool detectDirIndex() const;
-
   private:
     long _curlDebug;
 

--- a/zypp/media/TransferSettings.cc
+++ b/zypp/media/TransferSettings.cc
@@ -1,14 +1,12 @@
+#include <curl/curl.h>	// for useragent version info
+
 #include <iostream>
-#include <sstream>
 
 #include <zypp/base/String.h>
 #include <zypp/base/Logger.h>
-#include <zypp/base/WatchFile.h>
-#include <zypp/base/ReferenceCounted.h>
-#include <zypp/base/NonCopyable.h>
-#include <zypp/ExternalProgram.h>
 #include <zypp/media/TransferSettings.h>
 #include <zypp/ZConfig.h>
+#include <zypp/Target.h>
 
 using std::endl;
 
@@ -18,6 +16,22 @@ namespace zypp
 {
   namespace media
   {
+    namespace {
+      const std::string & defaultUserAgent()
+      {
+	// we need to add the release and identifier to the
+	// agent string.
+	// The target could be not initialized, and then this information
+	// is guessed.
+	static const std::string _value {
+	  str::form( "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s",
+		     curl_version_info(CURLVERSION_NOW)->version,
+		     Target::targetDistribution( Pathname()/*guess root*/ ).c_str() )
+	};
+	return _value;
+      }
+    }
+
     class TransferSettings::Impl
     {
     public:
@@ -53,7 +67,7 @@ namespace zypp
 
     public:
       std::vector<std::string> _headers;
-      std::string _useragent;
+      std::optional<std::string> _useragent;
       std::string _username;
       std::string _password;
       bool _useproxy;
@@ -100,10 +114,10 @@ namespace zypp
 
 
     void TransferSettings::setUserAgentString( std::string && val_r )
-    { _impl->_useragent = std::move(val_r); }
+    { if ( val_r.empty() ) _impl->_useragent.reset(); else _impl->_useragent = std::move(val_r); }
 
-    std::string TransferSettings::userAgentString() const
-    { return _impl->_useragent; }
+    const std::string & TransferSettings::userAgentString() const
+    { return _impl->_useragent.has_value() ? *(_impl->_useragent) : defaultUserAgent(); }
 
 
     void TransferSettings::setUsername( std::string && val_r )

--- a/zypp/media/TransferSettings.cc
+++ b/zypp/media/TransferSettings.cc
@@ -23,11 +23,14 @@ namespace zypp
 	// agent string.
 	// The target could be not initialized, and then this information
 	// is guessed.
-	static const std::string _value {
-	  str::form( "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s",
-		     curl_version_info(CURLVERSION_NOW)->version,
-		     Target::targetDistribution( Pathname()/*guess root*/ ).c_str() )
-	};
+	static const std::string _value {[](){
+	  std::string ret { ZConfig::instance().download_user_agent() };
+	  if ( ret.empty() )
+	    ret = str::form( "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s",
+			     curl_version_info(CURLVERSION_NOW)->version,
+			     Target::targetDistribution( Pathname()/*guess root*/ ).c_str() );
+	  return ret;
+	}()};
 	return _value;
       }
     }

--- a/zypp/media/TransferSettings.h
+++ b/zypp/media/TransferSettings.h
@@ -43,7 +43,7 @@ namespace zypp
       void setUserAgentString( std::string && val_r );
 
       /** user agent string */
-      std::string userAgentString() const;
+      const std::string & userAgentString() const;
 
 
       /** sets the auth username */

--- a/zypp/zyppng/media/network/request.cc
+++ b/zypp/zyppng/media/network/request.cc
@@ -123,11 +123,6 @@ namespace zyppng {
 
       locSet.addHeader("Pragma:");
 
-      locSet.setTimeout( zypp::ZConfig::instance().download_transfer_timeout() );
-      locSet.setConnectTimeout( CONNECT_TIMEOUT );
-
-      locSet.setUserAgentString( internal::agentString() );
-
       {
         char *ptr = getenv("ZYPP_MEDIA_CURL_DEBUG");
         _curlDebug = (ptr && *ptr) ? zypp::str::strtonum<long>( ptr) : 0L;


### PR DESCRIPTION
A bit clean-up. User agent string and some timeout values can be initialized and provided by the TransferSettings.
Custom user agent string tajen from ZConfig.