### PR TITLE
fix: boost::checked_delete(T*) has a different exception specifier

### DIFF
--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -153,7 +153,7 @@ namespace zypp
     explicit ZYpp( const Impl_Ptr & impl_r );
   private:
     /** Deleted via shared_ptr */
-    friend void ::boost::checked_delete<ZYpp>(ZYpp*);	// template<class T> inline void checked_delete(T * x)
+    friend void ::boost::checked_delete<ZYpp>(ZYpp*) BOOST_NOEXCEPT;	// template<class T> inline void checked_delete(T * x)
     /** Dtor */
     ~ZYpp();
   private:


### PR DESCRIPTION
I am using ```boost 1.80``` and it has an issue during the ```make``` process. The issue is below:

```
In file included from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp/ZYppFactory.h:18:0,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp/misc/DefaultLoadSystem.cc:19:
/home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp/ZYpp.h:156:17: error: declaration of ‘void boost::checked_delete(T*) [with T = zypp::ZYpp]’ has a different exception specifier
     friend void ::boost::checked_delete<ZYpp>(ZYpp*); // template<class T> inline void checked_delete(T * x)
                 ^~
In file included from /usr/local/lib/boost/include/boost/smart_ptr/detail/sp_counted_impl.hpp:27:0,
                 from /usr/local/lib/boost/include/boost/smart_ptr/detail/shared_count.hpp:27,
                 from /usr/local/lib/boost/include/boost/smart_ptr/shared_ptr.hpp:17,
                 from /usr/local/lib/boost/include/boost/shared_ptr.hpp:17,
                 from /usr/local/lib/boost/include/boost/format/alt_sstream.hpp:22,
                 from /usr/local/lib/boost/include/boost/format/internals.hpp:24,
                 from /usr/local/lib/boost/include/boost/format.hpp:38,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp-core/base/String.h:21,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp-core/base/Errno.h:18,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp-core/base/Exception.h:22,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp-core/CheckSum.h:19,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp-core/fs/PathInfo.h:32,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp/PathInfo.h:15,
                 from /home/hui-zhi/projects/src/github.com/openSUSE/libzypp/zypp/misc/DefaultLoadSystem.cc:15:
/usr/local/lib/boost/include/boost/core/checked_delete.hpp:31:31: note: from previous declaration ‘void boost::checked_delete(T*) noexcept [with T = zypp::ZYpp’
 template<class T> inline void checked_delete(T * x) BOOST_NOEXCEPT
```
This commit can fix it.