### PR TITLE
Fix building with GCC 13.

### DIFF
--- a/zypp/base/DrunkenBishop.cc
+++ b/zypp/base/DrunkenBishop.cc
@@ -8,6 +8,7 @@
 \---------------------------------------------------------------------*/
 /** \file	zypp/base/DrunkenBishop.cc
  */
+#include <cstdint>
 #include <iostream>
 //#include <zypp/base/LogTools.h>
 #include <zypp/base/Flags.h>


### PR DESCRIPTION
Resolves:

```
/home/abuild/rpmbuild/BUILD/libzypp-17.30.3/zypp/base/DrunkenBishop.cc:30:18: error: use of enum 'Direction' without previous declaration
30 |       enum class Direction : std::uint8_t       // actually 2 bits
```

Fixes: #396