### PR TITLE
Fix possible hang in singletrans mode (bsc#1197134)

### DIFF
--- a/tests/zyppng/io/AsyncDataSource_test.cc
+++ b/tests/zyppng/io/AsyncDataSource_test.cc
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE ( pipe_read_close )
 
   BOOST_REQUIRE( dataSource->open( pipeFds[0] ) );
   BOOST_REQUIRE( dataSource->canRead() );
+  BOOST_REQUIRE( dataSource->readFdOpen() );
 
   dataSource->connectFunc( &zyppng::AsyncDataSource::sigReadyRead, [&](){
     std::cout <<"Got read"<<std::endl;
@@ -48,6 +49,8 @@ BOOST_AUTO_TEST_CASE ( pipe_read_close )
 
   loop->run();
   writer.join();
+
+  BOOST_REQUIRE ( !dataSource->readFdOpen() );
 
   ::close( pipeFds[0] );
   BOOST_REQUIRE_EQUAL( std::string_view( readData.data(), readData.size() ), text );

--- a/zypp-core/zyppng/io/asyncdatasource.cpp
+++ b/zypp-core/zyppng/io/asyncdatasource.cpp
@@ -239,8 +239,8 @@ namespace zyppng {
       gotRR = true;
     }) );
 
-    // we can only wait if we are open for reading
-    while ( canRead() && !gotRR ) {
+    // we can only wait if we are open for reading and still have a valid fd
+    while ( readFdOpen() && canRead() && !gotRR ) {
       int rEvents = 0;
       if ( EventDispatcher::waitForFdEvent( d->_readFd,  AbstractEventSource::Read | AbstractEventSource::Error , rEvents, timeout ) ) {
         //simulate signal from read notifier
@@ -266,5 +266,10 @@ namespace zyppng {
   SignalProxy<void (std::size_t)> AsyncDataSource::sigBytesWritten()
   {
     return d_func()->_sigBytesWritten;
+  }
+
+  bool AsyncDataSource::readFdOpen() const
+  {
+    return ( d_func()->_readNotifier && d_func()->_readFd >= 0 );
   }
 }

--- a/zypp-core/zyppng/io/asyncdatasource.h
+++ b/zypp-core/zyppng/io/asyncdatasource.h
@@ -54,6 +54,11 @@ namespace zyppng {
      */
     SignalProxy< void (std::size_t)> sigBytesWritten ();
 
+    /*!
+     * Returns true as long as the read channel was not closed ( e.g. sigReadFdClosed was emitted )
+     */
+    bool readFdOpen () const;
+
   protected:
     AsyncDataSource (  );
     off_t writeData(const char *data, off_t count) override;

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -2162,7 +2162,7 @@ namespace zypp
           processDataFromScriptFd();
 
           // end of script is always sent by zypp-rpm, we need to wait for it to keep order
-          while ( scriptSource->canRead() && !gotEndOfScript ) {
+          while ( scriptSource->readFdOpen() && scriptSource->canRead() && !gotEndOfScript ) {
             // readyRead will trigger processDataFromScriptFd so no need to call it again
             // we still got nothing, lets wait for more
             scriptSource->waitForReadyRead( 100 );


### PR DESCRIPTION
In cases where librpm would not send a finalize message about a running
transaction step (RPMCALLBACK_*_STOP), zypp-rpm would not finalize the
report by sending the end of script tag. Adding another stop condition to
the wait loop when the communication pipe is closed should fix the
problem.