### PR TITLE
WIP: Store key signatures on public keys

### DIFF
--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -214,12 +214,6 @@ namespace zypp
   public:
     /** Offer default Impl. */
     static shared_ptr<Impl> nullimpl();
-    static Target & target(const Pathname & sysRoot = "/")
-    {
-      if ( ! getZYpp()->getTarget() )
-        getZYpp()->initializeTarget( sysRoot );
-      return *getZYpp()->getTarget();
-    }
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -295,17 +289,10 @@ namespace zypp
   }
 
   bool PublicKeySignatureData::inTrustedRing() const
-  {
-    std::list<PublicKey> allKeys = _pimpl->target().rpmDb().pubkeys();
-    return std::any_of(allKeys.begin(), allKeys.end(), [this](const PublicKey & key) {
-      return key.id() == id();
-    });
-  }
+  { return getZYpp()->keyRing()->isKeyTrusted(id()); }
 
-  bool PublicKeySignatureData::inSeenRing() const
-  {
-    return true;// TODO: locate the "seen" ring and implement this function
-  }
+  bool PublicKeySignatureData::inKnownRing() const
+  { return getZYpp()->keyRing()->isKeyKnown(id()); }
 
   ///////////////////////////////////////////////////////////////////
   /// \class PublicKeyData::Impl

--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -25,6 +25,9 @@
 #include <zypp/base/LogTools.h>
 #include <zypp/Date.h>
 #include <zypp/KeyManager.h>
+#include <zypp/Target.h>
+#include <zypp/target/rpm/RpmDb.h>
+#include <zypp/ZYppFactory.h>
 
 #include <gpgme.h>
 
@@ -197,6 +200,114 @@ namespace zypp
   }
 
   ///////////////////////////////////////////////////////////////////
+  /// \class PublicKeySignatureData::Impl
+  /// \brief  PublicKeySignatureData implementation.
+  ///////////////////////////////////////////////////////////////////
+
+  struct PublicKeySignatureData::Impl
+  {
+    std::string _keyid;
+    std::string _name;
+    Date        _created;
+    Date        _expires;
+
+  public:
+    /** Offer default Impl. */
+    static shared_ptr<Impl> nullimpl();
+    static Target & target(const Pathname & sysRoot = "/")
+    {
+      if ( ! getZYpp()->getTarget() )
+        getZYpp()->initializeTarget( sysRoot );
+      return *getZYpp()->getTarget();
+    }
+
+  private:
+    friend Impl * rwcowClone<Impl>( const Impl * rhs );
+    /** clone for RWCOW_pointer */
+    Impl * clone() const;
+  };
+
+  shared_ptr<zypp::PublicKeySignatureData::Impl> PublicKeySignatureData::Impl::nullimpl()
+  {
+    static shared_ptr<Impl> _nullimpl( new Impl );
+    return _nullimpl;
+  }
+
+  zypp::PublicKeySignatureData::Impl *PublicKeySignatureData::Impl::clone() const
+  {
+    return new Impl( *this );
+  }
+
+  ///////////////////////////////////////////////////////////////////
+  /// class PublicKeySignatureData
+  ///////////////////////////////////////////////////////////////////
+
+  PublicKeySignatureData::PublicKeySignatureData()
+    : _pimpl( Impl::nullimpl() )
+  {}
+
+  PublicKeySignatureData::PublicKeySignatureData(const _gpgme_key_sig *rawKeySignatureData)
+    : _pimpl (new Impl)
+  {
+    _pimpl->_keyid = str::asString(rawKeySignatureData->keyid);
+    _pimpl->_name = str::asString(rawKeySignatureData->uid);
+    _pimpl->_created = zypp::Date(rawKeySignatureData->timestamp);
+    _pimpl->_expires = zypp::Date(rawKeySignatureData->expires);
+  }
+
+  PublicKeySignatureData::~PublicKeySignatureData()
+  {}
+
+  PublicKeySignatureData::operator bool() const
+  { return !_pimpl->_keyid.empty(); }
+
+  std::string PublicKeySignatureData::id() const
+  { return _pimpl->_keyid; }
+
+  std::string PublicKeySignatureData::name() const
+  { return _pimpl->_name; }
+
+  Date PublicKeySignatureData::created() const
+  { return _pimpl->_created; }
+
+  Date PublicKeySignatureData::expires() const
+  { return _pimpl->_expires; }
+
+  bool PublicKeySignatureData::expired() const
+  { return isExpired( _pimpl->_expires ); }
+
+  int PublicKeySignatureData::daysToLive() const
+  { return hasDaysToLive( _pimpl->_expires ); }
+
+  std::string PublicKeySignatureData::asString() const
+  {
+    std::string nameStr;
+    if (!name().empty()) {
+      nameStr = str::Str() << name() << " ";
+    }
+    else {
+      nameStr = "[User ID not found] ";
+    }
+    return str::Str() << nameStr
+                      << id() << " "
+                      << created().printDate()
+                      << " [" << expiresDetail( expires() ) << "]";
+  }
+
+  bool PublicKeySignatureData::inTrustedRing() const
+  {
+    std::list<PublicKey> allKeys = _pimpl->target().rpmDb().pubkeys();
+    return std::any_of(allKeys.begin(), allKeys.end(), [this](const PublicKey & key) {
+      return key.id() == id();
+    });
+  }
+
+  bool PublicKeySignatureData::inSeenRing() const
+  {
+    return true;// TODO: locate the "seen" ring and implement this function
+  }
+
+  ///////////////////////////////////////////////////////////////////
   /// \class PublicKeyData::Impl
   /// \brief  PublicKeyData implementation.
   ///////////////////////////////////////////////////////////////////
@@ -211,6 +322,7 @@ namespace zypp
     Date        _expires;
 
     std::vector<PublicSubkeyData> _subkeys;
+    std::vector<PublicKeySignatureData> _signatures;
 
   public:
     bool hasSubkeyId( const std::string & id_r ) const;
@@ -246,7 +358,7 @@ namespace zypp
 
   shared_ptr<PublicKeyData::Impl> PublicKeyData::Impl::fromGpgmeKey(gpgme_key_t rawData)
   {
-    //gpgpme stores almost nothing in the top level key
+    //gpgme stores almost nothing in the top level key
     //the information we look for is stored in the subkey, where subkey[0]
     //is always the primary key
     gpgme_subkey_t sKey = rawData->subkeys;
@@ -259,6 +371,10 @@ namespace zypp
         // versions of the same key are imported. We take the last signature here,
         // the one GPGME_EXPORT_MODE_MINIMAL will later use in export.
         for ( auto t = rawData->uids->signatures->next; t; t = t->next ) {
+            if (t->keyid != nullptr) {
+              data->_signatures.push_back(PublicKeySignatureData(t));
+            }
+
           if ( t->timestamp > data->_created )
             data->_created = t->timestamp;
         }
@@ -366,6 +482,9 @@ namespace zypp
 
   Iterable<PublicKeyData::SubkeyIterator> PublicKeyData::subkeys() const
   { return makeIterable( &(*_pimpl->_subkeys.begin()), &(*_pimpl->_subkeys.end()) ); }
+
+  Iterable<PublicKeyData::KeySignatureIterator> PublicKeyData::signatures() const
+  { return makeIterable( &(*_pimpl->_signatures.begin()), &(*_pimpl->_signatures.end()) ); }
 
   bool PublicKeyData::providesKey( const std::string & id_r ) const
   {

--- a/zypp/PublicKey.h
+++ b/zypp/PublicKey.h
@@ -171,7 +171,7 @@ namespace zypp
     bool inTrustedRing() const;
 
     /** Whether the key has been seen before. */
-    bool inSeenRing() const;
+    bool inKnownRing() const;
 
     /** Simple string representation.
      * Encodes \ref id, \ref created and \ref expires

--- a/zypp/PublicKey.h
+++ b/zypp/PublicKey.h
@@ -28,6 +28,7 @@
 
 struct _gpgme_key;
 struct _gpgme_subkey;
+struct _gpgme_key_sig;
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
@@ -128,6 +129,72 @@ namespace zypp
   { return str << obj.asString(); }
 
   ///////////////////////////////////////////////////////////////////
+  /// \class PublicKeySignatureData
+  /// \brief Class representing a signature on a GPG Public Key.
+  /// \see \ref PublicKeyData.
+  ///////////////////////////////////////////////////////////////////
+  class PublicKeySignatureData
+  {
+  public:
+    /** Default constructed: empty data. */
+    PublicKeySignatureData();
+
+    ~PublicKeySignatureData();
+
+    /** Whether this contains valid data (not default constructed). */
+    explicit operator bool() const;
+
+  public:
+    /** The key ID of key used to create the signature. */
+    std::string id() const;
+
+    /** The user ID associated with this key, if present. */
+    std::string name() const;
+
+    /** Creation date. */
+    Date created() const;
+
+    /** Expiry date, or \c Date() if the key never expires. */
+    Date expires() const;
+
+    /**  Whether the key has expired. */
+    bool expired() const;
+
+    /** Number of days (24h) until the key expires (or since it expired).
+     * A value of \c 0 means the key will expire within the next 24h.
+     * Negative values indicate the key has expired less than \c N days ago.
+     * For keys without expiration date \c INT_MAX is returned.
+     */
+    int daysToLive() const;
+
+    /** Whether the signature is trusted in rpmdb. */
+    bool inTrustedRing() const;
+
+    /** Whether the key has been seen before. */
+    bool inSeenRing() const;
+
+    /** Simple string representation.
+     * Encodes \ref id, \ref created and \ref expires
+     * \code
+     * 640DB551 2016-04-12 [expires: 2019-04-12]
+     * \endcode
+     */
+    std::string asString() const;
+
+  private:
+    struct Impl;
+    RWCOW_pointer<Impl> _pimpl;
+    friend class PublicKeyData;
+    friend std::ostream & dumpOn( std::ostream & str, const PublicKeyData & obj );
+    PublicKeySignatureData(const _gpgme_key_sig *rawKeySignatureData);
+  };
+  ///////////////////////////////////////////////////////////////////
+
+  /** \relates PublicKeySignatureData Stream output */
+  inline std::ostream & operator<<( std::ostream & str, const PublicKeySignatureData & obj )
+  { return str << obj.asString(); }
+
+  ///////////////////////////////////////////////////////////////////
   /// \class PublicKeyData
   /// \brief Class representing one GPG Public Keys data.
   /// \ref PublicKeyData are provided e.g. by a \ref PublicKey or
@@ -177,7 +244,7 @@ namespace zypp
     int daysToLive() const;
 
     /** * Expiry info in a human readable form.
-     * The exipry daye plus an annotation if the key has expired, or will
+     * The expiry date plus an annotation if the key has expired, or will
      * expire within 90 days.
      * \code
      * (does not expire)
@@ -213,12 +280,16 @@ namespace zypp
 
   public:
     typedef const PublicSubkeyData * SubkeyIterator;
+    typedef const PublicKeySignatureData * KeySignatureIterator;
 
     /** Whether \ref subkeys is not empty. */
     bool hasSubkeys() const;
 
     /** Iterate any subkeys. */
     Iterable<SubkeyIterator> subkeys() const;
+
+    /** Iterate all key signatures. */
+    Iterable<KeySignatureIterator> signatures() const;
 
     /** Whether \a id_r is the \ref id or \ref fingerprint of the primary key or of a subkey.
      * As a convenience also allows to test the 8byte short ID e.g. rpm uses as version.
@@ -230,6 +301,10 @@ namespace zypp
      */
     static bool isSafeKeyId( const std::string & id_r )
     { return id_r.size() >= 16; }
+
+  public:
+    /** Whether \ref signatures is not empty. */
+    bool hasSignatures() const;
 
   public:
     /** Random art fingerprint visualization type (\ref base::DrunkenBishop). */


### PR DESCRIPTION
Add a new struct to hold data for signatures on public keys, and use this struct to store signature data on every PublicKeyData. Provide functions to determine whether a signature is trusted or known.

This work is being done with [zypper issue 348](https://github.com/openSUSE/zypper/issues/348) in mind.

