### PR TITLE
Fix segv if ZYPP_FULLOG is set (fixes #317)

### DIFF
--- a/zypp/solver/detail/Resolver.cc
+++ b/zypp/solver/detail/Resolver.cc
@@ -295,7 +295,7 @@ void Resolver::solverInit()
     // Solving with libsolv
     static bool poolDumped = false;
     MIL << "-------------- Calling SAT Solver -------------------" << endl;
-    if ( getenv("ZYPP_FULLLOG") ) {
+    if ( getenv("ZYPP_FULLLOG") and get() ) { // libzypp/issues/317: get() to make sure a satsolver instance is actually present
 	Testcase testcase("/var/log/YaST2/autoTestcase");
 	if (!poolDumped) {
 	    testcase.createTestcase (*this, true, false); // dump pool

--- a/zypp/solver/detail/Testcase.cc
+++ b/zypp/solver/detail/Testcase.cc
@@ -71,6 +71,12 @@ namespace zypp
 
       bool Testcase::createTestcase(Resolver & resolver, bool dumpPool, bool runSolver)
       {
+	// libzypp/issues/317: make sure a satsolver instance is actually present
+	if ( not resolver.get() ) {
+	  WAR << "Can't createTestcase if the satsolver is not yet initialized." << endl;
+	  return false;
+	}
+
 	MIL << "createTestcase at " << dumpPath << (dumpPool?" dumpPool":"") << (runSolver?" runSolver":"") << endl;
         PathInfo path (dumpPath);
 


### PR DESCRIPTION
ZYPP_FULLOG must not write a testcase before a
the solver is actually initialized.