### PR TITLE
Add Solvable::isBlacklisted as superset of retracted and ptf packages…

### DIFF
--- a/tests/sat/BlacklistedPool/@System.repo
+++ b/tests/sat/BlacklistedPool/@System.repo
@@ -1,0 +1,10 @@
+=Ver: 3.0
+# Retracted-patch-package() is not part of the installed package.
+# It's injected into available pkgs by libsolv
+
+=Pkg: package 5 1 x86_64
++Prv:
+ptf()
+ptf-package()
+package = 5-1
+-Prv:

--- a/tests/sat/BlacklistedPool/Repo.repo
+++ b/tests/sat/BlacklistedPool/Repo.repo
@@ -1,0 +1,34 @@
+=Ver: 3.0
+# Retracted-patch-package() is not part of the installed package.
+# It's injected into available pkgs by libsolv
+
+=Pkg: package 1 1 x86_64
++Prv:
+package = 1-1
+-Prv:
+
+=Pkg: package 2 1 x86_64
++Prv:
+retracted-patch-package()
+package = 2-1
+-Prv:
+
+=Pkg: package 3 1 x86_64
++Prv:
+ptf()
+package = 3-1
+-Prv:
+
+=Pkg: package 4 1 x86_64
++Prv:
+ptf-package()
+package = 4-1
+-Prv:
+
+=Pkg: package 5 1 x86_64
++Prv:
+retracted-patch-package()
+ptf()
+ptf-package()
+package = 5-1
+-Prv:

--- a/tests/sat/BlacklistedPool/zypp-control.yaml
+++ b/tests/sat/BlacklistedPool/zypp-control.yaml
@@ -1,0 +1,43 @@
+version: 1.0
+setup:
+  channels:
+    - alias: Repo
+      url: []
+      path: ""
+      type: NONE
+      generated: 0
+      outdated: 0
+      priority: 99
+      file: Repo.repo
+    - alias: "@System"
+      url: []
+      path: ""
+      type: NONE
+      generated: 0
+      outdated: 0
+      priority: 99
+      file: "@System.repo"
+  arch: x86_64
+  locales:
+    []
+  autoinst:
+    []
+  modalias:
+    []
+  multiversion:
+    []
+  resolverFlags:
+    focus: Job
+    ignorealreadyrecommended: false
+    onlyRequires: false
+    forceResolve: false
+    cleandepsOnRemove: false
+    allowDowngrade: false
+    allowNameChange: false
+    allowArchChange: false
+    allowVendorChange: false
+    dupAllowDowngrade: false
+    dupAllowNameChange: false
+    dupAllowArchChange: false
+    dupAllowVendorChange: false
+trials: []

--- a/tests/sat/Blacklisted_test.cc
+++ b/tests/sat/Blacklisted_test.cc
@@ -1,0 +1,82 @@
+#include <boost/test/unit_test.hpp>
+using boost::unit_test::test_case;
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include "TestSetup.h"
+#include <zypp/base/LogTools.h>
+using std::cin;
+using std::cout;
+using std::cerr;
+using std::endl;
+using namespace zypp;
+
+static TestSetup test( TestSetup::initLater );
+struct TestInit {
+  TestInit() {
+    test = TestSetup( Arch_x86_64 );
+  }
+  ~TestInit() { test.reset(); }
+};
+BOOST_GLOBAL_FIXTURE( TestInit );
+
+void testcase_init()
+{
+  test.loadTestcaseRepos( TESTS_SRC_DIR"/sat/BlacklistedPool" );
+}
+
+std::string blacktag( const PoolItem & pi_r )
+{
+  char buf[6];
+  buf[0] = pi_r.isBlacklisted()	? 'B' : ' ';
+  buf[1] = pi_r.isRetracted()	? 'R' : ' ';
+  buf[2] = pi_r.isPtf()		? 'P' : ' ';
+  buf[3] = pi_r.isPtfMaster()	? 'm' : ' ';
+  buf[4] = pi_r.isPtfPackage()	? 'p' : ' ';
+  buf[5] = '\0';
+  return buf;
+}
+
+std::string blacktag( ui::Selectable::Ptr sel_r )
+{
+  char buf[7];
+  buf[0] = sel_r->hasBlacklisted()		? 'B' : ' ';
+  buf[1] = sel_r->hasBlacklistedInstalled()	? 'b' : ' ';
+  buf[2] = sel_r->hasRetracted()		? 'R' : ' ';
+  buf[3] = sel_r->hasRetractedInstalled()	? 'r' : ' ';
+  buf[4] = sel_r->hasPtf()			? 'P' : ' ';
+  buf[5] = sel_r->hasPtfInstalled()		? 'p' : ' ';
+  buf[6] = '\0';
+  return buf;
+}
+
+BOOST_AUTO_TEST_CASE(BlacklistedPool)
+{
+  testcase_init();
+  ResPoolProxy poolProxy( test.poolProxy() );
+  ui::Selectable::Ptr s( poolProxy.lookup( ResKind::package, "package" ) );
+  BOOST_REQUIRE( s );
+
+  //cout << blacktag(s) << endl;
+  BOOST_CHECK_EQUAL( blacktag(s), "BbRrPp" );
+
+  std::vector<std::string> expect = {
+     "BRPmp"	// I__s_(7)package-5-1.x86_64(@System)
+    ,"     "	// U__s_(2)package-1-1.x86_64(Repo)
+    ,"BRPmp"	// U__s_(6)package-5-1.x86_64(Repo)
+    ,"B P p"	// U__s_(5)package-4-1.x86_64(Repo)
+    ,"B Pm "	// U__s_(4)package-3-1.x86_64(Repo)
+    ,"BR   "	// U__s_(3)package-2-1.x86_64(Repo)
+  };
+  unsigned idx = unsigned(-1);
+  for ( const auto & pi : s->installed() ) {
+    //cout << blacktag(pi) << " " << pi << endl;
+    BOOST_CHECK_EQUAL( blacktag(pi), expect[++idx] );
+  }
+  for ( const auto & pi : s->available() ) {
+    //cout << blacktag(pi) << " " << pi << endl;
+    BOOST_CHECK_EQUAL( blacktag(pi), expect[++idx] );
+  }
+}
+

--- a/tests/sat/CMakeLists.txt
+++ b/tests/sat/CMakeLists.txt
@@ -3,6 +3,7 @@
 INCLUDE_DIRECTORIES( ${LIBZYPP_SOURCE_DIR}/tests/zypp )
 
 ADD_TESTS(
+  Blacklisted
   IdString
   LookupAttr
   Pool

--- a/zypp/sat/Solvable.cc
+++ b/zypp/sat/Solvable.cc
@@ -98,7 +98,8 @@ namespace zypp
     const Solvable Solvable::noSolvable;
 
     const IdString Solvable::retractedToken	{ "retracted-patch-package()" };
-    const IdString Solvable::ptfToken		{ "ptf()" };
+    const IdString Solvable::ptfMasterToken	{ "ptf()" };
+    const IdString Solvable::ptfPackageToken	{ "ptf-package()" };
 
     /////////////////////////////////////////////////////////////////
 
@@ -396,21 +397,35 @@ namespace zypp
       return myPool().isNeedreboot( *this );
     }
 
+    // TODO: Optimize
+    bool Solvable::isBlacklisted() const
+    { return isPtf() || isRetracted(); }
+
     bool Solvable::isRetracted() const
     {
       NO_SOLVABLE_RETURN( false );
       if ( isKind<Package>() )
-	return provides().contains( Capability( retractedToken.id() ) );
+	return myPool().isRetracted( *this );
       if ( isKind<Patch>() )
 	return lookupStrAttribute( SolvAttr::updateStatus ) == "retracted";
       return false;
     }
 
     bool Solvable::isPtf() const
+    { return isPtfPackage() || isPtfMaster(); }
+
+    bool Solvable::isPtfMaster() const
     {
       NO_SOLVABLE_RETURN( false );
-      return provides().contains( Capability( ptfToken.id() ) );
+      return myPool().isPtfMaster( *this );
     }
+
+    bool Solvable::isPtfPackage() const
+    {
+      NO_SOLVABLE_RETURN( false );
+      return myPool().isPtfPackage( *this );
+    }
+
 
     bool Solvable::multiversionInstall() const
     {

--- a/zypp/sat/Solvable.h
+++ b/zypp/sat/Solvable.h
@@ -56,7 +56,8 @@ namespace zypp
       typedef sat::detail::SolvableIdType IdType;
 
       static const IdString retractedToken;	///< Indicator provides `retracted-patch-package()`
-      static const IdString ptfToken;		///< Indicator provides `ptf()`
+      static const IdString ptfMasterToken;	///< Indicator provides `ptf()`
+      static const IdString ptfPackageToken;	///< Indicator provides `ptf-package()`
 
     public:
       /** Default ctor creates \ref noSolvable.*/
@@ -147,11 +148,39 @@ namespace zypp
       /** Whether this solvable triggers the reboot-needed hint if installed/updated. */
       bool isNeedreboot() const;
 
+      /** \name Blacklisted packages.
+       *
+       * Blacklisted packages are visible in a repository, but no matter how good they
+       * apparently look like, they must not be considered during normal operations.
+       *
+       * Under normal conditions the resolver will avoid selecting blacklisted packages.
+       * To install a blacklisted package it must be selected explicitly. Whether this
+       * is a good idea, depends on the reason for having been blacklisted:
+       *
+       * - RETRACTED packages are usually buggy packages/patches which have been released
+       * and can not be removed from the public repositories anymore. Nevertheless those
+       * packages should not be installed.
+       *
+       * - PTFs usually contain special features or fixes which are not yet released as
+       * an official patch upadate. Installing a PTF will prevent it's packages from being
+       * updated until you decide to remove the PTF and follow the official releases again.
+       */
+      //@{
+      /** Whether this solvable is blacklisted (retracted,ptf,...). */
+      bool isBlacklisted() const;
+
       /** Whether this solvable is retracted (provides \ref retractedToken). */
       bool isRetracted() const;
 
-      /** Whether this solvable is a PTF (provides \ref ptfToken). */
+      /** Whether this solvable belongs to a PTF (provides \ref ptfMasterToken or \ref ptfPackageToken). */
       bool isPtf() const;
+
+      /** Subset of \ref isPtf (provides \ref ptfMasterToken). */
+      bool isPtfMaster() const;
+
+      /** Subset of \ref isPtf (provides \ref ptfPackageToken). */
+      bool isPtfPackage() const;
+      //@}
 
       /** The items build time. */
       Date buildtime() const;

--- a/zypp/sat/SolvableSpec.h
+++ b/zypp/sat/SolvableSpec.h
@@ -57,6 +57,13 @@ namespace zypp
       /** A all \ref sat::Solvable matching this \a provides_r. */
       void addProvides( Capability provides_r );
 
+      /** Extend the provides set to include idential installed items as well.
+       * Hack for retracted packages, where the indicator provides is  injected
+       * into the available items, but is not present in the installed items.
+       */
+      bool addIdenticalInstalledToo() const;
+      void addIdenticalInstalledToo( bool yesno_r );
+
     public:
       /** Parse and add spec from a string (`IDENT` or provides:CAPABILITY`). */
       void parse( const C_Str & spec_r );
@@ -95,6 +102,9 @@ namespace zypp
       void setDirty() const;
 
     public:
+      /** Whether neither idents nor provides are set. */
+      bool empty() const;
+
       /** Whether \a ident_r has been added to the specs (mainly for parser tests). */
       bool containsIdent( const IdString & ident_r ) const;
 

--- a/zypp/sat/SolvableType.h
+++ b/zypp/sat/SolvableType.h
@@ -81,8 +81,12 @@ namespace zypp
       bool		identIsAutoInstalled() const		{ return satSolvable().identIsAutoInstalled(); }
       bool		multiversionInstall() const		{ return satSolvable().multiversionInstall(); }
       bool              isNeedreboot() const			{ return satSolvable().isNeedreboot(); }
+
+      bool		isBlacklisted() const			{ return satSolvable().isBlacklisted(); }
       bool		isRetracted() const			{ return satSolvable().isRetracted(); }
       bool		isPtf() const				{ return satSolvable().isPtf(); }
+      bool		isPtfMaster() const			{ return satSolvable().isPtfMaster(); }
+      bool		isPtfPackage() const			{ return satSolvable().isPtfPackage(); }
 
       Date		buildtime() const			{ return satSolvable().buildtime(); }
       Date		installtime() const			{ return satSolvable().installtime(); }

--- a/zypp/sat/detail/PoolImpl.h
+++ b/zypp/sat/detail/PoolImpl.h
@@ -331,6 +331,17 @@ namespace zypp
           //@}
 
 	public:
+	  /** \name Blacklisted Solvables. */
+          //@{
+          bool isRetracted( const Solvable & solv_r ) const
+          { return _retractedSpec.contains( solv_r ); }
+          bool isPtfMaster( const Solvable & solv_r ) const
+          { return _ptfMasterSpec.contains( solv_r ); }
+          bool isPtfPackage( const Solvable & solv_r ) const
+          { return _ptfPackageSpec.contains( solv_r ); }
+          //@}
+
+	public:
 	  /** accessor for etc/sysconfig/storage reading file on demand */
 	  const std::set<std::string> & requiredFilesystems() const;
 
@@ -361,6 +372,11 @@ namespace zypp
 
 	  /** Solvables which should trigger the reboot-needed hint if installed/updated. */
 	  sat::SolvableSpec _needrebootSpec;
+
+	  /** Blacklisted specs: */
+	  sat::SolvableSpec _retractedSpec;
+	  sat::SolvableSpec _ptfMasterSpec;
+	  sat::SolvableSpec _ptfPackageSpec;
 
 	  /** filesystems mentioned in /etc/sysconfig/storage */
 	  mutable scoped_ptr<std::set<std::string> > _requiredFilesystemsPtr;

--- a/zypp/solver/detail/SATResolver.cc
+++ b/zypp/solver/detail/SATResolver.cc
@@ -707,7 +707,9 @@ SATResolver::solverInit(const PoolItemList & weakItems)
       queue_push( &(_jobQueue), SOLVER_BLACKLIST|SOLVER_SOLVABLE_PROVIDES );
       queue_push( &(_jobQueue), sat::Solvable::retractedToken.id() );
       queue_push( &(_jobQueue), SOLVER_BLACKLIST|SOLVER_SOLVABLE_PROVIDES );
-      queue_push( &(_jobQueue), sat::Solvable::ptfToken.id() );
+      queue_push( &(_jobQueue), sat::Solvable::ptfMasterToken.id() );
+      queue_push( &(_jobQueue), SOLVER_BLACKLIST|SOLVER_SOLVABLE_PROVIDES );
+      queue_push( &(_jobQueue), sat::Solvable::ptfPackageToken.id() );
     }
 
     // Ad rules for changed requestedLocales

--- a/zypp/ui/Selectable.cc
+++ b/zypp/ui/Selectable.cc
@@ -172,11 +172,24 @@ namespace zypp
 
     ////////////////////////////////////////////////////////////////////////
 
+    bool Selectable::hasBlacklisted() const
+    { return _pimpl->hasBlacklisted(); }
+
+    bool Selectable::hasBlacklistedInstalled() const
+    { return _pimpl->hasBlacklistedInstalled(); }
+
     bool Selectable::hasRetracted() const
     { return _pimpl->hasRetracted(); }
 
     bool Selectable::hasRetractedInstalled() const
     { return _pimpl->hasRetractedInstalled(); }
+
+    bool Selectable::hasPtf() const
+    { return _pimpl->hasPtf(); }
+
+    bool Selectable::hasPtfInstalled() const
+    { return _pimpl->hasPtfInstalled(); }
+
 
     bool Selectable::isUnmaintained() const
     { return _pimpl->isUnmaintained(); }

--- a/zypp/ui/Selectable.h
+++ b/zypp/ui/Selectable.h
@@ -125,7 +125,7 @@ namespace zypp
       /** The 'best' or 'most interesting' among all available objects.
        * One that is, or is likely to be, chosen for installation, unless
        * it violated any solver policy (see \ref updateCandidateObj).
-       * \note Might return a retracted item if explicitly set by \ref setCandidate
+       * \note Might return a blacklisted item if explicitly set by \ref setCandidate
        * or nothing else available.
        */
       PoolItem candidateObj() const;
@@ -134,7 +134,7 @@ namespace zypp
        * In contrary to \ref candidateObj, this may return no item even if
        * there are available objects. This simply means the \ref Repository
        * does not provide this object.
-       * \note Avoids to return retracted items.
+       * \note Avoids to return blacklisted items.
        */
       PoolItem candidateObjFrom( Repository repo_r ) const;
 
@@ -143,7 +143,7 @@ namespace zypp
        * there are available objects. This simply means the best object is
        * already installed, and all available objects violate at least one
        * update policy.
-       * \note Avoids to return retracted items.
+       * \note Avoids to return blacklisted items.
        */
       PoolItem updateCandidateObj() const;
 
@@ -151,7 +151,7 @@ namespace zypp
        * It's doubtful whether solely looking at the version makes a good
        * candidate, but apps ask for it. Beware that different vendors may
        * use different (uncomparable) version schemata.
-       * \note Avoids to return retracted items.
+       * \note Avoids to return blacklisted items.
        */
       PoolItem highestAvailableVersionObj() const;
 
@@ -326,11 +326,24 @@ namespace zypp
       bool hasCandidateObjOnly() const
       { return ( installedEmpty() ) && candidateObj(); }
 
-      /** True if this Selectable contains a retracted item. */
+
+       /** True if this Selectable contains available blacklisted items (retracted,ptf,...). */
+      bool hasBlacklisted() const;
+
+      /** True if this Selectable contains an installed blacklisted item (retracted,ptf,...). */
+      bool hasBlacklistedInstalled() const;
+
+      /** True if this Selectable contains available retracted items. */
       bool hasRetracted() const;
 
       /** True if this Selectable contains an installed retracted item. */
       bool hasRetractedInstalled() const;
+
+      /** True if this Selectable contains available ptf items. */
+      bool hasPtf() const;
+
+      /** True if this Selectable contains an installed ptf item. */
+      bool hasPtfInstalled() const;
       //@}
 
       /**

--- a/zypp/ui/SelectableTraits.h
+++ b/zypp/ui/SelectableTraits.h
@@ -34,7 +34,7 @@ namespace zypp
     struct SelectableTraits
     {
       /** Oder on AvailableItemSet.
-       * \li not retracted
+       * \li not blacklisted
        * \li repository priority
        * \li best Arch (arch/noarch changes are ok)
        * \li best Edition
@@ -50,8 +50,8 @@ namespace zypp
         //
         bool operator()( const PoolItem & lhs, const PoolItem & rhs ) const
         {
-	  if ( lhs.isRetracted() != rhs.isRetracted() )
-	    return rhs.isRetracted();
+	  if ( lhs.isBlacklisted() != rhs.isBlacklisted() )
+	    return rhs.isBlacklisted();
 
           int lprio = lhs->satSolvable().repository().satInternalPriority();
           int rprio = rhs->satSolvable().repository().satInternalPriority();


### PR DESCRIPTION
[bsc#1186503](https://bugzilla.suse.com/show_bug.cgi?id=1186503). API part is ready. 
Todo:
- [x] Indexing for installed retracted items because the indicator provides here is volatile and not part of the package.