### PR TITLE
Fix wrong encoding of iso: URL components (bsc#954813)

### DIFF
--- a/zypp/media/MediaISO.cc
+++ b/zypp/media/MediaISO.cc
@@ -61,31 +61,25 @@ namespace zypp
       if( _filesystem.empty())
         _filesystem = "auto";
 
-      std::string arg;
-      zypp::Url   src;
-      try
+      Url src;
       {
-        // this percent-decodes the query parameter, it must be later encoded
-        // again before used in a Url object
-        arg = _url.getQueryParam("url");
-        if( arg.empty() && _isofile.dirname().absolute())
-        {
-          src = std::string("dir:///");
-          src.setPathName(url::encode(_isofile.dirname().asString(), URL_SAFE_CHARS));
+        const std::string & arg { _url.getQueryParam("url") };
+        if ( arg.empty() ) {
+          src = "dir:/";
+          src.setPathName( _isofile.dirname() );
           _isofile = _isofile.basename();
         }
-        else
-        {
-          src = url::encode(arg, URL_SAFE_CHARS);
+        else try {
+          src = arg;
         }
-      }
-      catch(const zypp::url::UrlException &e)
-      {
-        ZYPP_CAUGHT(e);
-        ERR << "Unable to parse iso filename source media url" << std::endl;
-        MediaBadUrlException ne(_url);
-        ne.remember(e);
-        ZYPP_THROW(ne);
+        catch( const url::UrlException & e )
+        {
+          ZYPP_CAUGHT(e);
+          ERR << "Unable to parse iso filename source media url" << std::endl;
+          MediaBadUrlException ne(_url);
+          ne.remember(e);
+          ZYPP_THROW(ne);
+        }
       }
       if( !src.isValid())
       {


### PR DESCRIPTION
There is no need to fiddle with the encoding. If the iso: URL has a
url= embedded in the query part, the retrieved value must be a valid
- special chars encoded - URL. And if the retrieved iso= filename
contains special chars (spaces,etc.), Url::setPathName will properly
encode them. There should be no need for any manual url::encode call.