### PR TITLE
Some enhancements around reporting (traditional rpm and singletrans)

### DIFF
--- a/tools/zypp-NameReqPrv.cc
+++ b/tools/zypp-NameReqPrv.cc
@@ -126,8 +126,8 @@ struct Table
     #define fmtREPO "(%2d)%-*s"
     #define argREPO slv.repository().info().priority(), _maxREPO, slv.repository().name().c_str()
 
-    #define fmtTIME "%10ld"
-    #define argTIME time_t( slv.isSystem() ? slv.installtime() : slv.buildtime() )
+    #define fmtTIME "%s%10ld"
+    #define argTIME  ( slv.isSystem() && slv.installtime() ? "i" : "b" ), time_t( slv.isSystem() && slv.installtime() ? slv.installtime() : slv.buildtime() )
 
     #define fmtVEND "%s"
     #define argVEND slv.vendor().c_str()

--- a/tools/zypp-rpm/main.cc
+++ b/tools/zypp-rpm/main.cc
@@ -73,7 +73,7 @@ bool recvBytes ( int fd, char *buf, size_t n ) {
 }
 
 bool sendBytes ( int fd, const void *buf, size_t n ) {
-  const auto written =  zyppng::eintrSafeCall( ::write, fd, buf, n );
+  const size_t written =  zyppng::eintrSafeCall( ::write, fd, buf, n );
   return written == n;
 }
 

--- a/zypp-core/zyppng/io/asyncdatasource.h
+++ b/zypp-core/zyppng/io/asyncdatasource.h
@@ -59,6 +59,9 @@ namespace zyppng {
     off_t writeData(const char *data, off_t count) override;
     off_t readData(char *buffer, off_t bufsize) override;
     size_t rawBytesAvailable() const override;
+
+  private:
+    using IODevice::open;
   };
 }
 

--- a/zypp/ProgressData.cc
+++ b/zypp/ProgressData.cc
@@ -67,6 +67,7 @@ namespace zypp
     if ( _d->_state == INIT )
     {
       _d->_state = RUN;
+      DBG << str::form( "{#%u|%s} START", numericId(), name().c_str() ) << endl;
     }
     // XXX << str::form( "{#%u|%s}(%lld%s)", numericId(), name().c_str(), _d->_last_val, ( hasRange() ? "%" : "!" ) ) << endl;
 
@@ -85,7 +86,7 @@ namespace zypp
     }
     else if ( _d->_state == END )
     {
-      DBG << str::form( "{#%u|%s}END", numericId(), name().c_str() ) << endl;
+      DBG << str::form( "{#%u|%s} END", numericId(), name().c_str() ) << endl;
     }
 
     return true;	// continue per default

--- a/zypp/ZYppCallbacks.h
+++ b/zypp/ZYppCallbacks.h
@@ -1008,6 +1008,21 @@ namespace zypp
     //@}
   };
 
+  ///////////////////////////////////////////////////////////////////
+  /// \class UserDataJobReport
+  /// \brief \ref JobReport convenience sending this instance of \ref UserData with each message.
+  ///////////////////////////////////////////////////////////////////
+  struct UserDataJobReport : public JobReport::UserData
+  {
+    using JobReport::UserData::UserData;
+
+    bool debug( const std::string & msg_r )     { return JobReport::debug( msg_r, *this ); }
+    bool info( const std::string & msg_r )      { return JobReport::info( msg_r, *this ); }
+    bool warning( const std::string & msg_r )   { return JobReport::warning( msg_r, *this ); }
+    bool error( const std::string & msg_r )     { return JobReport::error( msg_r, *this ); }
+    bool important( const std::string & msg_r ) { return JobReport::important( msg_r, *this ); }
+    bool data( const std::string & msg_r )      { return JobReport::data( msg_r, *this ); }
+  };
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/ZYppCallbacks.h
+++ b/zypp/ZYppCallbacks.h
@@ -669,6 +669,37 @@ namespace zypp
       };
 #endif
 
+      ///////////////////////////////////////////////////////////////////
+      /// \brief Report active throughout the whole rpm transaction.
+      ///
+      /// The report covers events not directly related to an individual
+      /// sub-task. Mostly log lines.
+      /// \todo maybe include the sub-task reports here as well, so it
+      /// becomes the only report needed to follow the transaction.
+      ///////////////////////////////////////////////////////////////////
+      struct SingleTransReport : public callback::ReportBase
+      {
+        /** \c "zypp-rpm/logline" report a line suitable to be written to the screen.
+         * UserData:
+         * \c "line"  : std::reference_wrapper<const std::string>; the line to show
+         * \c "level" : enum class loglevel; rendering hint
+         */
+        static const UserData::ContentType contentLogline;
+        /** Rendering hint for log-lines to show. */
+        enum class loglevel { dbg, msg, war, err, crt };
+        /** Suggested prefix for log-lines to show. */
+        static const char *const loglevelPrefix( loglevel level_r )
+        {
+          switch ( level_r ) {
+            case loglevel::crt:  return "fatal error: ";
+            case loglevel::err:  return "error: ";
+            case loglevel::war:  return "warning: ";
+            case loglevel::msg:  return "";
+            case loglevel::dbg:  return "D: ";
+          }
+        }
+      };
+
       // Generic transaction reports, this is used for verifying and preparing tasks, the name param
       // for the start function defines which report we are looking at
       struct TransactionReportSA : public callback::ReportBase

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1896,7 +1896,8 @@ namespace zypp
 
       bool abort = false;
       zypp::AutoDispose<std::unordered_map<int, ManagedFile>> locCache([]( std::unordered_map<int, ManagedFile> &data ){
-        for ( auto &[key, value] : data ) {
+        for ( auto &[_, value] : data ) {
+          (void)_; // unsused; for older g++ versions
           value.resetDispose();
         }
         data.clear();

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -2141,9 +2141,10 @@ namespace zypp
             if( str::endsWith( l, endOfScriptTag ) ) {
               DBG << "Received end of script tag" << std::endl;
               gotEndOfScript = true;
-              l = l.substr( 0, l.size() - endOfScriptTag.size() );
-              if ( l.size() == 0 )
+              std::string::size_type rawsize { l.size() - endOfScriptTag.size() };
+              if ( not rawsize )
                 return;
+              l = l.substr( 0, rawsize );
             }
 
             sendRpmLineToReport( l );

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -2285,14 +2285,14 @@ namespace zypp
           // read the stdout and forward it to our log
           prog->stdoutDevice()->connectFunc( &zyppng::IODevice::sigReadyRead, [&](){
             while( prog->stdoutDevice()->canReadLine() ) {
-              MIL << "zypp-rpm stdout: " << prog->stdoutDevice()->readLine().asStringView() << std::endl;
+              L_DBG("zypp-rpm") << "zypp-rpm stdout: " << prog->stdoutDevice()->readLine().asStringView(); // no endl! - readLine does not trim
             }
           });
 
           // read the stderr and forward it to our log
           prog->stderrDevice()->connectFunc( &zyppng::IODevice::sigReadyRead, [&](){
             while( prog->stderrDevice()->canReadLine() ) {
-              MIL << "zypp-rpm stderr: " << prog->stderrDevice()->readLine().asStringView() << std::endl;
+              L_ERR("zypp-rpm") << "zypp-rpm stderr: " << prog->stderrDevice()->readLine().asStringView(); // no endl! - readLine does not trim
             }
           });
 

--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -1710,7 +1710,7 @@ void RpmDb::doInstallPackage( const Pathname & filename, RpmInstFlags flags, cal
   cmdout.set( "lineno", lineno );
 
   // LEGACY: collect and forward additional rpm output in finish
-  std::string rpmmsg;				// TODO: immediately forward lines via Callback::report rather than collecting
+  std::string rpmmsg;
   std::vector<std::string> configwarnings;	// TODO: immediately process lines rather than collecting
 
   while ( systemReadLine( line ) )
@@ -1766,7 +1766,10 @@ void RpmDb::doInstallPackage( const Pathname & filename, RpmInstFlags flags, cal
     sstr << "rpm output:" << endl << rpmmsg << endl;
     historylog.comment(sstr.str());
     // TranslatorExplanation the colon is followed by an error message
-    ZYPP_THROW(RpmSubprocessException(_("RPM failed: ") + (rpmmsg.empty() ? error_message : rpmmsg) ));
+    auto excpt { RpmSubprocessException(_("RPM failed: ") + error_message ) };
+    if ( not rpmmsg.empty() )
+      excpt.addHistory( rpmmsg );
+    ZYPP_THROW(std::move(excpt));
   }
   else if ( ! rpmmsg.empty() )
   {
@@ -1777,7 +1780,7 @@ void RpmDb::doInstallPackage( const Pathname & filename, RpmInstFlags flags, cal
     sstr << "Additional rpm output:" << endl << rpmmsg << endl;
     historylog.comment(sstr.str());
 
-    // report additional rpm output in finish
+    // report additional rpm output in finish (LEGACY! Lines are immediately reported as InstallResolvableReport::contentRpmout)
     // TranslatorExplanation Text is followed by a ':'  and the actual output.
     report->finishInfo(str::form( "%s:\n%s\n", _("Additional rpm output"),  rpmmsg.c_str() ));
   }
@@ -1890,7 +1893,7 @@ void RpmDb::doRemovePackage( const std::string & name_r, RpmInstFlags flags, cal
 
 
   // LEGACY: collect and forward additional rpm output in finish
-  std::string rpmmsg;		// TODO: immediately forward lines via Callback::report rather than collecting
+  std::string rpmmsg;
 
   // got no progress from command, so we fake it:
   // 5  - command started
@@ -1922,7 +1925,10 @@ void RpmDb::doRemovePackage( const std::string & name_r, RpmInstFlags flags, cal
     sstr << "rpm output:" << endl << rpmmsg << endl;
     historylog.comment(sstr.str());
     // TranslatorExplanation the colon is followed by an error message
-    ZYPP_THROW(RpmSubprocessException(_("RPM failed: ") + (rpmmsg.empty() ? error_message: rpmmsg) ));
+    auto excpt { RpmSubprocessException(_("RPM failed: ") + error_message ) };
+    if ( not rpmmsg.empty() )
+      excpt.addHistory( rpmmsg );
+    ZYPP_THROW(std::move(excpt));
   }
   else if ( ! rpmmsg.empty() )
   {
@@ -1933,7 +1939,7 @@ void RpmDb::doRemovePackage( const std::string & name_r, RpmInstFlags flags, cal
     sstr << "Additional rpm output:" << endl << rpmmsg << endl;
     historylog.comment(sstr.str());
 
-    // report additional rpm output in finish
+    // report additional rpm output in finish (LEGACY! Lines are immediately reported as RemoveResolvableReport::contentRpmout)
     // TranslatorExplanation Text is followed by a ':'  and the actual output.
     report->finishInfo(str::form( "%s:\n%s\n", _("Additional rpm output"),  rpmmsg.c_str() ));
   }

--- a/zypp/zyppng/media/network/private/downloaderstates/detectmeta_p.h
+++ b/zypp/zyppng/media/network/private/downloaderstates/detectmeta_p.h
@@ -27,7 +27,7 @@ namespace zyppng {
   /*!
    * State implementation for the metalink detection phase,
    * this state issues a HEAD request while setting the magic
-   * "Accept: *\/*, application/metalink+xml, application/metalink4+xml"
+   * "Accept: *\/\*, application/metalink+xml, application/metalink4+xml"
    * header in the request to figure out if a metalink file is available or not.
    *
    * In order to use metalink support the server


### PR DESCRIPTION
A few unrelated commits at the beginning.

Enhanced rpm script output reports to offer output lines immediately. Zypper will be enhanced to show them immediately rather than showing the collected output at the end.

For singetrans a new report is used to propagate the (debug)lines issued from the rpmlog subsystem.  Zypper will be enhanced to show them in addition to sny script output.