### PR TITLE
Don't do 2 HTTP requests when one is enough

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -183,11 +183,11 @@ IMPL_PTR_TYPE(MediaSetAccess);
   {
     try
     {
-      if ( doesFileExist( file, media_nr ) )
-        return provideFile( OnMediaLocation( file, media_nr ), PROVIDE_NON_INTERACTIVE );
+      // handle not-found condition via MediaFileNotFoundException
+      return provideFile( OnMediaLocation( file, media_nr ), PROVIDE_NON_INTERACTIVE );
     }
     catch ( const media::MediaFileNotFoundException & excpt_r )
-    { ZYPP_CAUGHT( excpt_r ); }
+    { ZYPP_CAUGHT( excpt_r ); } // ignore not found for optional file
     catch ( const media::MediaForbiddenException & excpt_r )
     { ZYPP_CAUGHT( excpt_r ); }
     catch ( const media::MediaNotAFileException & excpt_r )


### PR DESCRIPTION
improves time of zypper ref from 10.7 to 9.4s
and even more on high-latency connections

TODO: test handling if the file does not exist