### PR TITLE
$ZYPP_LOCK_TIMEOUT: Let negative values wait forever for the zypp loc…

### DIFF
--- a/doc/autoinclude/EnvironmentVariables.doc
+++ b/doc/autoinclude/EnvironmentVariables.doc
@@ -11,7 +11,7 @@
 \subsection zypp-envars-config zypp config options
 
 \li \c ZYPP_CONF=<PATH> Location of the zypp.conf file.
-\li \c ZYPP_LOCK_TIMEOUT=<sec> If zypp is locked by another process wait this number of seconds for the lock becoming available.
+\li \c ZYPP_LOCK_TIMEOUT=<sec> If zypp is locked by another process wait this number of seconds for the lock becoming available. A negative value will wait forever.
 
 \subsection zypp-envars-repos Variables related to repositories
 


### PR DESCRIPTION
…k [bsc#1184399](https://bugzilla.suse.com/show_bug.cgi?id=1184399)

Helps boot time services like 'zypper purge-kernels' to wait for the zypp lock until other services using zypper have completed.