### PR TITLE
Properly handle permission denied when providing optional files

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -184,6 +184,8 @@ IMPL_PTR_TYPE(MediaSetAccess);
     }
     catch ( const media::MediaFileNotFoundException & excpt_r )
     { ZYPP_CAUGHT( excpt_r ); }
+    catch ( const media::MediaForbiddenException & excpt_r )
+    { ZYPP_CAUGHT( excpt_r ); }
     catch ( const media::MediaNotAFileException & excpt_r )
     { ZYPP_CAUGHT( excpt_r ); }
    return Pathname();


### PR DESCRIPTION
[bsc#1185239](https://bugzilla.opensuse.org/show_bug.cgi?id=1185239)