### PR TITLE
Do not double check signatures and keys (bsc#1190059)

### DIFF
--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1879,7 +1879,13 @@ namespace zypp
       //
       // Because zypp builds the transaction and the resolver asserts that
       // everything is fine, or the user decided to ignore problems.
-      rpm::RpmInstFlags flags( policy_r.rpmInstFlags() | rpm::RPMINST_NODEPS  );
+      rpm::RpmInstFlags flags( policy_r.rpmInstFlags()
+                               | rpm::RPMINST_NODEPS
+                               // skip signature checks, we did that already
+                               | rpm::RPMINST_NODIGEST
+                               | rpm::RPMINST_NOSIGNATURE
+                               // ignore untrusted keys since we already checked those earlier
+                               | rpm::RPMINST_ALLOWUNTRUSTED );
 
       zpt::Commit commit;
       commit.set_flags( flags );

--- a/zypp/target/rpm/RpmFlags.h
+++ b/zypp/target/rpm/RpmFlags.h
@@ -36,20 +36,21 @@ namespace zypp
        */
       enum RpmInstFlag
       {
-        RPMINST_NONE          = 0x0000,
-        RPMINST_EXCLUDEDOCS   = 0x0001,
-        RPMINST_NOSCRIPTS     = 0x0002,
-        RPMINST_FORCE         = 0x0004,
-        RPMINST_NODEPS        = 0x0008,
-        RPMINST_IGNORESIZE    = 0x0010,
-        RPMINST_JUSTDB        = 0x0020,
-        RPMINST_NODIGEST      = 0x0040,
-        RPMINST_NOSIGNATURE   = 0x0080,
-        RPMINST_NOUPGRADE     = 0x0100,
-        RPMINST_TEST          = 0x0200,
-	RPMINST_NOPOSTTRANS   = 0x0400,
-        RPMINST_ALLOWDOWNGRADE= 0x0800,
-        RPMINST_REPLACEFILES  = 0x1000
+        RPMINST_NONE            = 0x0000,
+        RPMINST_EXCLUDEDOCS     = 0x0001,
+        RPMINST_NOSCRIPTS       = 0x0002,
+        RPMINST_FORCE           = 0x0004,
+        RPMINST_NODEPS          = 0x0008,
+        RPMINST_IGNORESIZE      = 0x0010,
+        RPMINST_JUSTDB          = 0x0020,
+        RPMINST_NODIGEST        = 0x0040,
+        RPMINST_NOSIGNATURE     = 0x0080,
+        RPMINST_NOUPGRADE       = 0x0100,
+        RPMINST_TEST            = 0x0200,
+	RPMINST_NOPOSTTRANS     = 0x0400,
+        RPMINST_ALLOWDOWNGRADE  = 0x0800,
+        RPMINST_REPLACEFILES    = 0x1000,
+        RPMINST_ALLOWUNTRUSTED  = 0x2000,
       };
 
       /** \relates RpmInstFlag Type-safe way of storing OR-combinations. */


### PR DESCRIPTION
Since we already check signatures and keys in libzypp there is no need
to check them again in the zypp-rpm backend. This patch adds a new
install flag and disables redundant checks in zypp-rpm.