### PR TITLE
Fix kernel-*-livepatch removal in purge-kernels

### DIFF
--- a/zypp/PurgeKernels.cc
+++ b/zypp/PurgeKernels.cc
@@ -157,7 +157,7 @@ namespace zypp {
     MIL << "Request to remove package: " << pi << std::endl;
 
     //list of packages that are allowed to be removed automatically.
-    const str::regex validRemovals("(kernel-syms(-.*)?|kgraft-patch(-.*)?|kernel-livepatch(-.*)?|.*-kmp(-.*)?)");
+    const str::regex validRemovals("(kernel-syms(-.*)?|kgraft-patch(-.*)?|kernel-(.*)-livepatch(-.*)?|kernel-livepatch(-.*)?|.*-kmp(-.*)?)");
 
     if ( pi.status().isLocked() ) {
       MIL << "Package " << pi << " is locked by the user, not removing." << std::endl;


### PR DESCRIPTION
This change is required for the smooth integration of SLE Live Patching into SLE Micro. The REGEX for kernel-*-livepatch matching might perhaps be improved but I believe that this simple one is enough.