### PR TITLE
Rephrase vendor conflict message in case 2 packages are involved (bsc…

### DIFF
--- a/zypp/solver/detail/SATResolver.cc
+++ b/zypp/solver/detail/SATResolver.cc
@@ -1489,7 +1489,17 @@ SATResolver::problems ()
 				{
                                     IdString s_vendor( s.vendor() );
                                     IdString sd_vendor( sd.vendor() );
-				    std::string description = str::Format(_("install %1% (with vendor change)\n  %2%  -->  %3%") ) % sd.asString() % ( s_vendor ? s_vendor.c_str() : " (no vendor) " ) % ( sd_vendor ? sd_vendor.c_str() : " (no vendor) " );
+				    std::string description;
+				    if ( s == sd )
+				      description = str::Format(_("install %1% (with vendor change)\n  %2%  -->  %3%") )
+				      % sd.asString()
+				      % ( s_vendor ? s_vendor.c_str() : " (no vendor) " )
+				      % ( sd_vendor ? sd_vendor.c_str() : " (no vendor) " );
+				    else
+				      description = str::Format(_("install %1% from vendor %2%\n  replacing %3% from vendor %4%") )
+				      % sd.asString()  % ( sd_vendor ? sd_vendor.c_str() : " (no vendor) " )
+				      % s.asString() % ( s_vendor ? s_vendor.c_str() : " (no vendor) " );
+
 				    MIL << description << endl;
 				    problemSolution->addDescription (description);
 				    gotone = 1;


### PR DESCRIPTION
…#1187760)

This covers the case where not the packages itself would change
its vendor, but replaces a package from a different vendor.