### PR TITLE
Fix issues in medianetwork

### DIFF
--- a/zypp/zyppng/media/medianetwork.cc
+++ b/zypp/zyppng/media/medianetwork.cc
@@ -539,6 +539,9 @@ namespace zyppng {
         case NetworkRequestError::NotFound:
           ZYPP_THROW( zypp::media::MediaFileNotFoundException( reqUrl, filename ) );
           break;
+        case NetworkRequestError::ExceededMaxLen:
+          ZYPP_THROW( zypp::media::MediaFileSizeExceededException( reqUrl, 0 ) );
+          break;
         default:
           break;
       }

--- a/zypp/zyppng/media/network/private/downloaderstates/rangedownloader_p.h
+++ b/zypp/zyppng/media/network/private/downloaderstates/rangedownloader_p.h
@@ -78,6 +78,7 @@ namespace zyppng {
     void handleRequestError( std::shared_ptr<Request> req, const zyppng::NetworkRequestError &err );
     bool addBlockRanges( std::shared_ptr<Request> req, std::vector<Block> &&blocks ) const;
     void addNewRequest     (std::shared_ptr<Request> req, const bool connectSignals = true );
+    bool assertExpectedFilesize ( off_t currentFilesize );
 
     std::vector<Block> getNextBlocks ( const std::string &urlScheme );
     std::vector<Block> getNextFailedBlocks( const std::string &urlScheme );


### PR DESCRIPTION
This patch fixes some issues in the downloader and medianetwork code.
Especially with recursive calling of CURL API which is always a bad idea