### PR TITLE
Show key fpr from signature when signature check fails (bsc#1187224) 

### DIFF
--- a/tests/zypp/RpmPkgSigCheck_test.cc
+++ b/tests/zypp/RpmPkgSigCheck_test.cc
@@ -165,13 +165,13 @@ BOOST_AUTO_TEST_CASE(signed_pkg_nokey)
   BOOST_CHECK_EQUAL( cp, cs );
 
   CheckResult xpct { RpmDb::CHK_NOKEY, {
-    { RpmDb::CHK_NOKEY,	"    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: NOKEY" },
+    { RpmDb::CHK_NOKEY,	"    Header V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: NOKEY" },
     { RpmDb::CHK_OK,	"    Header SHA1 digest: OK" },
     { RpmDb::CHK_OK,	"    Header SHA256 digest: OK" },
     { RpmDb::CHK_OK,	"    Payload SHA256 digest: OK" },
     { RpmDb::CHK_OK,	"    MD5 digest: OK" },
 #ifdef HAVE_RPMTSSETVFYFLAGS
-    { RpmDb::CHK_NOKEY,	"    V3 RSA/SHA256 Signature, key ID 3dbdc284: NOKEY" },
+    { RpmDb::CHK_NOKEY,	"    V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: NOKEY" },
 #endif
   } };
   BOOST_CHECK_EQUAL( xpct, cs );
@@ -185,13 +185,13 @@ BOOST_AUTO_TEST_CASE(signed_broken_pkg_nokey)
   BOOST_CHECK_EQUAL( cp, cs );
 
   CheckResult xpct { RpmDb::CHK_FAIL, {
-    { RpmDb::CHK_NOKEY,	"    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: NOKEY" },
+    { RpmDb::CHK_NOKEY,	"    Header V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: NOKEY" },
     { RpmDb::CHK_OK,	"    Header SHA1 digest: OK" },
     { RpmDb::CHK_OK,	"    Header SHA256 digest: OK" },
     { RpmDb::CHK_FAIL,	"    Payload SHA256 digest: BAD (Expected 6632dfb6e78fd3346baa860da339acdedf6f019fb1b5448ba1baa6cef67de795 != 85156c232f4c76273bbbb134d8d869e93bbfc845dd0d79016856e5356dd33727)" },
     { RpmDb::CHK_FAIL,	"    MD5 digest: BAD (Expected 8e64684e4d5bd90c3c13f76ecbda9ee2 != 442a473472708c39f3ac2b5eb38b476f)" },
 #ifdef HAVE_RPMTSSETVFYFLAGS
-    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
 #endif
   } };
   BOOST_CHECK_EQUAL( xpct, cs );
@@ -205,13 +205,13 @@ BOOST_AUTO_TEST_CASE(signed_broken_header_pkg_nokey)
   BOOST_CHECK_EQUAL( cp, cs );
 
   CheckResult xpct { RpmDb::CHK_FAIL, {
-    { RpmDb::CHK_FAIL,	"    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    Header V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
     { RpmDb::CHK_FAIL,	"    Header SHA1 digest: BAD (Expected 9ca2e3aec038e562d33442271ee52c08ded0d637 != 95286fd653f927df0a42746e310861d3f89bb75c)" },
     { RpmDb::CHK_FAIL,	"    Header SHA256 digest: BAD (Expected e88100656c8e06b6e4bb9155f0dd111ef8042866941f02b623cb46e12a82f732 != 76b343bcb9b8aaf9998fdcf7392e234944a0b078c67667fa0d658208b9a66983)" },
     { RpmDb::CHK_FAIL,	"    Payload SHA256 digest: BAD (Expected 6632dfb6e78fd3346baa860da339acdedf6f019fb1b5448ba1baa6cef67de795 != 85156c232f4c76273bbbb134d8d869e93bbfc845dd0d79016856e5356dd33727)" },
     { RpmDb::CHK_FAIL,	"    MD5 digest: BAD (Expected 8e64684e4d5bd90c3c13f76ecbda9ee2 != 81df819a7d94638ff3ffe0bb93a7d177)" },
 #ifdef HAVE_RPMTSSETVFYFLAGS
-    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
 #endif
   } };
   BOOST_CHECK_EQUAL( xpct, cs );
@@ -256,13 +256,13 @@ BOOST_AUTO_TEST_CASE(signed_broken_pkg_withkey)
   BOOST_CHECK_EQUAL( cp, cs );
 
   CheckResult xpct { RpmDb::CHK_FAIL, {
-    { RpmDb::CHK_OK,	"    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: OK" },
+    { RpmDb::CHK_OK,	"    Header V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: OK" },
     { RpmDb::CHK_OK,	"    Header SHA1 digest: OK" },
     { RpmDb::CHK_OK,	"    Header SHA256 digest: OK" },
     { RpmDb::CHK_FAIL,	"    Payload SHA256 digest: BAD (Expected 6632dfb6e78fd3346baa860da339acdedf6f019fb1b5448ba1baa6cef67de795 != 85156c232f4c76273bbbb134d8d869e93bbfc845dd0d79016856e5356dd33727)" },
     { RpmDb::CHK_FAIL,	"    MD5 digest: BAD (Expected 8e64684e4d5bd90c3c13f76ecbda9ee2 != 442a473472708c39f3ac2b5eb38b476f)" },
 #ifdef HAVE_RPMTSSETVFYFLAGS
-    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
 #endif
   } };
   BOOST_CHECK_EQUAL( xpct, cs );
@@ -276,13 +276,13 @@ BOOST_AUTO_TEST_CASE(signed_broken_header_pkg_withkey)
   BOOST_CHECK_EQUAL( cp, cs );
 
   CheckResult xpct { RpmDb::CHK_FAIL, {
-    { RpmDb::CHK_FAIL,	"    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    Header V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
     { RpmDb::CHK_FAIL,	"    Header SHA1 digest: BAD (Expected 9ca2e3aec038e562d33442271ee52c08ded0d637 != 95286fd653f927df0a42746e310861d3f89bb75c)" },
     { RpmDb::CHK_FAIL,	"    Header SHA256 digest: BAD (Expected e88100656c8e06b6e4bb9155f0dd111ef8042866941f02b623cb46e12a82f732 != 76b343bcb9b8aaf9998fdcf7392e234944a0b078c67667fa0d658208b9a66983)" },
     { RpmDb::CHK_FAIL,	"    Payload SHA256 digest: BAD (Expected 6632dfb6e78fd3346baa860da339acdedf6f019fb1b5448ba1baa6cef67de795 != 85156c232f4c76273bbbb134d8d869e93bbfc845dd0d79016856e5356dd33727)" },
     { RpmDb::CHK_FAIL,	"    MD5 digest: BAD (Expected 8e64684e4d5bd90c3c13f76ecbda9ee2 != 81df819a7d94638ff3ffe0bb93a7d177)" },
 #ifdef HAVE_RPMTSSETVFYFLAGS
-    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID 3dbdc284: BAD" },
+    { RpmDb::CHK_FAIL,	"    V3 RSA/SHA256 Signature, key ID b88b2fd43dbdc284: BAD" },
 #endif
   } };
   BOOST_CHECK_EQUAL( xpct, cs );

--- a/zypp/KeyManager.h
+++ b/zypp/KeyManager.h
@@ -15,6 +15,7 @@
 #include <zypp/base/PtrTypes.h>
 #include <zypp/Pathname.h>
 #include <zypp/PublicKey.h>
+#include <zypp-core/ByteArray.h>
 
 #include <memory>
 
@@ -70,11 +71,17 @@ class KeyManagerCtx
         /** Tries to import a key from \a keyfile, returns true on success */
         bool importKey(const Pathname & keyfile);
 
+        /** Tries to import a key from \a buffer, returns true on success */
+        bool importKey(const ByteArray & keydata);
+
         /** Tries to delete a key specified by \a id, returns true on success */
         bool deleteKey (const std::string & id);
 
         /** Reads all fingerprints from the \a signature file , returns a list of all found fingerprints */
         std::list<std::string> readSignatureFingerprints(const Pathname & signature);
+
+        /** Reads all fingerprints from the \a buffer, returns a list of all found fingerprints */
+        std::list<std::string> readSignatureFingerprints( const ByteArray & keyData );
 
     private:
       KeyManagerCtx();

--- a/zypp/target/rpm/BinHeader.cc
+++ b/zypp/target/rpm/BinHeader.cc
@@ -342,6 +342,28 @@ int BinHeader::int_val( tag tag_r ) const
   return 0;
 }
 
+ByteArray BinHeader::blob_val( tag tag_r ) const
+{
+  if ( !empty() )
+  {
+    HeaderEntryGetter headerget( _h, tag_r );
+
+    if ( headerget.val() )
+    {
+      switch ( headerget.type() )
+      {
+        case RPM_NULL_TYPE:
+          return {};
+        case RPM_BIN_TYPE:
+          return ByteArray( reinterpret_cast<char *>( headerget.val() ), headerget.cnt() );
+        default:
+          INT << "RPM_TAG MISSMATCH: RPM_BIN_TYPE " << tag_r << " got type " << headerget.type() << endl;
+      }
+    }
+  }
+  return {};
+}
+
 ///////////////////////////////////////////////////////////////////
 //
 //

--- a/zypp/target/rpm/BinHeader.h
+++ b/zypp/target/rpm/BinHeader.h
@@ -26,6 +26,7 @@ extern "C"
 #include <zypp/base/NonCopyable.h>
 #include <zypp/base/PtrTypes.h>
 #include <zypp/target/rpm/librpm.h>
+#include <zypp-core/ByteArray.h>
 
 namespace zypp
 {
@@ -86,6 +87,8 @@ public:
   unsigned string_list( tag tag_r, stringList & lst_r ) const;
 
   int int_val( tag tag_r ) const;
+
+  ByteArray blob_val ( tag tag_r ) const;
 
   std::string string_val( tag tag_r ) const;
   std::string format ( const char * fmt) const;


### PR DESCRIPTION
Rpm by default only shows the short key ID when checking the signature
of a package fails. This patch reads the signatures from the RPM headers
and replaces she short IDs with the key fingerprints fetched from the signatures.