### PR TITLE
Fix unsafe usage of static in media verifier

### DIFF
--- a/zypp/repo/SUSEMediaVerifier.cc
+++ b/zypp/repo/SUSEMediaVerifier.cc
@@ -92,7 +92,7 @@ namespace zypp
 
       Pathname mediaFilePath( media::MediaNr mediaNr_r = 0 ) const
       {
-	static str::Format fmt { "/media.%d/media" };
+	str::Format fmt { "/media.%d/media" };
 	fmt % str::numstring( mediaNr_r ? mediaNr_r : _mediaNr );
 	return fmt.str();
       }


### PR DESCRIPTION
Unless something changed dramatically recently in C++ - using `static` without `const` or mutex is always thread-unsafe.