### PR TITLE
multicurl: propagate ssl settings stored in repo url (boo#1127591)

### DIFF
--- a/zypp/media/CurlHelper.cc
+++ b/zypp/media/CurlHelper.cc
@@ -387,9 +387,11 @@ Url clearQueryString(const Url &url)
 }
 
 // bsc#933839: propagate proxy settings passed in the repo URL
+// boo#1127591: propagate ssl settings passed in the repo URL
+//    should "ssl_clientcert" propagate to mirrors as well?
 zypp::Url propagateQueryParams( zypp::Url url_r, const zypp::Url & template_r )
 {
-  for ( std::string param : { "proxy", "proxyport", "proxyuser", "proxypass"} )
+  for ( std::string param : { "proxy", "proxyport", "proxyuser", "proxypass", "ssl_capath", "ssl_verify"} )
   {
     const std::string & value( template_r.getQueryParam( param ) );
     if ( ! value.empty() )


### PR DESCRIPTION
apply logic from 5cabcedf6f5447ac28e3d4155cebd0e951ad8110
to ssl_capath and ssl_verify