### PR TITLE
Bug bsc 1185325

### DIFF
--- a/tests/zypp/PurgeKernels_test.cc
+++ b/tests/zypp/PurgeKernels_test.cc
@@ -132,6 +132,7 @@ namespace  {
         "running",
         {
           { "kernel-default-1-2.x86_64", false },
+          { "kernel-default-extra-1-2.x86_64", false },
           { "kernel-default-devel-1-2.x86_64", false },
           { "kernel-default-devel-debuginfo-1-2.x86_64", false },
           { "kernel-devel-1-2.noarch", false },
@@ -152,6 +153,7 @@ namespace  {
         "running",
         {
           { "kernel-default-1-2.x86_64", false },
+          { "kernel-default-extra-1-2.x86_64", false },
           { "kernel-default-devel-1-2.x86_64", false },
           { "kernel-default-devel-debuginfo-1-2.x86_64", false },
           { "kernel-devel-1-2.noarch", false },

--- a/tests/zypp/data/PurgeKernels/withdeps/@System.repo
+++ b/tests/zypp/data/PurgeKernels/withdeps/@System.repo
@@ -92,6 +92,23 @@ kernel-default = 1-2
 +Rec:
 kernel-firmware
 -Rec:
+
+=Vnd: openSUSE
+=Pkg: kernel-default-extra 1 2 x86_64
+=Sum: The Standard Kernel - Unsupported kernel modules
++Req:
+kernel-default = 1-2
+-Req:
++Prv:
+multiversion(kernel)
+kernel-extra = 1-2
+config(kernel-default-extra) = 1-2
+kernel-default-extra = 1-2
+kmod(a)
+kmod(b) 
+ksym(c)
+-Prv:
+
 =Vnd: openSUSE
 =Pkg: kernel-livepatch-default 1 2 x86_64
 +Req:

--- a/tools/zypp-runpurge.cc
+++ b/tools/zypp-runpurge.cc
@@ -1,0 +1,83 @@
+#include <zypp/PurgeKernels.h>
+#include "argparse.h"
+
+#define INCLUDE_TESTSETUP_WITHOUT_BOOST
+#include "../tests/lib/TestSetup.h"
+#undef  INCLUDE_TESTSETUP_WITHOUT_BOOST
+
+static std::string appname { "NO_NAME" };
+
+int errexit( const std::string & msg_r = std::string(), int exit_r = 100 )
+{
+  if ( ! msg_r.empty() )
+    cerr << endl << appname << ": ERR: " << msg_r << endl << endl;
+  return exit_r;
+}
+
+int usage( const argparse::Options & options_r, int return_r = 0 )
+{
+  cerr << "USAGE: " << appname << " [OPTION]... path/to/testcase" << endl;
+  cerr << "    Calculate the kernels that would be purged based on the spec and testcase." << endl;
+  cerr << options_r << endl;
+  return return_r;
+}
+
+int main ( int argc, char *argv[] )
+{
+
+  appname = Pathname::basename( argv[0] );
+  argparse::Options options;
+  options.add()
+    ( "help,h",   "Print help and exit." )
+    ( "uname",    "The running kernels uname", argparse::Option::Arg::required )
+    ( "keepSpec", "The keepspec ( default is oldest,running,latest)", argparse::Option::Arg::required );
+
+  auto result = options.parse( argc, argv );
+
+  if ( result.count( "help" ) || !result.count("uname") || !result.positionals().size() )
+    return usage( options, 1 );
+
+  const std::string &testcaseDir = result.positionals().front();
+  const auto &pathInfo = PathInfo(testcaseDir);
+  if ( !pathInfo.isExist() || !pathInfo.isDir() ) {
+    std::cerr << "Invalid or non existing testcase path: " << testcaseDir << std::endl;
+    return 1;
+  }
+
+  if ( ::chdir( testcaseDir.data() ) != 0 ) {
+    std::cerr << "Failed to chdir to " << testcaseDir << std::endl;
+    return 1;
+  }
+
+  TestSetup t;
+  try {
+    t.LoadSystemAt( result.positionals().front() );
+  }  catch ( const zypp::Exception &e ) {
+    std::cerr << "Failed to load the testcase at " << result.positionals().front() << std::endl;
+    std::cerr << "Got exception: " << e << std::endl;
+    return 1;
+  }
+
+  std::string keepSpec = "oldest,running,latest";
+  if ( result.count("keepSpec") ) {
+    keepSpec = result["keepSpec"].arg();
+  }
+
+  PurgeKernels krnls;
+  krnls.setUnameR( result["uname"].arg() );
+  krnls.setKeepSpec( keepSpec );
+  krnls.markObsoleteKernels();
+
+  const auto &makeNVRA = []( const PoolItem &pck ) -> std::string  {
+    return pck.name() + "-" + pck.edition().asString() + "." + pck.arch().asString();
+  };
+
+  auto pool = ResPool::instance();
+  const filter::ByStatus toBeUninstalledFilter( &ResStatus::isToBeUninstalled );
+  for ( auto it = pool.byStatusBegin( toBeUninstalledFilter ); it != pool.byStatusEnd( toBeUninstalledFilter );  it++  ) {
+    std::cout << "Removing " << makeNVRA(*it) + (it->status().isByUser() ? " (by user)" : " (autoremoved)") << std::endl;
+  }
+
+  return 0;
+
+}

--- a/zypp/misc/YamlTestcaseHelpers.h
+++ b/zypp/misc/YamlTestcaseHelpers.h
@@ -59,7 +59,14 @@ namespace yamltest::detail {
             }
             MIL << "Loaded " << cnt << " Elements from file" << std::endl;
           } catch ( YAML::Exception &e ) {
-            if ( err ) *err = e.what();
+            if ( err ) {
+              auto errStr = zypp::str::Str();
+              errStr << e.what();
+              if ( !e.mark.is_null() ) {
+                errStr << " Line: " << e.mark.line << " Col: " << e.mark.column << " pos: " << e.mark.pos;
+              }
+              *err = errStr;
+            }
             return false;
           } catch ( ... )  {
             if ( err ) *err = zypp::str::Str() << "Unknown error when parsing the file for " << key;


### PR DESCRIPTION
Leap 15.3 introduces a new kernel package called kernel-flavour-extra,
which contain kmp's. Currently kmp's are detected by name ".*-kmp(-.*)?"
but this does not work which those new packages. This patch fixes the
problem by checking packages for kmod(*) and ksym(*) provides and only
falls back to name checking if the package in question does not provide
one of those.