### PR TITLE
Save locks: Update an existing locks changed comment string

### DIFF
--- a/zypp/Locks.cc
+++ b/zypp/Locks.cc
@@ -423,7 +423,7 @@ public:
 bool Locks::Impl::mergeList(callback::SendReport<SavingLocksReport>& report)
 {
   MIL << "merge list old: " << locks().size()
-    << " to add: " << toAdd.size() << "to remove: " << toRemove.size() << endl;
+    << " to add: " << toAdd.size() << " to remove: " << toRemove.size() << endl;
   for_(it,toRemove.begin(),toRemove.end())
   {
     std::set<sat::Solvable> s(it->begin(),it->end());
@@ -433,7 +433,11 @@ bool Locks::Impl::mergeList(callback::SendReport<SavingLocksReport>& report)
   if (!report->progress())
     return false;
 
-  MANIPlocks().insert( toAdd.begin(), toAdd.end() );
+  for ( const auto & q : toAdd ) {
+    const auto & [i,b] { MANIPlocks().insert( q ) };
+    if ( not b &&  i->comment() != q.comment() )
+      i->setComment( q.comment() ); // update comment if query already exists
+  }
 
   toAdd.clear();
   toRemove.clear();

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -455,8 +455,8 @@ namespace zypp
     /** Kinds to search */
     Kinds _kinds;
 
-    /** comments */
-    std::string _comment;
+    /** Optional comment string for serialization. */
+    mutable std::string _comment;
     //@}
 
   public:
@@ -492,6 +492,7 @@ namespace zypp
           && _attrs.size() == 1
           && _attrs.begin()->first == sat::SolvAttr::name ) )
       {
+        // ma: Intentionally a different _comment is not considered.
         return ( _strings == rhs._strings
               && _attrs == rhs._attrs
               && _uncompiledPredicated == rhs._uncompiledPredicated
@@ -870,8 +871,12 @@ namespace zypp
   void PoolQuery::addKind(const ResKind & kind)
   { _pimpl->_kinds.insert(kind); }
 
+  void PoolQuery::setComment(const std::string & comment) const
+  { _pimpl->_comment = comment; }
+#if LEGACY(1722)
   void PoolQuery::setComment(const std::string & comment)
   { _pimpl->_comment = comment; }
+#endif
 
   void PoolQuery::addString(const std::string & value)
   { _pimpl->_strings.insert(value); }
@@ -1476,8 +1481,8 @@ namespace zypp
       str << "complex: "<< it->serialize() << delim;
     }
 
-    str << PoolQueryAttr::commentAttr.asString() << ": "
-        << comment() << delim ;
+    if ( const std::string & c { comment() }; not c.empty() )
+      str << PoolQueryAttr::commentAttr.asString() << ": " << c << delim ;
 
     //separating delim - protection
     str << delim;

--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -159,8 +159,14 @@ namespace zypp
      * only the specified repo will be returned (multiple repos will be ORed).
      */
     void addRepo(const std::string &repoalias);
-    void setComment(const std::string & comment);
 
+    /** Set an optional comment string describing the purpose of the query.
+     * Stored and retrieved when serializing the query. E.g. as lock.
+     */
+    void setComment(const std::string & comment) const;
+#if LEGACY(1722)
+    void setComment(const std::string & comment);
+#endif
 
     /** Installed status filter setters. */
     //@{


### PR DESCRIPTION
A query/lock comment string is nonfunctional, so allow changing it for const objects.  
With this we can easily update changed comment strings of already existing locks when  serializing the locks. If you now re-add an already existing lock with a different comment in zypper the comment is updated.