### PR TITLE
Fix serializing/deserializing type mismatch in zypp-rpm protocol (bsc#1196925)

### DIFF
--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -2377,7 +2377,7 @@ namespace zypp
         if ( !msgSource->open( messagePipe->readFd ) )
           ZYPP_THROW( target::rpm::RpmSubprocessException( "Failed to open read stream to subprocess" ) );
 
-        size_t pendingMessageSize = 0;
+        zyppng::rpc::HeaderSizeType pendingMessageSize = 0;
         const auto &processMessages = [&] ( ) {
 
           // lambda function that parses the passed message type and checks if the stepId is a valid offset


### PR DESCRIPTION
Deserializing a 32bit value into a 64bit variable is not giving the correct result on big endian architectures. This patch should fix the issues with singletrans on s390