### PR TITLE
Add a simple version of MediaNetwork using less connections and supporting zsync

### DIFF
--- a/doc/autodoc/CMakeLists.txt
+++ b/doc/autodoc/CMakeLists.txt
@@ -12,7 +12,9 @@ ENDIF ( NOT DOT )
 
 SET( ZYPP_PROJECT_ROOT   ${LIBZYPP_SOURCE_DIR} )
 SET( ZYPP_SOURCE_DIR     ${LIBZYPP_SOURCE_DIR}/zypp )
-SET( ZYPP_CORE_SOURCE_DIR     ${LIBZYPP_SOURCE_DIR}/zypp-core )
+SET( ZYPP_CORE_SOURCE_DIR   ${LIBZYPP_SOURCE_DIR}/zypp-core )
+SET( ZYPP_MEDIA_SOURCE_DIR  ${LIBZYPP_SOURCE_DIR}/zypp-media)
+SET( ZYPP_CURL_SOURCE_DIR   ${LIBZYPP_SOURCE_DIR}/zypp-curl )
 SET( ZYPP_DOCINCLUDE_DIR ${LIBZYPP_SOURCE_DIR}/doc/autoinclude )
 SET( ZYPP_EXAMPLE_DIR    ${LIBZYPP_SOURCE_DIR}/examples )
 
@@ -65,4 +67,3 @@ INSTALL( DIRECTORY
 ### ##################################################
 ENDIF ( DOXYGEN )
 ### ##################################################
-

--- a/doc/autodoc/Doxyfile.cmake
+++ b/doc/autodoc/Doxyfile.cmake
@@ -69,7 +69,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @ZYPP_DOCINCLUDE_DIR@ @ZYPP_SOURCE_DIR@ @ZYPP_CORE_SOURCE_DIR@
+INPUT                  = @ZYPP_DOCINCLUDE_DIR@ @ZYPP_SOURCE_DIR@ @ZYPP_CORE_SOURCE_DIR@ @ZYPP_MEDIA_SOURCE_DIR@ @ZYPP_CURL_SOURCE_DIR@
 FILE_PATTERNS          = *.h *.hh *.hxx *.hpp *.h++ *.c *.cc *.cxx *.cpp *.c++ *.tcc *.hcc *.doc
 RECURSIVE              = YES
 EXCLUDE                =
@@ -118,6 +118,7 @@ DISABLE_INDEX          = NO
 ENUM_VALUES_PER_LINE   = 4
 GENERATE_TREEVIEW      = YES
 TREEVIEW_WIDTH         = 250
+USE_MATHJAX            = YES
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output
 #---------------------------------------------------------------------------

--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -82,6 +82,11 @@ BuildRequires:  boost-devel
 %endif
 BuildRequires:  dejagnu
 BuildRequires:  doxygen
+BuildRequires:  texlive-latex
+BuildRequires:  texlive-xcolor
+BuildRequires:  texlive-newunicodechar
+BuildRequires:  texlive-dvips
+BuildRequires:  ghostscript
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel
 BuildRequires:  graphviz

--- a/tests/media/metalink/metalink.dockerfile
+++ b/tests/media/metalink/metalink.dockerfile
@@ -1,0 +1,38 @@
+FROM opensuse/leap:15.4
+ENV container docker
+
+ENV LANG en_US.UTF-8
+
+RUN zypper ar -f http://download.opensuse.org/repositories/openSUSE:infrastructure:MirrorCache/15.4 mc
+RUN zypper --gpg-auto-import-keys ref
+
+# install MirrorCache here to fetch all dependencies
+RUN zypper -vvv -n install MirrorCache \
+    vim postgresql postgresql-server curl sudo git-core wget tar m4 make \
+    perl-Digest-MD4 tidy perl-DateTime-HiRes \
+    perl-Inline-C gcc # dependencies for hashes calculation
+
+WORKDIR /opt/project
+ENV TZ UTC
+
+# let pg initialize data dir in cache to save some time on every run
+RUN sudo -u postgres /usr/share/postgresql/postgresql-script start && \
+     sudo -u postgres createuser mirrorcache && \
+     sudo -u postgres createdb mirrorcache && \
+     sudo -u postgres /usr/share/postgresql/postgresql-script stop
+
+COPY testfile /opt/project/testfile
+
+ENV MIRRORCACHE_ROOT=/opt/project \
+    MIRRORCACHE_PERMANENT_JOBS='' \
+    MIRRORCACHE_HASHES_QUEUE=default \
+    MIRRORCACHE_HASHES_COLLECT=1
+
+RUN echo 100 # change this number to invalidate docker cache
+
+RUN sudo -u postgres /usr/share/postgresql/postgresql-script start && \
+    sudo -u mirrorcache -E /usr/share/mirrorcache/script/mirrorcache minion job -e folder_sync -a '["/"]' && \
+    sudo -u mirrorcache -E /usr/share/mirrorcache/script/mirrorcache backstage run --oneshot && \
+    ( sudo -u mirrorcache -E /usr/share/mirrorcache/script/mirrorcache daemon & ) && \
+    sleep 5 && \
+    curl -is 127.0.0.1:3000/download/testfile.meta4

--- a/tests/zyppng/media/EvDownloader_test.cc
+++ b/tests/zyppng/media/EvDownloader_test.cc
@@ -266,8 +266,8 @@ std::vector< MirrorSet > generateMirr ()
   res.back().filename = "primary.xml.zck";
   res.back().dlTotal = 274638;
   res.back().expectSuccess = true;
-  res.back().expectedHandlerDownloads  = 2; // query if metalink avail + dl metalink
-  res.back().expectedFileDownloads  = 6; // Zck Head + 5 Chunks ( chunk size is at least 4K but is likely a few bytes bigger )
+  res.back().expectedHandlerDownloads  = 3; // query if metalink avail + dl metalink + dl zck head because request is reused
+  res.back().expectedFileDownloads  = 5; // 5 Chunks ( chunk size is at least 4K but is likely a few bytes bigger )
   res.back().expectedStates = { zyppng::Download::InitialState, zyppng::Download::DetectMetaLink, zyppng::Download::DlMetaLinkInfo, zyppng::Download::PrepareMulti, zyppng::Download::DlZChunkHead, zyppng::Download::DlZChunk, zyppng::Download::Finished};
   res.back().headerChecksum = zypp::CheckSum( zypp::Digest::sha256(), "90a1a1b99ba3b6c8ae9f14b0c8b8c43141c69ec3388bfa3b9915fbeea03926b7");
   res.back().headerSize     = 11717;

--- a/tools/CalculateReusableBlocks.cc
+++ b/tools/CalculateReusableBlocks.cc
@@ -1,6 +1,6 @@
 #include <zypp-curl/parser/MediaBlockList>
 #include <zypp-curl/parser/MetaLinkParser>
-#include <zypp/media/ZsyncParser.h>
+#include <zypp-curl/parser/ZsyncParser>
 #include <zypp-core/Pathname.h>
 #include <zypp-core/fs/PathInfo.h>
 #include <zypp-core/fs/TmpPath.h>
@@ -71,7 +71,7 @@ int main ( int argc, char *argv[] )
 
   std::cout << "Blocks parsed from Metalink file: " << numBlocksBefore << std::endl;
   if ( numBlocksBefore ) {
-    zypp::AutoFILE f( fopen( file.path().c_str(), "w"));
+    zypp::AutoFILE f( fopen( "Out.test.gz", "w"));
     if ( *f ) {
       blocks.reuseBlocks( *f, deltaFile.asString() );
     }

--- a/tools/CalculateReusableBlocks.cc
+++ b/tools/CalculateReusableBlocks.cc
@@ -1,0 +1,86 @@
+#include <zypp-curl/parser/MediaBlockList>
+#include <zypp-curl/parser/MetaLinkParser>
+#include <zypp/media/ZsyncParser.h>
+#include <zypp-core/Pathname.h>
+#include <zypp-core/fs/PathInfo.h>
+#include <zypp-core/fs/TmpPath.h>
+#include <zypp-core/base/String.h>
+#include <iostream>
+#include <algorithm>
+
+int main ( int argc, char *argv[] )
+{
+  if ( argc < 3 ) {
+    std::cerr << "Usage: CalculateReusebleBlocks <metalinkfile> <deltafile>" << std::endl;
+    return 1;
+  }
+
+  constexpr auto checkFileAccessible = []( const zypp::Pathname &path ){
+    zypp::PathInfo pi( path );
+    return ( pi.isExist() && pi.isFile() && pi.userMayR() );
+  };
+
+  zypp::Pathname metaLink( zypp::str::asString(argv[1]) );
+  zypp::Pathname deltaFile( zypp::str::asString(argv[2]) );
+
+  if ( !checkFileAccessible(metaLink) ) {
+    std::cerr << "Metalink file at " << metaLink << " not accessible" << std::endl;
+    return 1;
+  }
+
+  if ( !checkFileAccessible(deltaFile) ) {
+    std::cerr << "Deltafile file at " << deltaFile << " not accessible" << std::endl;
+    return 1;
+  }
+
+  zypp::media::MediaBlockList blocks;
+  if ( zypp::str::hasSuffix( metaLink.asString(), "zsync") )  {
+      zypp::media::ZsyncParser parser;
+      try {
+        parser.parse( metaLink.asString() );
+        blocks = parser.getBlockList();
+      } catch (const zypp::Exception& e) {
+        std::cerr << "Failed to parse Metalink file: " << e << std::endl;
+        return 1;
+      } catch ( const std::exception &e ) {
+        std::cerr << "Failed to parse Metalink file: " << e.what() << std::endl;
+        return 1;
+      }
+  } else {
+    zypp::media::MetaLinkParser parser;
+    try {
+      parser.parse( metaLink );
+      blocks = parser.getBlockList();
+    } catch(const zypp::Exception& e) {
+      std::cerr << "Failed to parse Metalink file: " << e << std::endl;
+      return 1;
+    }
+  }
+
+  constexpr auto getDownloadSize = []( const zypp::media::MediaBlockList &blocks ){
+    size_t size = 0;
+    for ( size_t i = 0; i < blocks.numBlocks(); i++ ) {
+      size += blocks.getBlock(i).size;
+    }
+    return size;
+  };
+
+  zypp::filesystem::TmpFile file;
+  const auto numBlocksBefore = blocks.numBlocks();
+  const zypp::ByteCount sizeBefore = getDownloadSize(blocks);
+
+  std::cout << "Blocks parsed from Metalink file: " << numBlocksBefore << std::endl;
+  if ( numBlocksBefore ) {
+    zypp::AutoFILE f( fopen( file.path().c_str(), "w"));
+    if ( *f ) {
+      blocks.reuseBlocks( *f, deltaFile.asString() );
+    }
+  }
+
+  const size_t numBlocksAfter = blocks.numBlocks();
+  const zypp::ByteCount sizeAfter = getDownloadSize(blocks);
+
+  std::cout << "Finished, reused " << ( numBlocksBefore - numBlocksAfter ) << " of " << numBlocksBefore << " blocks." << std::endl;
+  std::cout << "Need to download " << sizeAfter << " of " << sizeBefore << std::endl;
+  return 0;
+}

--- a/tools/DownloadFiles.cc
+++ b/tools/DownloadFiles.cc
@@ -1,0 +1,239 @@
+﻿// A small tool to test the downloader backend in zypp
+// takes a yaml file as first argument that has a list of downloadable files and possible deltafiles to
+// use when requesting the file:
+// - url: "https://dlmirror.foo/file1"
+//   delta: "/path/to/delta1"
+// - url: "https://dlmirror.foo/file2"
+//   delta: "/path/to/file2"
+
+
+#include <zypp/MediaSetAccess.h>
+#include <zypp/ZYppCallbacks.h>
+#include <zypp-core/ManagedFile.h>
+#include <zypp-core/fs/TmpPath.h>
+#include <yaml-cpp/yaml.h>
+
+#include <boost/program_options.hpp>
+#include <boost/progress.hpp>
+#include <iostream>
+
+namespace po = boost::program_options;
+
+struct DLEntry {
+  zypp::Url _url;
+  zypp::Pathname _deltaFile;
+};
+
+// progress for downloading a file
+struct DownloadProgressReportReceiver : public zypp::callback::ReceiveReport<zypp::media::DownloadProgressReport>
+{
+  DownloadProgressReportReceiver()
+  {
+    connect();
+  }
+
+  virtual void start( const zypp::Url & uri, zypp::Pathname localfile )
+  {
+    assert(!_display);
+    std::cout << "Starting download of: " << uri << " to " << localfile << std::endl;
+    _display = std::make_unique<boost::progress_display>( 100 );
+  }
+
+  virtual bool progress(int value, const zypp::Url & uri, double drate_avg, double drate_now)
+  {
+    auto increase = value - _display->count();
+    if ( increase > 0 && ( increase + _display->count() ) <= _display->expected_count() ) {
+      (*_display) += increase;
+    }
+    return true;
+  }
+
+  virtual DownloadProgressReport::Action
+  problem( const zypp::Url & uri, DownloadProgressReport::Error error, const std::string & description )
+  {
+    std::cerr << "Problem while downloading file " << description << std::endl;
+    return DownloadProgressReport::ABORT;
+  }
+
+  // used only to finish, errors will be reported in media change callback (libzypp 3.20.0)
+  virtual void finish( const zypp::Url & uri, Error error, const std::string & konreason )
+  {
+    _display.reset();
+    std::cout << std::endl;
+  }
+
+private:
+  std::unique_ptr<boost::progress_display> _display;
+};
+
+
+
+int main ( int argc, char *argv[] )
+{
+  // force the use of the new downloader code
+  setenv("ZYPP_MEDIANETWORK", "1", 1);
+
+  auto appname = zypp::Pathname::basename( argv[0] );
+  po::positional_options_description p;
+  p.add("control-file", 1);
+
+  po::options_description visibleOptions("Allowed options");
+  visibleOptions.add_options()
+    ("help", "produce help message")
+    ("mediabackend" , po::value<std::string>()->default_value("legacy"), "Select the mediabackend to use, possible options: legacy, provider")
+    ("target-dir"   , po::value<std::string>()->default_value("."), "Directory where to download the files to." );
+
+  po::options_description positionalOpts;
+  positionalOpts.add_options ()
+    ("control-file" , po::value<std::string>(), "Control file to read the urls from" );
+
+  po::options_description cmdline_options;
+  cmdline_options.add(visibleOptions).add(positionalOpts);
+
+  const auto &usage = [&](){
+    std::cerr << "Usage: " << appname << " [OPTIONS] <control-file>" << std::endl;
+    std::cerr << visibleOptions << std::endl;
+  };
+
+  po::variables_map vm;
+
+  try {
+    po::store(po::command_line_parser(argc, argv).
+               options(cmdline_options).positional(p).run(), vm);
+    po::notify(vm);
+  } catch ( const po::error & e ) {
+    std::cerr << e.what () << std::endl;
+    usage();
+  }
+
+  if ( vm.count ("help") ) {
+    usage();
+    return 0;
+  }
+
+  if ( !vm.count("control-file") ) {
+    std::cerr << "Missing the required control-file argument.\n" << std::endl;
+    usage();
+    return 1;
+  }
+
+  const auto &cFInfo = zypp::PathInfo( vm["control-file"].as<std::string>());
+  if ( !cFInfo.isExist() || !cFInfo.userMayR() ) {
+    std::cerr << "Control file " << cFInfo.path () << " is not accessible" << std::endl;
+    usage();
+    return 1;
+  }
+
+  if ( !vm.count("mediabackend")
+       || ( vm["mediabackend"].as<std::string>() != "legacy" && vm["mediabackend"].as<std::string>() != "provider" ) ) {
+    std::cerr << "Invalid value given for mediabackend option: " << vm["mediabackend"].as<std::string>() <<".\n";
+    usage();
+    return 1;
+  }
+
+  if ( !vm.count("target-dir") ) {
+    std::cerr << "Targetdir not initialized, this is a bug.\n" << std::endl;
+    usage();
+    return 1;
+  }
+
+  const zypp::PathInfo targetDir( vm["target-dir"].as<std::string>() );
+  if ( !targetDir.isDir() || !targetDir.userMayRWX() ) {
+    std::cerr << "Target directory is not accessible." << std::endl;
+    usage();
+    return 1;
+  }
+
+  constexpr auto makeError = [] ( const std::string &str ) {
+    std::cerr << str << std::endl;
+    return 1;
+  };
+
+  std::vector<DLEntry> entries;
+
+  YAML::Node control;
+  try {
+    control = YAML::LoadFile( cFInfo.path().asString() );
+
+    if ( control.Type() != YAML::NodeType::Sequence )
+      return makeError("Root node must be of type Sequence.");
+
+    for ( const auto &dlFile : control ) {
+      const auto &url = dlFile["url"];
+      if ( !url ) {
+        return makeError("Each element in the control sequence needs a \"url\" field.");
+      }
+      if ( url.Type() != YAML::NodeType::Scalar )
+        return makeError("Field 'url' must be a scalar.");
+
+      zypp::Url dlUrl( url.as<std::string> () );
+      zypp::Pathname deltaFile;
+
+      const auto &delta = dlFile["delta"];
+      if ( delta ) {
+        if ( delta.Type() != YAML::NodeType::Scalar )
+          return makeError("Field 'delta' must be a scalar.");
+
+        deltaFile = zypp::Pathname( delta.as<std::string>() );
+      }
+
+      entries.push_back ( { std::move(dlUrl), std::move(deltaFile) } );
+    }
+  } catch ( YAML::Exception &e ) {
+    std::cerr << "YAML exception: " << e.what() << std::endl;
+    return 1;
+  } catch ( ... )  {
+    std::cerr << "Unknown error when parsing the control file" << std::endl;
+    return 1;
+  }
+
+  std::vector< zypp::ManagedFile > files;
+
+  std::cout << "Using yaml: " << cFInfo.path() << "\n"
+            << "Downloading to: " << targetDir.path ().realpath ()<< "\n"
+            << "Using backend: " << vm["mediabackend"].as<std::string>() << "\n"
+            << "Nr of downloads: " << entries.size() << "\n" << std::endl;
+
+  if ( vm["mediabackend"].as<std::string>() == "provider" ) {
+    std::cerr << "The provider support is not yet implemented, please try again later." << std::endl;
+    return 1;
+  }
+
+
+  DownloadProgressReportReceiver receiver;
+
+  if ( entries.size() ) {
+    for ( const auto &e : entries ) {
+      try {
+
+        zypp::Url url(e._url);
+        zypp::Pathname path(url.getPathName());
+
+        url.setPathName ("/");
+        zypp::MediaSetAccess access(url);
+
+        zypp::ManagedFile locFile( targetDir.path().realpath() / path.dirname(), zypp::filesystem::unlink );
+        zypp::filesystem::assert_dir( locFile->dirname() );
+
+        auto file = access.provideFile(
+          zypp::OnMediaLocation(path, 1)
+            .setOptional  ( false )
+            .setDeltafile ( e._deltaFile ));
+
+        //prevent the file from being deleted when MediaSetAccess gets out of scope
+        if ( zypp::filesystem::hardlinkCopy(file, locFile) != 0 )
+          ZYPP_THROW( zypp::Exception("Can't copy file from " + file.asString() + " to " +  locFile->asString() ));
+
+        std::cout << "File downloaded: " << e._url << std::endl;
+        files.push_back ( locFile );
+
+      } catch ( const zypp::Exception &e ) {
+        std::cerr << "Failed to download file: " << e << std::endl;
+      }
+    }
+  }
+
+  //std::cout << "Done, press any key to continue" << std::endl;
+  //getchar();
+  return 0;
+}

--- a/tools/zypp-media-http/networkprovider.cc
+++ b/tools/zypp-media-http/networkprovider.cc
@@ -417,6 +417,7 @@ void NetworkProvider::itemFinished( NetworkProvideItemRef item )
     switch( error.type() ) {
       case zyppng::NetworkRequestError::NoError: { throw std::runtime_error("DownloadError info broken"); break;}
       case zyppng::NetworkRequestError::InternalError: { errCode = zyppng::ProvideMessage::Code::InternalError; break;}
+      case zyppng::NetworkRequestError::RangeFail: { errCode = zyppng::ProvideMessage::Code::InternalError; break;}
       case zyppng::NetworkRequestError::Cancelled: { errCode = zyppng::ProvideMessage::Code::Cancelled; break;}
       case zyppng::NetworkRequestError::PeerCertificateInvalid: { errCode = zyppng::ProvideMessage::Code::PeerCertificateInvalid; break;}
       case zyppng::NetworkRequestError::ConnectionFailed: { errCode = zyppng::ProvideMessage::Code::ConnectionFailed; break;}

--- a/zypp-core/Digest.cc
+++ b/zypp-core/Digest.cc
@@ -63,6 +63,7 @@ namespace zypp {
         const EVP_MD *md;
         unsigned char md_value[EVP_MAX_MD_SIZE];
         unsigned md_len;
+        zypp::ByteCount bytesHashed;
 
         bool finalized : 1;
         static bool openssl_digests_added;
@@ -120,6 +121,8 @@ namespace zypp {
         md_len = 0;
         ::memset(md_value, 0, sizeof(md_value));
 
+        bytesHashed = 0;
+
         mdctx.swap(tmp_mdctx);
       }
       return true;
@@ -169,6 +172,7 @@ namespace zypp {
       if(!EVP_DigestInit_ex(_dp->mdctx.get(), _dp->md, NULL))
         return false;
       _dp->finalized = false;
+      _dp->bytesHashed = 0;
       return true;
     }
 
@@ -265,6 +269,7 @@ namespace zypp {
       if(!EVP_DigestUpdate(_dp->mdctx.get(), reinterpret_cast<const unsigned char*>(bytes), len))
         return false;
 
+      _dp->bytesHashed += len;
       return true;
     }
 
@@ -285,6 +290,11 @@ namespace zypp {
       }
 
       return true;
+    }
+
+    ByteCount Digest::bytesHashed() const
+    {
+      return _dp->bytesHashed;
     }
 
     std::string Digest::digest(const std::string& name, std::istream& is, size_t bufsize)

--- a/zypp-core/Digest.h
+++ b/zypp-core/Digest.h
@@ -21,6 +21,7 @@
 
 #include <zypp-core/Pathname.h>
 #include <zypp-core/ByteArray.h>
+#include <zypp-core/ByteCount.h>
 
 namespace zypp {
 
@@ -95,6 +96,11 @@ namespace zypp {
          * @return whether an error occured
          * */
         bool update(std::istream& is, size_t bufsize = 4096);
+
+        /**
+         * Returns the number of input bytes that have been added to the hash
+         */
+        zypp::ByteCount bytesHashed () const;
 
         /** \brief get hex string representation of the digest
          *

--- a/zypp-core/base/StringV.h
+++ b/zypp-core/base/StringV.h
@@ -90,6 +90,14 @@ namespace zypp
     inline std::string_view trim( std::string_view str_r, TrimFlag trim_r )
     { return trim( std::move(str_r), blank, std::move(trim_r) ); }
 
+    /** Return whether \a str_r has prefix \a prefix_r. */
+    inline bool hasPrefix( std::string_view str_r, std::string_view prefix_r )
+    { return( ::strncmp( str_r.data(), prefix_r.data(), prefix_r.size() ) == 0 ); }
+
+    /** \overload Case insensitive */
+    inline bool hasPrefixCI( std::string_view str_r, std::string_view prefix_r  )
+    { return( ::strncasecmp( str_r.data(), prefix_r.data(), prefix_r.size()  ) == 0 ); }
+
     ///////////////////////////////////////////////////////////////////
     namespace detail
     {

--- a/zypp-core/zyppng/base/eventdispatcher.h
+++ b/zypp-core/zyppng/base/eventdispatcher.h
@@ -25,9 +25,8 @@ namespace zyppng {
 
 class SocketNotifier;
 class Timer;
-class EventDispatcher;
 
-
+ZYPP_FWD_DECL_TYPE_WITH_REFS( EventDispatcher );
 class EventDispatcherPrivate;
 
 /*!

--- a/zypp-core/zyppng/core/string.h
+++ b/zypp-core/zyppng/core/string.h
@@ -42,8 +42,12 @@ namespace str {
       typename T::size_type p = ret.find_first_not_of( " \t\r\n" );
       if ( p == T::npos )
       {
-        ret.clear();
-        return ret;
+        if constexpr ( std::is_same_v<std::string_view, StrType> )
+          return T();
+        else {
+          ret.clear();
+          return ret;
+        }
       }
       ret.remove_prefix( p );
     }
@@ -53,8 +57,12 @@ namespace str {
       typename T::size_type p = ret.find_last_not_of( " \t\r\n" );
       if ( p == T::npos )
       {
-        ret.clear();
-        return ret;
+        if constexpr ( std::is_same_v<std::string_view, StrType> )
+          return T();
+        else {
+          ret.clear();
+          return ret;
+        }
       }
       ret.remove_suffix( ret.size() - ( p+1 ) );
     }

--- a/zypp-curl/CMakeLists.txt
+++ b/zypp-curl/CMakeLists.txt
@@ -131,14 +131,17 @@ SET( zypp_curl_parser_HEADERS
   parser/mediablocklist.h
   parser/MetaLinkParser
   parser/metalinkparser.h
+  parser/ZsyncParser
+  parser/zsyncparser.h
 )
 
 SET( zypp_curl_parser_private_HEADERS
 )
 
 SET( zypp_curl_parser_SRCS
-  parser/mediablocklist.cc
+  parser/mediablocklist.cc  
   parser/metalinkparser.cc
+  parser/zsyncparser.cc
 )
 
 INSTALL(  FILES ${zypp_curl_parser_HEADERS} DESTINATION "${INCLUDE_INSTALL_DIR}/zypp-curl/parser" )

--- a/zypp-curl/ng/network/downloader.h
+++ b/zypp-curl/ng/network/downloader.h
@@ -24,6 +24,9 @@ namespace zyppng {
 
   using TransferSettings = zypp::media::TransferSettings;
 
+  ZYPP_FWD_DECL_TYPE_WITH_REFS( Downloader );
+  ZYPP_FWD_DECL_TYPE_WITH_REFS( Download );
+
 
   /**
    * @brief The Downloader class
@@ -37,8 +40,8 @@ namespace zyppng {
     ZYPP_DECLARE_PRIVATE( Downloader )
   public:
 
-    using Ptr = std::shared_ptr<Downloader>;
-    using WeakPtr = std::shared_ptr<Downloader>;
+    using Ptr = DownloaderRef;
+    using WeakPtr = DownloaderWeakRef;
 
     Downloader();
     Downloader( std::shared_ptr<MirrorControl> mc );
@@ -126,8 +129,8 @@ namespace zyppng {
 
   public:
 
-    using Ptr = std::shared_ptr<Download>;
-    using WeakPtr = std::shared_ptr<Download>;
+    using Ptr = DownloadRef;
+    using WeakPtr = DownloadWeakRef;
 
     /*!
      * The states of the internal state machine. Each of them represents a different

--- a/zypp-curl/ng/network/downloadspec.cc
+++ b/zypp-curl/ng/network/downloadspec.cc
@@ -30,7 +30,7 @@ namespace zyppng {
     bool _metalink_enabled   = true;  //< should the download try to use metalinks
     zypp::ByteCount _headerSize;     //< Optional file header size for things like zchunk
     std::optional<zypp::CheckSum> _headerChecksum; //< Optional file header checksum
-    zypp::ByteCount _preferred_chunk_size = zypp::ByteCount( 4096, zypp::ByteCount::K );
+    zypp::ByteCount _preferred_chunk_size = 0;
   };
 
   ZYPP_IMPL_PRIVATE( DownloadSpec )

--- a/zypp-curl/ng/network/downloadspec.h
+++ b/zypp-curl/ng/network/downloadspec.h
@@ -81,6 +81,8 @@ namespace zyppng {
     /*!
      * Sets the prefered amount of bytes the downloader tries to request from a single server per metalink chunk request.
      * If the metalink description has smaller chunks those are coalesced to match the preferred size.
+     *
+     * Setting this to 0 tells the \ref Downloader instance to automatically calculate the chunk size. This is also the default.
      */
     DownloadSpec &setPreferredChunkSize ( const zypp::ByteCount &bc );
     zypp::ByteCount preferredChunkSize() const;

--- a/zypp-curl/ng/network/mirrorcontrol.cc
+++ b/zypp-curl/ng/network/mirrorcontrol.cc
@@ -57,7 +57,11 @@ namespace zyppng {
 
   void MirrorControl::Mirror::transferUnref()
   {
-    bool stillLoaded = ( runningTransfers - 1 ) >= maxConnections();
+    const auto newCount = runningTransfers - 1;
+    if ( newCount < 0 )
+      return;
+
+    bool stillLoaded = ( newCount ) >= maxConnections();
     runningTransfers--;
     if ( !stillLoaded )
       _parent._sigNewMirrorsReady.emit();

--- a/zypp-curl/ng/network/mirrorcontrol.cc
+++ b/zypp-curl/ng/network/mirrorcontrol.cc
@@ -296,4 +296,3 @@ namespace zyppng {
 #endif
 
 }
-

--- a/zypp-curl/ng/network/networkrequestdispatcher.cc
+++ b/zypp-curl/ng/network/networkrequestdispatcher.cc
@@ -56,6 +56,7 @@ NetworkRequestDispatcherPrivate::NetworkRequestDispatcherPrivate(  NetworkReques
   curl_multi_setopt( _multi, CURLMOPT_TIMERDATA, reinterpret_cast<void *>( this ) );
   curl_multi_setopt( _multi, CURLMOPT_SOCKETFUNCTION, NetworkRequestDispatcherPrivate::static_socket_callback );
   curl_multi_setopt( _multi, CURLMOPT_SOCKETDATA, reinterpret_cast<void *>( this ) );
+  curl_multi_setopt( _multi, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX|CURLPIPE_HTTP1 );
 
   _timer->setSingleShot( true );
   _timer->connect( &Timer::sigExpired, *this, &NetworkRequestDispatcherPrivate::multiTimerTimout );

--- a/zypp-curl/ng/network/networkrequestdispatcher.cc
+++ b/zypp-curl/ng/network/networkrequestdispatcher.cc
@@ -56,7 +56,10 @@ NetworkRequestDispatcherPrivate::NetworkRequestDispatcherPrivate(  NetworkReques
   curl_multi_setopt( _multi, CURLMOPT_TIMERDATA, reinterpret_cast<void *>( this ) );
   curl_multi_setopt( _multi, CURLMOPT_SOCKETFUNCTION, NetworkRequestDispatcherPrivate::static_socket_callback );
   curl_multi_setopt( _multi, CURLMOPT_SOCKETDATA, reinterpret_cast<void *>( this ) );
-  curl_multi_setopt( _multi, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX|CURLPIPE_HTTP1 );
+
+  // disabled explicit pipelining since it breaks our tests on releases < 15.2
+  // we could consider enabling it starting with a specific CURL version
+  // curl_multi_setopt( _multi, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX|CURLPIPE_HTTP1 );
 
   _timer->setSingleShot( true );
   _timer->connect( &Timer::sigExpired, *this, &NetworkRequestDispatcherPrivate::multiTimerTimout );

--- a/zypp-curl/ng/network/networkrequestdispatcher.cc
+++ b/zypp-curl/ng/network/networkrequestdispatcher.cc
@@ -365,6 +365,11 @@ void NetworkRequestDispatcher::setMaximumConcurrentConnections( const int maxCon
   d_func()->_maxConnections = maxConn;
 }
 
+int NetworkRequestDispatcher::maximumConcurrentConnections () const
+{
+  return d_func()->_maxConnections;
+}
+
 void NetworkRequestDispatcher::enqueue(const std::shared_ptr<NetworkRequest> &req )
 {
   if ( !req )

--- a/zypp-curl/ng/network/networkrequestdispatcher.h
+++ b/zypp-curl/ng/network/networkrequestdispatcher.h
@@ -96,6 +96,11 @@ namespace zyppng {
        */
       void setMaximumConcurrentConnections ( const int maxConn );
 
+      /**
+       * returns the maximum number of allowed concurrent connections
+       */
+      int maximumConcurrentConnections () const;
+
       /*!
        * Enqueues a new \a request and puts it into the waiting queue. If the dispatcher
        * is already running and has free capacatly the request might be started right away

--- a/zypp-curl/ng/network/networkrequesterror.cc
+++ b/zypp-curl/ng/network/networkrequesterror.cc
@@ -169,10 +169,14 @@ NetworkRequestError NetworkRequestErrorPrivate::fromCurlError(NetworkRequest &re
       case CURLE_FTP_CANT_GET_HOST:
         c = NetworkRequestError::ConnectionFailed;
         break;
-      case CURLE_WRITE_ERROR:
+      case CURLE_WRITE_ERROR: {
+        // this error code also handles the cases when a callback returned a error.
         c = NetworkRequestError::InternalError;
         break;
+      }
       case CURLE_PARTIAL_FILE:
+        c = NetworkRequestError::ServerReturnedError;
+        break;
       case CURLE_OPERATION_TIMEDOUT:
         c = NetworkRequestError::Timeout;
         break;
@@ -276,6 +280,8 @@ std::string NetworkRequestErrorPrivate::typeToString( NetworkRequestError::Type 
       return "Server returned an error for the given request.";
     case NetworkRequestError::MissingData:
       return "Server did not send all requested ranges.";
+    case NetworkRequestError::RangeFail:
+      return "Invalid data from server, multipart was requested but there was no range status code.";
   }
   return std::string();
 }

--- a/zypp-curl/ng/network/networkrequesterror.h
+++ b/zypp-curl/ng/network/networkrequesterror.h
@@ -40,7 +40,8 @@ class NetworkRequestErrorPrivate;
       Unauthorized,        //<< No auth data given but authorization required
       AuthFailed,          //<< Auth data was given, but authorization failed
       ServerReturnedError, //<< A error was returned by the server that is not explicitly handled
-      MissingData          //<< The download was a multirange download and we did not get all data that was requested, if that is returned some ranges might have been downloaded successful
+      MissingData,         //<< The download was a multirange download and we did not get all data that was requested, if that is returned some ranges might have been downloaded successful
+      RangeFail,           //<< The download was a multirange download but the server decided to return the full file.
     };
 
     NetworkRequestError ();

--- a/zypp-curl/ng/network/private/downloader_p.h
+++ b/zypp-curl/ng/network/private/downloader_p.h
@@ -60,7 +60,7 @@ namespace zyppng {
     Transition< DetectMetalinkState, &DetectMetalinkState::sigFinished,   DlNormalFileState,   &DetectMetalinkState::toSimpleDownloadGuard >,
 
     Transition< DlMetaLinkInfoState, &DlMetaLinkInfoState::sigFinished,    FinishedState, DefaultStateCondition, &DlMetaLinkInfoState::transitionToFinished >,
-    Transition< DlMetaLinkInfoState, &DlMetaLinkInfoState::sigGotMetalink, PrepareMultiState, DefaultStateCondition, &DlMetaLinkInfoState::transitionToPrepareMulti >,
+    Transition< DlMetaLinkInfoState, &DlMetaLinkInfoState::sigGotMetadata, PrepareMultiState, DefaultStateCondition, &DlMetaLinkInfoState::transitionToPrepareMulti >,
     Transition< DlMetaLinkInfoState, &DlMetaLinkInfoState::sigFailed,      FinishedState, DefaultStateCondition, &DlMetaLinkInfoState::transitionToFinished >,
 
     Transition< PrepareMultiState, &PrepareMultiState::sigFinished,   DlMetalinkState,  &PrepareMultiState::toMetalinkDownloadGuard , &PrepareMultiState::transitionToMetalinkDl >,

--- a/zypp-curl/ng/network/private/downloaderstates/base_p.h
+++ b/zypp-curl/ng/network/private/downloaderstates/base_p.h
@@ -51,6 +51,7 @@ namespace zyppng {
       std::string chksumtype;
       std::optional<UByteArray> chksumVec;
       std::optional<size_t> chksumCompareLen; //< initialized if only the first few bytes of the checksum should be considered
+      std::optional<size_t> chksumPad; //< initialized if the hashed blocks for a digest need to be padded if a block is smaller ( e.g. last block in a zsync file )
 
       int _retryCount = 0;  //< how many times was this request restarted
       NetworkRequestError _failedWithErr; //< what was the error this request failed with

--- a/zypp-curl/ng/network/private/downloaderstates/initial_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/initial_p.cc
@@ -17,9 +17,9 @@
 
 namespace zyppng {
 
-  void InitialState::enter(){ MIL << "Entering initial state"  << std::endl; }
+  void InitialState::enter(){ MIL_MEDIA << "Entering initial state"  << std::endl; }
 
-  void InitialState::exit(){  MIL << "Leaving initial state"  << std::endl;  }
+  void InitialState::exit(){  MIL_MEDIA << "Leaving initial state"  << std::endl;  }
 
   void InitialState::initiate()
   {

--- a/zypp-curl/ng/network/private/downloaderstates/metalink_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/metalink_p.cc
@@ -101,14 +101,19 @@ namespace zyppng {
 
     // remember how many bytes we need to download
     size_t bytesToDl = 0;
+    // do we need to pad the digest when calculating the checksum for blocks
+    const auto &chksumPad  = _blockList.checksumPad ();
     for ( size_t i = 0; i < _blockList.numBlocks(); i++ ) {
       const auto &mediaBlock = _blockList.getBlock( i );
+      const auto &blockSum   = _blockList.getChecksum ( i );
       _ranges.push_back(
         Block{
           .start = mediaBlock.off,
           .len   = mediaBlock.size,
           .chksumtype = _blockList.getChecksumType(),
-          .chksumVec  = _blockList.getChecksum ( i )
+          .chksumVec  = blockSum,
+          .chksumCompareLen = blockSum.size( ),
+          .chksumPad = chksumPad > 0 ? chksumPad : std::optional<size_t>()
         } );
 
       bytesToDl += mediaBlock.size;

--- a/zypp-curl/ng/network/private/downloaderstates/metalink_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/metalink_p.cc
@@ -49,7 +49,11 @@ namespace zyppng {
         } catch ( ... ) { }
 
         fclose( f );
+      } else {
+        DBG << "Delta XFER: Delta file: " << spec.deltaFile() << " does not exist or is not readable." << std::endl;
       }
+    } else {
+      DBG << "Delta XFER: No delta file given, can not reuse blocks." << std::endl;
     }
 
     // setup the base downloader

--- a/zypp-curl/ng/network/private/downloaderstates/metalinkinfo_p.h
+++ b/zypp-curl/ng/network/private/downloaderstates/metalinkinfo_p.h
@@ -23,6 +23,12 @@ namespace zyppng {
   struct FinishedState;
   struct PrepareMultiState;
 
+  enum class MetaDataType {
+    None  = 0,
+    Zsync,
+    MetaLink
+  };
+
   /*!
      * State to download the actual metalink file, we can however not be 100% sure that we actually
      * will get a metalink file, so we need to check the content type or in bad cases the
@@ -37,8 +43,8 @@ namespace zyppng {
     SignalProxy< void () > sigFinished() {
       return _sigFinished;
     }
-    SignalProxy< void () > sigGotMetalink() {
-      return _sigGotMetalink;
+    SignalProxy< void () > sigGotMetadata() {
+      return _sigGotMetadata;
     }
     SignalProxy< void () > sigFailed() {
       return _sigFailed;
@@ -51,8 +57,8 @@ namespace zyppng {
     virtual void gotFinished () override;
 
   protected:
-    bool _isMetalink = false;
-    Signal< void () > _sigGotMetalink;
+    MetaDataType _detectedMetaType = MetaDataType::None;
+    Signal< void () > _sigGotMetadata;
 
     virtual void handleRequestProgress ( NetworkRequest &req, off_t dltotal, off_t dlnow ) override;
   };

--- a/zypp-curl/ng/network/private/downloaderstates/preparemulti_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/preparemulti_p.cc
@@ -141,11 +141,13 @@ namespace zyppng {
 
         off_t currOff = 0;
         off_t filesize = _blockList.getFilesize();
+        const auto &prefSize = std::max<zypp::ByteCount>(  sm._spec.preferredChunkSize(), zypp::ByteCount(4, zypp::ByteCount::K) );
+
         while ( currOff <  filesize )  {
 
           auto blksize = filesize - currOff ;
-          if ( blksize > sm._spec.preferredChunkSize() )
-            blksize = sm._spec.preferredChunkSize();
+          if ( blksize > prefSize )
+            blksize = prefSize;
 
           _blockList.addBlock( currOff, blksize );
           currOff += blksize;

--- a/zypp-curl/ng/network/private/downloaderstates/preparemulti_p.h
+++ b/zypp-curl/ng/network/private/downloaderstates/preparemulti_p.h
@@ -38,7 +38,12 @@ namespace zyppng {
 
     using Request = DownloadPrivateBase::Request;
 
-    PrepareMultiState ( std::shared_ptr<Request> oldReq, DownloadPrivate &parent );
+    enum Mode {
+      Zsync,
+      Metalink
+    };
+
+    PrepareMultiState ( std::shared_ptr<Request> oldReq, Mode m, DownloadPrivate &parent );
 
     void enter ();
     void exit ();
@@ -77,6 +82,7 @@ namespace zyppng {
 #if ENABLE_ZCHUNK_COMPRESSION
     bool _haveZckData = false; //< do we have zck data ready
 #endif
+    Mode _mode; //< wether we should expect a metalink or zsync file
     std::shared_ptr<Request> _oldRequest; //< exising request of previous states, that the next states might reuse
     NetworkRequestError _error;
     Signal< void () > _sigFinished;

--- a/zypp-curl/ng/network/private/downloaderstates/rangedownloader_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/rangedownloader_p.cc
@@ -126,7 +126,8 @@ namespace zyppng {
         std::transform( fRanges.begin(), fRanges.end(), std::back_inserter(_failedRanges), [ &req ]( const auto &r ){
           Block b = std::any_cast<Block>(r.userData);;
           b._failedWithErr = req->error();
-          DBG_MEDIA << "Adding failed block to failed blocklist: " << b.start << " " << b.len << " (" << req->error().toString() << " [" << req->error().nativeErrorString()<< "])" << std::endl;
+          if ( zypp::env::ZYPP_MEDIA_CURL_DEBUG() > 3 )
+            DBG_MEDIA << "Adding failed block to failed blocklist: " << b.start << " " << b.len << " (" << req->error().toString() << " [" << req->error().nativeErrorString()<< "])" << std::endl;
           return b;
         });
 
@@ -317,10 +318,13 @@ namespace zyppng {
           return false;
         }
 
-        DBG_MEDIA << "Starting block " << block.start << " with checksum " << zypp::Digest::digestVectorToString( *block.chksumVec ) << "." << std::endl;
-        req->addRequestRange( block.start, block.len, dig, *block.chksumVec, std::any( block ), block.chksumCompareLen );
+        if ( zypp::env::ZYPP_MEDIA_CURL_DEBUG() > 3 )
+          DBG_MEDIA << "Starting block " << block.start << " with checksum " << zypp::Digest::digestVectorToString( *block.chksumVec ) << "." << std::endl;
+        req->addRequestRange( block.start, block.len, dig, *block.chksumVec, std::any( block ), block.chksumCompareLen, block.chksumPad );
       } else {
-        DBG_MEDIA << "Starting block " << block.start << " without checksum." << std::endl;
+
+        if ( zypp::env::ZYPP_MEDIA_CURL_DEBUG() > 3 )
+          DBG_MEDIA << "Starting block " << block.start << " without checksum." << std::endl;
         req->addRequestRange( block.start, block.len, {}, {}, std::any( block ) );
       }
     }

--- a/zypp-curl/ng/network/private/downloaderstates/rangedownloader_p.h
+++ b/zypp-curl/ng/network/private/downloaderstates/rangedownloader_p.h
@@ -54,11 +54,14 @@ namespace zyppng {
     void mirrorReceived(MirrorControl::MirrorPick mirror) override;
     void failedToPrepare() override;
 
+    static zypp::ByteCount makeBlksize ( size_t filesize );
+
   protected:
     NetworkRequestError _error;
     bool _inEnsureDownloadsRunning = false; //< Flag to prevent multiple entry to ensureDownloadsRunning
 
     size_t             _fileSize = 0; //< The expected filesize, this is used to make sure we do not write after the end offset of the expected file size
+    zypp::ByteCount    _preferredChunkSize = 0; //< The preferred chunk size we want to download per request
     std::list<Block>   _ranges;
 
     //keep a list with failed blocks in case we run out of mirrors,

--- a/zypp-curl/ng/network/private/networkrequestdispatcher_p.h
+++ b/zypp-curl/ng/network/private/networkrequestdispatcher_p.h
@@ -64,6 +64,7 @@ private:
   int  socketCallback(CURL *easy, curl_socket_t s, int what, void * );
 
   void cancelAll ( NetworkRequestError result );
+  bool addRequestToMultiHandle ( NetworkRequest &req );
   void setFinished( NetworkRequest &req , NetworkRequestError result );
 
   void onSocketActivated  ( const SocketNotifier &listener, int events );

--- a/zypp-curl/ng/network/private/request_p.h
+++ b/zypp-curl/ng/network/private/request_p.h
@@ -27,7 +27,6 @@
 
 #include <boost/optional.hpp>
 #include <variant>
-#include <boost/utility/string_view.hpp>
 
 namespace zyppng {
 
@@ -53,8 +52,8 @@ namespace zyppng {
     void onActivityTimeout (Timer &);
     bool checkIfRangeChkSumIsValid(const NetworkRequest::Range &rng);
     void validateRange ( NetworkRequest::Range &rng );
-    bool parseContentRangeHeader (const boost::string_view &line, size_t &start , size_t &len);
-    bool parseContentTypeMultiRangeHeader ( const boost::string_view &line, std::string &boundary );
+    bool parseContentRangeHeader (const std::string_view &line, size_t &start , size_t &len);
+    bool parseContentTypeMultiRangeHeader ( const std::string_view &line, std::string &boundary );
 
     std::string errorMessage () const;
 

--- a/zypp-curl/ng/network/private/request_p.h
+++ b/zypp-curl/ng/network/private/request_p.h
@@ -48,6 +48,8 @@ namespace zyppng {
 
     bool setupHandle ( std::string &errBuf );
 
+    bool assertOutputFile ();
+
     /*!
      * \internal
      * Called by the dispatcher if we report a error. If this function returns
@@ -148,9 +150,8 @@ namespace zyppng {
       255,
       127,
       63,
-      31,
       15,
-      7
+      5
     };
 
     struct pending_t;

--- a/zypp-curl/ng/network/request.cc
+++ b/zypp-curl/ng/network/request.cc
@@ -77,15 +77,15 @@ namespace zyppng {
 
     switch (type) {
       case CURLINFO_TEXT:
-        DBG << "== Info: ";
-        DBG << std::string( data, size ) << std::endl;
+        DBG << handle << " " << "== Info: ";
+        DBG << handle << " " << std::string( data, size ) << std::endl;
 
       default: /* in case a new one is introduced to shock us */
         return 0;
 
       case CURLINFO_HEADER_OUT:
         text = "=> Send header: ";
-        DBG << std::string( data, size ) << std::endl;
+        DBG << handle << " " << std::string( data, size ) << std::endl;
         return 0;
       case CURLINFO_DATA_OUT:
         text = "=> Send data";
@@ -95,7 +95,7 @@ namespace zyppng {
         break;
       case CURLINFO_HEADER_IN:
         text = "<= Recv header: ";
-        DBG << std::string( data, size ) << std::endl;
+        DBG << handle << " " << std::string( data, size ) << std::endl;
         return 0;
       case CURLINFO_DATA_IN:
         text = "<= Recv data";
@@ -108,7 +108,7 @@ namespace zyppng {
     if ( maxlvl > 4 )
       dump(text, stderr, (unsigned char *)data, size);
     else
-      DBG << " " << size << " bytes " << std::endl;
+      DBG << handle << " " << " " << size << " bytes " << std::endl;
     return 0;
   }
 
@@ -261,7 +261,7 @@ namespace zyppng {
             if constexpr ( std::is_same_v<T, pending_t> ) {
               arg._requireStatusPartial = false;
             } else {
-              DBG << "NetworkRequestPrivate::setupHandle called in unexpected state" << std::endl;
+              DBG << _easyHandle << " " << "NetworkRequestPrivate::setupHandle called in unexpected state" << std::endl;
             }
           }, _runningMode );
           _requestedRanges.push_back( NetworkRequest::Range() );
@@ -387,7 +387,7 @@ namespace zyppng {
         long auth = zypp::media::CurlAuthData::auth_type_str2long(use_auth);
         if( auth != CURLAUTH_NONE)
         {
-          DBG << "Enabling HTTP authentication methods: " << use_auth
+          DBG << _easyHandle << " "  << "Enabling HTTP authentication methods: " << use_auth
               << " (CURLOPT_HTTPAUTH=" << auth << ")" << std::endl;
           setCurlOption(CURLOPT_HTTPAUTH, auth);
         }
@@ -395,7 +395,7 @@ namespace zyppng {
 
       if ( locSet.proxyEnabled() && ! locSet.proxy().empty() )
       {
-        DBG << "Proxy: '" << locSet.proxy() << "'" << std::endl;
+        DBG << _easyHandle << " " << "Proxy: '" << locSet.proxy() << "'" << std::endl;
         setCurlOption(CURLOPT_PROXY, locSet.proxy().c_str());
         setCurlOption(CURLOPT_PROXYAUTH, CURLAUTH_BASIC|CURLAUTH_DIGEST|CURLAUTH_NTLM );
 
@@ -413,16 +413,16 @@ namespace zyppng {
           zypp::media::CurlConfig curlconf;
           zypp::media::CurlConfig::parseConfig(curlconf); // parse ~/.curlrc
           if ( curlconf.proxyuserpwd.empty() )
-            DBG << "Proxy: ~/.curlrc does not contain the proxy-user option" << std::endl;
+            DBG << _easyHandle << " "  << "Proxy: ~/.curlrc does not contain the proxy-user option" << std::endl;
           else
           {
             proxyuserpwd = curlconf.proxyuserpwd;
-            DBG << "Proxy: using proxy-user from ~/.curlrc" << std::endl;
+            DBG << _easyHandle << " " << "Proxy: using proxy-user from ~/.curlrc" << std::endl;
           }
         }
         else
         {
-          DBG << "Proxy: using provided proxy-user '" << _settings.proxyUsername() << "'" << std::endl;
+          DBG << _easyHandle << " "  << _easyHandle << " "  << "Proxy: using provided proxy-user '" << _settings.proxyUsername() << "'" << std::endl;
         }
 
         if ( ! proxyuserpwd.empty() )
@@ -435,15 +435,15 @@ namespace zyppng {
       {
         // Explicitly disabled in URL (see fillSettingsFromUrl()).
         // This should also prevent libcurl from looking into the environment.
-        DBG << "Proxy: explicitly NOPROXY" << std::endl;
+        DBG << _easyHandle << " "  << "Proxy: explicitly NOPROXY" << std::endl;
         setCurlOption(CURLOPT_NOPROXY, "*");
       }
 
 #endif
       else
       {
-        DBG << "Proxy: not explicitly set" << std::endl;
-        DBG_MEDIA << "Proxy: libcurl may look into the environment" << std::endl;
+        DBG << _easyHandle << " " << "Proxy: not explicitly set" << std::endl;
+        DBG << _easyHandle << " " << "Proxy: libcurl may look into the environment" << std::endl;
       }
 
       /** Speed limits */
@@ -462,7 +462,7 @@ namespace zyppng {
       if ( zypp::str::strToBool( _url.getQueryParam( "cookies" ), true ) )
         setCurlOption( CURLOPT_COOKIEFILE, _currentCookieFile.c_str() );
       else
-        MIL << "No cookies requested" << std::endl;
+        MIL << _easyHandle << " " << "No cookies requested" << std::endl;
       setCurlOption(CURLOPT_COOKIEJAR, _currentCookieFile.c_str() );
 
 #if CURLVERSION_AT_LEAST(7,18,0)
@@ -621,7 +621,7 @@ namespace zyppng {
         }
 
         if ( rangesAdded >= maxRanges ) {
-          MIL_MEDIA << "Reached max nr of ranges (" << maxRanges << "), batching the request to not break the server" << std::endl;
+          MIL_MEDIA << _easyHandle << " " << "Reached max nr of ranges (" << maxRanges << "), batching the request to not break the server" << std::endl;
           break;
         }
       }
@@ -630,7 +630,7 @@ namespace zyppng {
       if ( currentZippedRange )
         addRangeString( *currentZippedRange );
 
-      MIL_MEDIA << "Requesting Ranges: " << rangeDesc << std::endl;
+      MIL_MEDIA << _easyHandle << " " << "Requesting Ranges: " << rangeDesc << std::endl;
 
       setCurlOption( CURLOPT_RANGE, rangeDesc.c_str() );
     }
@@ -648,7 +648,7 @@ namespace zyppng {
   {
     bool isRangeContinuation = std::holds_alternative<prepareNextRangeBatch_t>( _runningMode );
     if ( isRangeContinuation ) {
-      MIL_MEDIA << "Continuing a previously started range batch." << std::endl;
+      MIL_MEDIA << _easyHandle << " " << "Continuing a previously started range batch." << std::endl;
       _runningMode = running_t( std::move(std::get<prepareNextRangeBatch_t>( _runningMode )) );
     } else {
       _runningMode = running_t( std::move(std::get<pending_t>( _runningMode )) );
@@ -657,6 +657,7 @@ namespace zyppng {
     auto &m = std::get<running_t>( _runningMode );
 
     if ( m._activityTimer ) {
+      DBG_MEDIA << _easyHandle << " Setting activity timeout to: " << _settings.timeout() << std::endl;
       m._activityTimer->connect( &Timer::sigExpired, *this, &NetworkRequestPrivate::onActivityTimeout );
       m._activityTimer->start( static_cast<uint64_t>( _settings.timeout() * 1000 ) );
     }
@@ -724,8 +725,11 @@ namespace zyppng {
     });
   }
 
-  void NetworkRequestPrivate::onActivityTimeout( Timer & )
+  void NetworkRequestPrivate::onActivityTimeout( Timer &t )
   {
+    auto &m = std::get<running_t>( _runningMode );
+
+    MIL_MEDIA << _easyHandle << " Request timeout interval: " << t.interval()<< " remaining: " << t.remaining() <<  std::endl;
     std::map<std::string, boost::any> extraInfo;
     extraInfo.insert( {"requestUrl", _url } );
     extraInfo.insert( {"filepath", _targetFile } );
@@ -737,7 +741,7 @@ namespace zyppng {
     if ( rng._digest && rng._checksum.size() ) {
       auto bytesHashed = rng._digest->bytesHashed ();
       if ( rng._chksumPad && *rng._chksumPad > bytesHashed ) {
-        MIL_MEDIA << "Padding the digest to required block size" << std::endl;
+        MIL_MEDIA << _easyHandle << " " << "Padding the digest to required block size" << std::endl;
         zypp::ByteArray padding( *rng._chksumPad - bytesHashed, '\0' );
         rng._digest->update( padding.data(), padding.size() );
       }
@@ -771,7 +775,7 @@ namespace zyppng {
 
     zypp::str::smatch what;
     if( !zypp::str::regex_match( std::string(line), what, regex ) || what.size() != 4 ) {
-      DBG << "Invalid Content-Range Header format: '" << std::string(line) << std::endl;
+      DBG << _easyHandle << " " << "Invalid Content-Range Header format: '" << std::string(line) << std::endl;
       return false;
     }
 
@@ -817,7 +821,7 @@ namespace zyppng {
     NetworkRequestPrivate *that = reinterpret_cast<NetworkRequestPrivate *>( clientp );
 
     if ( !std::holds_alternative<running_t>(that->_runningMode) ){
-      DBG_MEDIA << "Curl progress callback was called in invalid state "<< that->z_func()->state() << std::endl;
+      DBG_MEDIA << that->_easyHandle << " " << "Curl progress callback was called in invalid state "<< that->z_func()->state() << std::endl;
       return -1;
     }
 
@@ -855,7 +859,7 @@ namespace zyppng {
       else
         hdr = std::string_view();
 
-      DBG_MEDIA << "Received header: " << hdr << std::endl;
+      DBG_MEDIA << _easyHandle << " " << "Received header: " << hdr << std::endl;
 
       auto &rmode = std::get<running_t>( _runningMode );
       if ( !hdr.size() ) {
@@ -881,7 +885,7 @@ namespace zyppng {
         }
       } else if ( zypp::strv::hasPrefixCI( hdr, "Location:" ) ) {
         _lastRedirect = hdr.substr( 9 );
-        DBG << "redirecting to " << _lastRedirect << std::endl;
+        DBG << _easyHandle << " " << "redirecting to " << _lastRedirect << std::endl;
 
       } else if ( zypp::strv::hasPrefixCI( hdr, "Content-Type:") ) {
         std::string sep;
@@ -895,7 +899,7 @@ namespace zyppng {
           rmode._cachedResult = NetworkRequestErrorPrivate::customError( NetworkRequestError::InternalError, "Invalid Content-Range header format." );
           return 0;
         }
-        DBG_MEDIA << "Got content range :" << r.start << " len " << r.len << std::endl;
+        DBG_MEDIA << _easyHandle << " " << "Got content range :" << r.start << " len " << r.len << std::endl;
         rmode._gotContentRangeHeader = true;
         rmode._currentSrvRange = r;
 
@@ -904,7 +908,7 @@ namespace zyppng {
         auto str = std::string ( lenStr.data(), lenStr.length() );
         auto len = zypp::str::strtonum<typename zypp::ByteCount::SizeType>( str.data() );
         if ( len > 0 ) {
-          DBG_MEDIA << "Got Content-Length Header: " << len << std::endl;
+          DBG_MEDIA << _easyHandle << " " << "Got Content-Length Header: " << len << std::endl;
           rmode._contentLenght = zypp::ByteCount(len, zypp::ByteCount::B);
         }
       }
@@ -933,7 +937,7 @@ namespace zyppng {
     auto writeDataToFile = [ this, &rmode ]( off_t offset, const char *data, size_t len ) -> off_t {
 
       if ( rmode._currentRange < 0 ) {
-        DBG_MEDIA << "Current range is zero in write request" << std::endl;
+        DBG_MEDIA << _easyHandle << " " << "Current range is zero in write request" << std::endl;
         return 0;
       }
 

--- a/zypp-curl/parser/ZsyncParser
+++ b/zypp-curl/parser/ZsyncParser
@@ -1,0 +1,1 @@
+#include "zsyncparser.h"

--- a/zypp-curl/parser/mediablocklist.cc
+++ b/zypp-curl/parser/mediablocklist.cc
@@ -6,9 +6,97 @@
 |                         /_____||_| |_| |_|                           |
 |                                                                      |
 \---------------------------------------------------------------------*/
-/** \file zypp-curl/parser/mediablocklist.cc
- *
- */
+/**
+  \file zypp-curl/parser/mediablocklist.cc
+
+  This file implements the delta file block reuse algorithm. If the available hashes use rolling checksum style
+  hashes, we use the zsync algorithm to search for blocks that are available.
+
+  The basic idea of zsync is that on the server side a metadata file is generated, this file contains a list of checksums
+  for each block in the target file ( the file we want to download ) as well as some other important informations
+  like the size of the blocks, file checksum and mirrors. The client ( we ) then can use a delta file, basically
+  a older version of the file we want to download, to find reusable blocks identified by their checksum.
+
+  A simple approach would be now to calculate all checksums in the delta file for each block, but that does not take into
+  account that the blocks we want to reuse have moved in the file, e.g. a new set bytes of data was put in the beginning
+  of the file, shifting all blocks to a new offset most likely not as a multiple of blocksize or worse not even a power of 2.
+  Think a block is 2k but the data inserted is only 200 bytes, offsetting all blocks for 200bytes, in that case the simple approach could not reuse a single block
+  of data because it can't find them.
+
+  To work around this problem the code calculates the checksums on every possible byte offset of the delta file. To speed this process
+  up when finding a block we skip forward to the end of the block. If there is a match at x, its very unlikely to find another match starting
+  inside the boundaries of the current block ( between x and x + blocksize - 1 ), except if the file has a lot of redundancy.
+
+  This process naturally can take very long if there are no, or just a few matching blocks in the two files. To speed this up
+  a multi step checksum process is used. First we calculate a very cheap to calculate weak checksum for each block based on
+  the Adler-32 checksum:
+
+  \f[
+    a(k,l) = (\sum_{i=k}^l X_i) \bmod M
+  \f]
+  \f[
+    \begin{align}
+    b(k,l) &= (\sum_{i=k}^l (l-i+1)X_i) \bmod M \\
+           &= (\sum_{i=k}^l a(k,i) ) \bmod M
+    \end{align}
+  \f]
+  \f[
+    s(k,l) = a(k,l) + 2^{16} b(k,l)
+  \f]
+
+  where \f$s(k, l)\f$ is the rolling checksum of the bytes \f$X_k \ldots X_l\f$. For simplicity and speed, we use \f$M = 2^{16}\f$.
+
+  The important property of this checksum is that successive values can be computed very efficiently using recurrence relations:
+  \f[
+    a(k+1,l+1) = (a(k,l) - X_k + X_{l+1}) \bmod M
+  \f]
+  \f[
+    b(k+1,l+1) = (b(k,l) - (l-k+1) X_k + a(k+1,l+1)) \bmod M
+  \f]
+
+  To understand why we can use recurrence relations its important to look at the formulas written out
+  for a simple example, we will ignore the modulo operation for simplicity:
+
+  For the \a a formula is simple to see that we just need to subtract the value of the byte moving out of the block and add the
+  value of the new byte coming in at the end
+  \f[
+    \begin{align}
+    a(0,2) &= X_0 + X_1 + X_2  \\
+    a(1,3) &= a(0,2) - X_0 + X_3  \\
+           &= X_0 + X_1 + X_2 - X_0 + X_3  \\
+           &= X_1 + X_2 + X_3
+    \end{align}
+  \f]
+
+  The \a b part is a bit more complex, writing the formula out also shows us why \a b can be expressed as: \f$b=(\sum_{i=k}^l a(k,i) ) \bmod M\f$:
+  \f[
+    \begin{align}
+    b(0,2) &= 3X_0 + 2X_1 + X_2 \\
+           &= X_0 + X_0 +X_0 + X_1 + X_1 + X_2 \\
+           &= X0 + X0 + X1 + X0 +X1 +X2 \\
+           &= a(0,0) + a(0,1) + a(0,2) = (\sum_{i=k}^l a(k,i) )
+    \end{align}
+  \f]
+  \f[
+    \begin{align}
+    b(1,3) &= b(0,2) - (2-0+1)X_0 + a(1,3) \\
+           &= b(0,2) - 3X_0 + a(1,3) \\
+           &= 3X_0 + 2X_1 + X_2 - 3X_0 + X_1 + X_2 + X_3 \\
+           &= 3X_1 + 2X_2 + X_3
+    \end{align}
+  \f]
+
+  This shows us that we can very quickly calculate the new checksum of a block at offset \a i+1 based on the checksum of the block at offset \a i.
+
+  If the weak checksum matches, a stronger MD4 checksum is calculated for the same block to make sure we really got the block we wanted. If the strong checksum
+  matches as well the block is written to the target file and removed from the list of blocks we still need to find. The read offset then jumps to the end
+  of the current bock: \a offset+blocksize and continues the process from there.
+
+  Zsync additionally can require that always a sequence of 2 neighboring blocks need to match before they are considered a match. This depends on the filesize and is specified in the zsync metadata file.
+  According to the zsync docs this greatly lowers the probability of a false match and allows to send smaller checksums for the blocks, minimizing the data we need to download in the meta datafile.
+
+  More in depth docs can be found at http://zsync.moria.org.uk/paper and https://rsync.samba.org/tech_report
+*/
 
 #include "mediablocklist.h"
 
@@ -23,11 +111,36 @@
 
 #include <zypp-core/base/Logger.h>
 #include <zypp-core/base/String.h>
+#include <zypp-core/AutoDispose.h>
 
 using namespace zypp::base;
 
 namespace zypp {
   namespace media {
+
+    namespace {
+      /**
+       * Zsync uses a different rsum length based on the blocksize, since we always calculate the big
+       * checksum we need to cut off the bits we are not interested in
+       */
+      void inline truncateRsum ( unsigned int &rs, const int rsumlen )
+      {
+        switch(rsumlen)
+        {
+        case 3:
+          rs &= 0xffffff;
+          break;
+        case 2:
+          rs &= 0xffff;
+          break;
+        case 1:
+          rs &= 0xff;
+          break;
+        default:
+          break;
+        }
+      }
+    }
 
 MediaBlockList::MediaBlockList(off_t size)
 {
@@ -151,6 +264,7 @@ MediaBlockList::updateRsum(unsigned int rs, const char* bytes, size_t len) const
 {
   if (!len)
     return rs;
+
   unsigned short s, m;
   s = (rs >> 16) & 65535;
   m = rs & 65535;
@@ -179,17 +293,7 @@ MediaBlockList::verifyRsum(size_t blkno, unsigned int rs) const
       m += s * (rsumpad - size);
       rs = (s & 65535) << 16 | (m & 65535);
     }
-  switch(rsumlen)
-    {
-    case 3:
-      rs &= 0xffffff;
-    case 2:
-      rs &= 0xffff;
-    case 1:
-      rs &= 0xff;
-    default:
-      break;
-    }
+  truncateRsum( rs, rsumlen );
   return rs == rsums[blkno];
 }
 
@@ -295,11 +399,10 @@ fetchnext(FILE *fp, unsigned char *bp, size_t blksize, size_t pushback, unsigned
   return blksize - l;
 }
 
-
-void
-MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
+void MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
 {
-  FILE *fp;
+
+  zypp::AutoFILE fp;
 
   if ( !chksumlen ) {
     DBG << "Delta XFER: Can not reuse blocks because we have no chksumlen" << std::endl;
@@ -318,15 +421,27 @@ MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
       size_t blksize = blocks[0].size;
       if (nblks == 1 && rsumpad && rsumpad > blksize)
         blksize = rsumpad;
+
       // create hash of checksums
+
+      // calculate the size of the hashtable by setting
+      // all bits to 1 up the to currently set MSB
+      // if we have 00010010 we end up with 00011111
       unsigned int hm = rsums.size() * 2;
-      while (hm & (hm - 1))
+      while (hm & (hm - 1))  {
         hm &= hm - 1;
+      }
       hm = hm * 2 - 1;
+
+      // we want at least a size if 0011 1111 1111 1111
       if (hm < 16383)
         hm = 16383;
-      unsigned int *ht = new unsigned int[hm + 1];
-      memset(ht, 0, (hm + 1) * sizeof(unsigned int));
+
+      // simple hashtable of checksums
+      auto rsumHashTable = std::make_unique<unsigned int[]>( hm+1 );
+      memset(rsumHashTable.get(), 0, (hm + 1) * sizeof(unsigned int));
+
+      // insert each rsum into the hash table
       for (unsigned int i = 0; i < rsums.size(); i++)
         {
           if (blocks[i].size != blksize && (i != nblks - 1 || rsumpad != blksize))
@@ -334,22 +449,41 @@ MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
           unsigned int r = rsums[i];
           unsigned int h = r & hm;
           unsigned int hh = 7;
-          while (ht[h])
+          while (rsumHashTable[h])
             h = (h + hh++) & hm;
-          ht[h] = i + 1;
+          rsumHashTable[h] = i + 1;
         }
 
-      unsigned char *buf = new unsigned char[blksize];
-      unsigned char *buf2 = new unsigned char[blksize];
+      // read in block by block to find matches
+      // the read buffer "buf" works like a ring buffer, means that once we are done with reading a full block
+      // and didn't find a match we start again at buf[0] , filling the buffer up again, rotating until we find
+      // a matching block. Once we find a matching block all we need to do is check if the current offset "i"
+      // is at the end of the buffer, then we can simply write the full buffer out, or if its somewhere in between
+      // then the begin of our block is buf[i+1, bufsize-1] and the end buf[0,i]
+      auto ringBuf = std::make_unique<unsigned char[]>( blksize );
+
+      // we use a second buffer to read in the next block if we are required to match more than one block at the same time.
+      auto buf2 = std::make_unique<unsigned char[]>( blksize );
+
+      // when we are required to match more than one block, it is read into buf2 advancing the file pointer,
+      // to make sure that we do not loose those bytes in case the match fails we remember their count and
+      // start in buf2, in the next loop those will be consumed before reading from the file again
       size_t pushback = 0;
       unsigned char *pushbackp = 0;
-      int bshift = 0;
+
+      // use byteshift instead of multiplication if the blksize is a power of 2
+      // a value is a power of 2 if  ( N & N-1 ) == 0
+      int bshift = 0; // how many bytes do we need to shift
       if ((blksize & (blksize - 1)) == 0)
         for (bshift = 0; size_t(1 << bshift) != blksize; bshift++)
           ;
+
+      // a and b are the LS and MS bytes of the checksum, calculated a rolling style Adler32 checksum
+      //
+      // a(k,l) = (\sum_{i=k}^l X_i) \bmod M
       unsigned short a, b;
       a = b = 0;
-      memset(buf, 0, blksize);
+      memset(ringBuf.get(), 0, blksize);
       bool eof = 0;
       bool init = 1;
       int sql = nblks > 1 && chksumlen < 16 ? 2 : 1;
@@ -357,6 +491,8 @@ MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
         {
           for (size_t i = 0; i < blksize; i++)
             {
+              // get the next character from the file
+              // or if there are pushback chars use those
               int c;
               if (eof)
                 c = 0;
@@ -377,91 +513,119 @@ MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
                         break;
                     }
                 }
-              int oc = buf[i];
-              buf[i] = c;
+
+              // calculate the rsum on the fly using recurrence relations, see https://rsync.samba.org/tech_report/node3.html
+              // basically we subtract the checksum value of a byte the leaves the current block window and add the new incoming one
+              // using this trick we do not need to calculate the full block checksum
+              // the least significant part of the checksum ( lower 8 bits ) is simply the sum of all chars in the block , modulo 2^16
+              // zsync uses only a 16bit type to calculate the sums and as far as i can see does not do the modulo per block as the formula
+              // says it should, we might need to do the same
+              int oc = ringBuf[i];
+              ringBuf[i] = c;
+
               a += c - oc;
+
+              // this is calculates the most significant part of the checksum, bshift should be always set since blocksize
+              // should always be a power of 2
               if (bshift)
-                b += a - (oc << bshift);
+                b += a - ( oc << bshift );
               else
-                b += a - oc * blksize;
+                // This seems to make no sense it does not even factor in the character itself
+                b += 2 * blksize;
+
               if (init)
                 {
+                  // continue reading bytes until we have the full block in our buffer
                   if (size_t(i) != blksize - 1)
                     continue;
                   init = 0;
                 }
-              unsigned int r;
-              if (rsumlen == 1)
-                r = ((unsigned int)b & 255);
-              else if (rsumlen == 2)
-                r = ((unsigned int)b & 65535);
-              else if (rsumlen == 3)
-                r = ((unsigned int)a & 255) << 16 | ((unsigned int)b & 65535);
-              else
-                r = ((unsigned int)a & 65535) << 16 | ((unsigned int)b & 65535);
+
+              unsigned int r = ((unsigned int)a & 65535) << 16 | ((unsigned int)b & 65535);
+              truncateRsum(r, rsumlen);
+
               unsigned int h = r & hm;
               unsigned int hh = 7;
-              for (; ht[h]; h = (h + hh++) & hm)
+
+              // go through our hashmap to find all the matching rsums
+              for (; rsumHashTable[h]; h = (h + hh++) & hm)
                 {
-                  size_t blkno = ht[h] - 1;
+                  size_t blkno = rsumHashTable[h] - 1;
+
+                  // does the current block match?
                   if (rsums[blkno] != r)
                     continue;
                   if (found[blkno])
                     continue;
+
+                  // if we need to always match 2 blocks in sequence, get the next block
+                  // and check its checksum
                   if (sql == 2)
                     {
                       if (eof || blkno + 1 >= nblks)
                         continue;
-                      pushback = fetchnext(fp, buf2, blksize, pushback, pushbackp);
-                      pushbackp = buf2;
+                      pushback = fetchnext(fp, buf2.get(), blksize, pushback, pushbackp);
+                      pushbackp = buf2.get();
                       if (!pushback)
                         continue;
-                      if (!checkRsum(blkno + 1, buf2, blksize))
+
+                      if (!checkRsum(blkno + 1, buf2.get(), blksize))
                         continue;
                     }
-                  if (!checkChecksumRotated(blkno, buf, blksize, i + 1))
+
+                  // here we have matched all blocks that we need, do the heavy checksum
+                  if (!checkChecksumRotated(blkno, ringBuf.get(), blksize, i + 1))
                     continue;
-                  if (sql == 2 && !checkChecksum(blkno + 1, buf2, blksize))
+
+                  // heavy checksum for second block
+                  if (sql == 2 && !checkChecksum(blkno + 1, buf2.get(), blksize))
                     continue;
-                  writeBlock(blkno, wfp, buf, blksize, i + 1, found);
+
+                  // write the first and second blocks if applicable
+                  writeBlock(blkno, wfp, ringBuf.get(), blksize, i + 1, found);
                   if (sql == 2)
                     {
-                      writeBlock(blkno + 1, wfp, buf2, blksize, 0, found);
+                      writeBlock(blkno + 1, wfp, buf2.get(), blksize, 0, found);
                       pushback = 0;
                       blkno++;
                     }
+
+                  // try to continue as long as we still match blocks
                   while (!eof)
                     {
                       blkno++;
-                      pushback = fetchnext(fp, buf2, blksize, pushback, pushbackp);
-                      pushbackp = buf2;
+                      pushback = fetchnext(fp, buf2.get(), blksize, pushback, pushbackp);
+                      pushbackp = buf2.get();
                       if (!pushback)
                         break;
-                      if (!checkRsum(blkno, buf2, blksize))
+
+                      if (!checkRsum(blkno, buf2.get(), blksize))
                         break;
-                      if (!checkChecksum(blkno, buf2, blksize))
+
+                      if (!checkChecksum(blkno, buf2.get(), blksize))
                         break;
-                      writeBlock(blkno, wfp, buf2, blksize, 0, found);
+
+                      writeBlock(blkno, wfp, buf2.get(), blksize, 0, found);
                       pushback = 0;
                     }
-                  init = false;
-                  memset(buf, 0, blksize);
+
+                  // if we get to this part we found at least a block, skip over the current block and start reading
+                  // in a full block
+                  init = true;
+                  memset(ringBuf.get(), 0, blksize);
                   a = b = 0;
                   i = size_t(-1);	// start with 0 on next iteration
                   break;
                 }
             }
         }
-      delete[] buf2;
-      delete[] buf;
-      delete[] ht;
     }
   else if (chksumlen >= 16)
     {
       // dummy variant, just check the checksums
       size_t bufl = 4096;
       off_t off = 0;
-      unsigned char *buf = new unsigned char[bufl];
+      auto buf = std::make_unique<unsigned char[]>( bufl );
       for (size_t blkno = 0; blkno < blocks.size(); ++blkno)
         {
           if (off > blocks[blkno].off)
@@ -469,23 +633,22 @@ MediaBlockList::reuseBlocks(FILE *wfp, std::string filename)
           size_t blksize = blocks[blkno].size;
           if (blksize > bufl)
             {
-              delete[] buf;
               bufl = blksize;
-              buf = new unsigned char[bufl];
+              buf = std::make_unique<unsigned char[]>( bufl );
             }
           size_t skip = blocks[blkno].off - off;
           while (skip)
             {
               size_t l = skip > bufl ? bufl : skip;
-              if (fread(buf, l, 1, fp) != 1)
+              if (fread(buf.get(), l, 1, fp) != 1)
                 break;
               skip -= l;
               off += l;
             }
-          if (fread(buf, blksize, 1, fp) != 1)
+          if (fread(buf.get(), blksize, 1, fp) != 1)
             break;
-          if (checkChecksum(blkno, buf, blksize))
-            writeBlock(blkno, wfp, buf, blksize, 0, found);
+          if (checkChecksum(blkno, buf.get(), blksize))
+            writeBlock(blkno, wfp, buf.get(), blksize, 0, found);
           off += blksize;
         }
     }

--- a/zypp-curl/parser/mediablocklist.h
+++ b/zypp-curl/parser/mediablocklist.h
@@ -97,6 +97,7 @@ public:
   bool checkChecksum(size_t blkno, const unsigned char *buf, size_t bufl) const;
   UByteArray getChecksum( size_t blkno ) const;
   std::string getChecksumType( ) const;
+  size_t checksumPad() const;
   bool createDigest(Digest &digest) const;
   bool verifyDigest(size_t blkno, Digest &digest) const;
   inline bool haveChecksum(size_t blkno) const {
@@ -107,6 +108,12 @@ public:
    * set / verify the (weak) rolling checksum over a single block
    **/
   void setRsum(size_t blkno, int rsl, unsigned int rs, size_t rspad=0);
+
+  /**
+   * how many blocks in sequence need to have the correct checksums to be
+   * considered a match
+   */
+  void setRsumSequence( uint seq );
   bool checkRsum(size_t blkno, const unsigned char *buf, size_t bufl) const;
   unsigned int updateRsum(unsigned int rs, const char *bytes, size_t len) const;
   bool verifyRsum(size_t blkno, unsigned int rs) const;
@@ -118,6 +125,7 @@ public:
    * scan a file for blocks from our blocklist. if we find a suitable block,
    * it is removed from the list
    **/
+  void reuseBlocksOld(FILE *wfp, std::string filename);
   void reuseBlocks(FILE *wfp, std::string filename);
 
   /**
@@ -141,8 +149,8 @@ private:
   size_t chksumpad;
   std::vector<unsigned char> chksums;
 
-  std::string rsumtype;
   int rsumlen;
+  uint rsumseq; // < how many consecutive matches are required
   size_t rsumpad;
   std::vector<unsigned int> rsums;
 };

--- a/zypp-curl/parser/mediablocklist.h
+++ b/zypp-curl/parser/mediablocklist.h
@@ -54,7 +54,7 @@ public:
   /**
    * return the offset/size of a block with number blkno
    **/
-  inline MediaBlock getBlock(size_t blkno) const {
+  inline const MediaBlock &getBlock(size_t blkno) const {
     return blocks[blkno];
   }
   /**
@@ -154,4 +154,3 @@ inline std::ostream & operator<<(std::ostream &str, const MediaBlockList &bl)
 } // namespace zypp
 
 #endif // ZYPP_CURL_PARSER_MEDIABLOCKLIST_H
-

--- a/zypp-curl/parser/zsyncparser.cc
+++ b/zypp-curl/parser/zsyncparser.cc
@@ -10,8 +10,8 @@
  *
  */
 
-#include <zypp/media/ZsyncParser.h>
-#include <zypp/base/Logger.h>
+#include "zsyncparser.h"
+#include <zypp-core/base/Logger.h>
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -61,7 +61,7 @@ hexstr2bytes(unsigned char *buf, const char *str, int buflen)
 }
 
 void
-ZsyncParser::parse(std::string filename)
+ZsyncParser::parse( const Pathname &filename )
 {
   char buf[4096];
 
@@ -100,6 +100,9 @@ ZsyncParser::parse(std::string filename)
     {
       if (csl < 3 || csl > 16 || rsl < 1 || rsl > 4 || sql < 1 || sql > 2)
         ZYPP_THROW(Exception("Parse Error: illegal hash lengths"));
+
+      bl.setRsumSequence( sql );
+
       size_t nblks = (filesize + blksize - 1) / blksize;
       size_t i;
       off_t off = 0;
@@ -122,7 +125,7 @@ ZsyncParser::parse(std::string filename)
               if (is.bad())
                 throw zypp::Exception( "I/O error while reading" );
               else if (is.eof())
-                throw zypp::Exception( "End of file reached successfully" );
+                throw zypp::Exception( "End of file reached unexpectedly" );
               else if (is.fail())
                 throw zypp::Exception( "Non-integer data encountered" );
               else
@@ -138,7 +141,7 @@ ZsyncParser::parse(std::string filename)
               if (is.bad())
                 throw zypp::Exception( "I/O error while reading" );
               else if (is.eof())
-                throw zypp::Exception( "End of file reached successfully" );
+                throw zypp::Exception( "End of file reached unexpectedly" );
               else if (is.fail())
                 throw zypp::Exception( "Non-integer data encountered" );
               else
@@ -149,7 +152,7 @@ ZsyncParser::parse(std::string filename)
             if (is.bad())
               throw zypp::Exception( "I/O error while reading" );
             else if (is.eof())
-              throw zypp::Exception( "End of file reached successfully" );
+              throw zypp::Exception( "End of file reached unexpectedly" );
             else if (is.fail())
               throw zypp::Exception( "Non-integer data encountered" );
             else

--- a/zypp-curl/parser/zsyncparser.h
+++ b/zypp-curl/parser/zsyncparser.h
@@ -6,18 +6,18 @@
 |                         /_____||_| |_| |_|                           |
 |                                                                      |
 \---------------------------------------------------------------------*/
-/** \file zypp/media/ZsyncParser.h
+/** \file zypp-curl/parser/zsyncparser.h
  *
 */
-#ifndef ZYPP_MEDIA_ZSYNCPARSER_H
-#define ZYPP_MEDIA_ZSYNCPARSER_H
+#ifndef ZYPP_CURL_PARSER_ZSYNCPARSER_H
+#define ZYPP_CURL_PARSER_ZSYNCPARSER_H
 
 #include <string>
 
-#include <zypp/base/Exception.h>
-#include <zypp/base/NonCopyable.h>
+#include <zypp-core/base/Exception.h>
+#include <zypp-core/base/NonCopyable.h>
 #include <zypp-curl/parser/MediaBlockList>
-#include <zypp/Url.h>
+#include <zypp-core/Url.h>
 
 namespace zypp {
   namespace media {
@@ -30,7 +30,7 @@ public:
    * parse a file consisting of zlink data
    * \throws Exception
    **/
-  void parse(std::string filename);
+  void parse( const Pathname &filename );
   /**
    * return the download urls from the parsed metalink data
    **/
@@ -53,4 +53,4 @@ private:
   } // namespace media
 } // namespace zypp
 
-#endif // ZYPP_MEDIA_ZSYNCPARSER_H
+#endif // ZYPP_CURL_PARSER_ZSYNCPARSER_H

--- a/zypp/CMakeLists.txt
+++ b/zypp/CMakeLists.txt
@@ -257,7 +257,6 @@ SET( zypp_media_SRCS
   media/MediaSource.cc
   media/MediaManager.cc
   media/MediaPriority.cc
-  media/ZsyncParser.cc
   media/UrlResolverPlugin.cc
 )
 
@@ -279,7 +278,6 @@ SET( zypp_media_HEADERS
   media/MediaNFS.h
   media/MediaSource.h
   media/MediaPriority.h
-  media/ZsyncParser.h
   media/UrlResolverPlugin.h
 )
 

--- a/zypp/CMakeLists.txt
+++ b/zypp/CMakeLists.txt
@@ -249,6 +249,7 @@ SET( zypp_media_SRCS
   media/MediaDISK.cc
   media/MediaCIFS.cc
   media/MediaNetworkCommonHandler.cc
+  media/MediaNetwork.cc
   media/MediaCurl.cc
   media/MediaMultiCurl.cc
   media/MediaISO.cc
@@ -266,6 +267,7 @@ SET( zypp_media_HEADERS
   media/MediaCurl.h
   media/MediaMultiCurl.h
   media/MediaNetworkCommonHandler.h
+  media/MediaNetwork.h
   media/MediaDIR.h
   media/MediaDISK.h
   media/MediaException.h

--- a/zypp/media/MediaHandlerFactory.cc
+++ b/zypp/media/MediaHandlerFactory.cc
@@ -13,6 +13,7 @@
 #include <zypp/media/MediaCIFS.h>
 #include <zypp/media/MediaCurl.h>
 #include <zypp/media/MediaMultiCurl.h>
+#include <zypp/media/MediaNetwork.h>
 #include <zypp/media/MediaISO.h>
 #include <zypp/media/MediaPlugin.h>
 #include <zypp/media/UrlResolverPlugin.h>
@@ -57,12 +58,12 @@ namespace zypp::media {
       _handler = std::make_unique<MediaCIFS> (url,preferred_attach_point);
     else if (scheme == "ftp" || scheme == "tftp" || scheme == "http" || scheme == "https")
     {
-      enum WhichHandler { choose, curl, multicurl };
+      enum WhichHandler { choose, curl, multicurl, network };
       WhichHandler which = choose;
       // Leagcy: choose handler in UUrl query
       if ( const std::string & queryparam = url.getQueryParam("mediahandler"); ! queryparam.empty() ) {
         if ( queryparam == "network" )
-          which = multicurl;
+          which = network;
         else if ( queryparam == "multicurl" )
           which = multicurl;
         else if ( queryparam == "curl" )
@@ -78,8 +79,8 @@ namespace zypp::media {
         };
 
         if ( getenvIs( "ZYPP_MEDIANETWORK", "1" ) ) {
-          WAR << "network backend preview was removed, defaulting to multicurl." << std::endl;
-          which = multicurl;
+          WAR << "MediaNetwork backend enabled" << std::endl;
+          which = network;
         }
         else if ( getenvIs( "ZYPP_MULTICURL", "0" ) ) {
           WAR << "multicurl manually disabled." << std::endl;
@@ -94,6 +95,10 @@ namespace zypp::media {
         default:
         case multicurl:
           handler = std::make_unique<MediaMultiCurl>( url, preferred_attach_point );
+          break;
+
+        case network:
+          handler = std::make_unique<MediaNetwork>( url, preferred_attach_point );
           break;
 
         case curl:

--- a/zypp/media/MediaNetwork.cc
+++ b/zypp/media/MediaNetwork.cc
@@ -379,7 +379,8 @@ namespace zypp {
           case zyppng::NetworkRequestError::PeerCertificateInvalid:
           case zyppng::NetworkRequestError::ConnectionFailed:
           case zyppng::NetworkRequestError::ServerReturnedError:
-          case zyppng::NetworkRequestError::MissingData:  {
+          case zyppng::NetworkRequestError::MissingData:
+          case zyppng::NetworkRequestError::RangeFail: {
             excp = ZYPP_EXCPT_PTR( zypp::media::MediaCurlException( spec.url(), error.toString(), error.nativeErrorString() ) );
             break;
           }

--- a/zypp/media/MediaNetwork.cc
+++ b/zypp/media/MediaNetwork.cc
@@ -1,0 +1,501 @@
+/*---------------------------------------------------------------------\
+|                          ____ _   __ __ ___                          |
+|                         |__  / \ / / . \ . \                         |
+|                           / / \ V /|  _/  _/                         |
+|                          / /__ | | | | | |                           |
+|                         /_____||_| |_| |_|                           |
+|                                                                      |
+\---------------------------------------------------------------------*/
+/** \file zypp/media/MediaCurl.cc
+ *
+*/
+
+#include <iostream>
+#include <list>
+#include <chrono>
+
+#include <zypp/base/Logger.h>
+#include <zypp/base/String.h>
+#include <zypp/base/Gettext.h>
+
+#include <zypp-core/parser/Sysconfig>
+#include <zypp-core/zyppng/base/EventDispatcher>
+#include <zypp-core/zyppng/base/EventLoop>
+#include <zypp-core/zyppng/base/private/threaddata_p.h>
+
+#include <zypp-curl/ng/network/Downloader>
+#include <zypp-curl/ng/network/NetworkRequestDispatcher>
+#include <zypp-curl/ng/network/DownloadSpec>
+#include <zypp-media/MediaConfig>
+
+#include <zypp/media/MediaNetwork.h>
+#include <zypp-media/auth/CredentialManager>
+#include <zypp-curl/private/curlhelper_p.h>
+#include <zypp/Target.h>
+#include <zypp/ZYppFactory.h>
+#include <zypp/ZConfig.h>
+
+
+using std::endl;
+
+namespace internal {
+
+
+    struct ProgressTracker {
+
+      using clock = std::chrono::steady_clock;
+
+      std::optional<clock::time_point> _timeStart; ///< Start total stats
+      std::optional<clock::time_point> _timeLast;	 ///< Start last period(~1sec)
+
+      double _dnlTotal	= 0.0;	///< Bytes to download or 0 if unknown
+      double _dnlLast	= 0.0;	  ///< Bytes downloaded at period start
+      double _dnlNow	= 0.0;	  ///< Bytes downloaded now
+
+      int    _dnlPercent= 0;	///< Percent completed or 0 if _dnlTotal is unknown
+
+      double _drateTotal= 0.0;	///< Download rate so far
+      double _drateLast	= 0.0;	///< Download rate in last period
+
+      void updateStats( double dltotal = 0.0, double dlnow = 0.0 )
+      {
+        clock::time_point now = clock::now();
+
+        if ( !_timeStart )
+          _timeStart = _timeLast = now;
+
+        // If called without args (0.0), recompute based on the last values seen
+        if ( dltotal && dltotal != _dnlTotal )
+          _dnlTotal = dltotal;
+
+        if ( dlnow && dlnow != _dnlNow ) {
+          _dnlNow = dlnow;
+        }
+
+        // percentage:
+        if ( _dnlTotal )
+          _dnlPercent = int(_dnlNow * 100 / _dnlTotal);
+
+        // download rates:
+        _drateTotal = _dnlNow / std::max( std::chrono::duration_cast<std::chrono::seconds>(now - *_timeStart).count(), int64_t(1) );
+
+        if ( _timeLast < now )
+        {
+          _drateLast = (_dnlNow - _dnlLast) / int( std::chrono::duration_cast<std::chrono::seconds>(now - *_timeLast).count() );
+          // start new period
+          _timeLast  = now;
+          _dnlLast   = _dnlNow;
+        }
+        else if ( _timeStart == _timeLast )
+          _drateLast = _drateTotal;
+      }
+    };
+
+
+  // All media handler instances share the same EventDispatcher and Downloader
+  // This is released at application shutdown.
+  struct SharedData {
+
+    ~SharedData() {
+      MIL << "Releasing internal::SharedData for MediaNetwork." << std::endl;
+    }
+
+    static std::shared_ptr<SharedData> instance ()  {
+      static std::shared_ptr<SharedData> data = std::shared_ptr<SharedData>( new SharedData() );
+      return data;
+    }
+
+    // we need to keep a reference
+    zyppng::EventDispatcherRef _dispatcher;
+    zyppng::DownloaderRef _downloader;
+
+    private:
+      SharedData() {
+        MIL << "Initializing internal::SharedData for MediaNetwork" << std::endl;
+        _dispatcher = zyppng::ThreadData::current().ensureDispatcher();
+        _downloader = std::make_shared<zyppng::Downloader>();
+        _downloader->requestDispatcher()->setMaximumConcurrentConnections( zypp::MediaConfig::instance().download_max_concurrent_connections() );
+      }
+  };
+
+}
+
+using namespace internal;
+using namespace zypp::base;
+
+namespace zypp {
+
+  namespace media {
+
+  MediaNetwork::MediaNetwork( const Url &      url_r,
+                              const Pathname & attach_point_hint_r )
+      : MediaNetworkCommonHandler( url_r, attach_point_hint_r,
+                                  "/",   // urlpath at attachpoint
+                                  true ) // does_download
+  {
+    MIL << "MediaNetwork::MediaNetwork(" << url_r << ", " << attach_point_hint_r << ")" << endl;
+
+    // make sure there is a event loop and downloader instance
+    _shared = internal::SharedData::instance();
+
+    if( !attachPoint().empty())
+    {
+      PathInfo ainfo(attachPoint());
+      Pathname apath(attachPoint() + "XXXXXX");
+      char    *atemp = ::strdup( apath.asString().c_str());
+      char    *atest = NULL;
+      if( !ainfo.isDir() || !ainfo.userMayRWX() ||
+          atemp == NULL || (atest=::mkdtemp(atemp)) == NULL)
+      {
+        WAR << "attach point " << ainfo.path()
+            << " is not useable for " << url_r.getScheme() << endl;
+        setAttachPoint("", true);
+      }
+      else if( atest != NULL)
+        ::rmdir(atest);
+
+      if( atemp != NULL)
+        ::free(atemp);
+    }
+  }
+
+  void MediaNetwork::attachTo (bool next)
+  {
+    if ( next )
+      ZYPP_THROW(MediaNotSupportedException(_url));
+
+    if ( !_url.isValid() )
+      ZYPP_THROW(MediaBadUrlException(_url));
+
+    // use networkdispatcher check if the scheme is supported
+    if ( !_shared->_downloader->requestDispatcher()->supportsProtocol( _url ) ) {
+      std::string msg("Unsupported protocol '");
+      msg += _url.getScheme();
+      msg += "'";
+      ZYPP_THROW(MediaBadUrlException(_url, msg));
+    }
+
+    if( !isUseableAttachPoint( attachPoint() ) )
+    {
+      setAttachPoint( createAttachPoint(), true );
+    }
+
+    disconnectFrom();
+
+    MediaSourceRef media( new MediaSource(_url.getScheme(), _url.asString()));
+    setMediaSource(media);
+  }
+
+  bool
+  MediaNetwork::checkAttachPoint(const Pathname &apoint) const
+  {
+    return MediaHandler::checkAttachPoint( apoint, true, true);
+  }
+
+  void MediaNetwork::disconnectFrom()
+  {
+  }
+
+  void MediaNetwork::releaseFrom( const std::string & ejectDev )
+  {
+    disconnect();
+  }
+
+  void MediaNetwork::runRequest ( const zyppng::DownloadSpec &spec, callback::SendReport<DownloadProgressReport> *report ) const
+  {
+    auto ev = zyppng::EventLoop::create();
+    std::vector<zyppng::connection> signalConnections;
+    OnScopeExit deferred([&](){
+      while( signalConnections.size() ) {
+        signalConnections.back().disconnect();
+        signalConnections.pop_back();
+      }
+    });
+
+    zyppng::DownloadRef dl = _shared->_downloader->downloadFile( spec );
+    std::optional<internal::ProgressTracker> progTracker;
+
+    const auto &startedSlot = [&]( zyppng::Download &req ){
+      if ( !report) return;
+      (*report)->start( spec.url(), spec.targetPath());
+    };
+
+    const auto &aliveSlot = [&]( zyppng::Download &req, off_t dlNow ){
+      if ( !report || !progTracker )
+        return;
+      progTracker->updateStats( 0.0, dlNow );
+      if ( !(*report)->progress( progTracker->_dnlPercent, spec.url(), progTracker-> _drateTotal, progTracker->_drateLast ) )
+        req.cancel();
+    };
+
+    const auto &progressSlot = [&]( zyppng::Download &req, off_t dlTotal, off_t dlNow ) {
+      if ( !report || !progTracker )
+        return;
+
+      progTracker->updateStats( dlTotal, dlNow );
+      if ( !(*report)->progress( progTracker->_dnlPercent, spec.url(), progTracker-> _drateTotal, progTracker->_drateLast ) )
+        req.cancel();
+    };
+
+    const auto &finishedSlot = [&]( zyppng::Download & ){
+      ev->quit();
+    };
+
+    bool firstTry = true;
+    const auto &authRequiredSlot = [&]( zyppng::Download &req, zyppng::NetworkAuthData &auth, const std::string &availAuth ){
+
+      //! \todo need a way to pass different CredManagerOptions here
+      CredentialManager cm(CredManagerOptions(ZConfig::instance().repoManagerRoot()));
+      CurlAuthData_Ptr credentials;
+
+      // get stored credentials
+      AuthData_Ptr cmcred = cm.getCred(_url);
+      if ( cmcred && auth.lastDatabaseUpdate() < cmcred->lastDatabaseUpdate() ) {
+        credentials.reset(new CurlAuthData(*cmcred));
+        DBG << "got stored credentials:" << endl << *credentials << endl;
+
+      } else {
+        // if not found, ask user
+        CurlAuthData_Ptr curlcred;
+        curlcred.reset(new CurlAuthData());
+        callback::SendReport<AuthenticationReport> auth_report;
+
+        // preset the username if present in current url
+        if (!_url.getUsername().empty() && firstTry)
+          curlcred->setUsername(_url.getUsername());
+        // if CM has found some credentials, preset the username from there
+        else if (cmcred)
+          curlcred->setUsername(cmcred->username());
+
+        // indicate we have no good credentials from CM
+        cmcred.reset();
+
+        std::string prompt_msg = str::Format(_("Authentication required for '%s'")) % _url.asString();
+
+        // set available authentication types from the signal
+        // might be needed in prompt
+        curlcred->setAuthType( availAuth );
+
+        // ask user
+        if (auth_report->prompt(_url, prompt_msg, *curlcred))
+        {
+          DBG << "callback answer: retry" << endl
+              << "CurlAuthData: " << *curlcred << endl;
+
+          if (curlcred->valid())
+          {
+            credentials = curlcred;
+              // if (credentials->username() != _url.getUsername())
+              //   _url.setUsername(credentials->username());
+              /**
+               *  \todo find a way to save the url with changed username
+               *  back to repoinfo or dont store urls with username
+               *  (and either forbid more repos with the same url and different
+               *  user, or return a set of credentials from CM and try them one
+               *  by one)
+               */
+          }
+        }
+        else
+        {
+          DBG << "callback answer: cancel" << endl;
+        }
+      }
+
+      if ( !credentials  ) {
+        auth = zyppng::NetworkAuthData();
+        return;
+      }
+
+      auth = *credentials;
+      if (!cmcred) {
+        credentials->setUrl(_url);
+        cm.addCred(*credentials);
+        cm.save();
+      }
+    };
+
+    signalConnections.insert( signalConnections.end(), {
+      dl->connectFunc( &zyppng::Download::sigStarted, startedSlot),
+      dl->connectFunc( &zyppng::Download::sigFinished, finishedSlot ),
+      dl->connectFunc( &zyppng::Download::sigAuthRequired, authRequiredSlot )
+    });
+
+    if ( report ) {
+      progTracker = internal::ProgressTracker();
+      signalConnections.insert( signalConnections.end(), {
+        dl->connectFunc( &zyppng::Download::sigAlive, aliveSlot ),
+        dl->connectFunc( &zyppng::Download::sigProgress, progressSlot ),
+      });
+    }
+
+    dl->start();
+    ev->run();
+
+    std::for_each( signalConnections.begin(), signalConnections.end(), []( auto &conn ) { conn.disconnect(); });
+
+    if ( report ) {
+      if ( dl->hasError() ) {
+        auto errCode = zypp::media::DownloadProgressReport::ERROR;
+        std::exception_ptr excp;
+        const auto &error = dl->lastRequestError();
+        switch ( error.type() ) {
+          case zyppng::NetworkRequestError::InternalError:
+          case zyppng::NetworkRequestError::InvalidChecksum:
+          case zyppng::NetworkRequestError::UnsupportedProtocol:
+          case zyppng::NetworkRequestError::MalformedURL:
+          case zyppng::NetworkRequestError::PeerCertificateInvalid:
+          case zyppng::NetworkRequestError::ConnectionFailed:
+          case zyppng::NetworkRequestError::ServerReturnedError:
+          case zyppng::NetworkRequestError::MissingData:  {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaCurlException( spec.url(), error.toString(), error.nativeErrorString() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::Cancelled: {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaRequestCancelledException( error.toString() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::ExceededMaxLen: {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaFileSizeExceededException( spec.url(), spec.expectedFileSize() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::TemporaryProblem: {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaTemporaryProblemException( spec.url(), error.toString() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::Timeout: {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaTimeoutException( spec.url(), error.toString() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::Forbidden: {
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaForbiddenException( spec.url(), error.toString() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::NotFound: {
+            errCode = zypp::media::DownloadProgressReport::NOT_FOUND;
+
+            //@BUG using getPathName() can result in wrong error messages
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaFileNotFoundException( _url, spec.url().getPathName() ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::Unauthorized:
+          case zyppng::NetworkRequestError::AuthFailed: {
+            errCode = zypp::media::DownloadProgressReport::ACCESS_DENIED;
+            excp = ZYPP_EXCPT_PTR( zypp::media::MediaUnauthorizedException( spec.url(), error.toString(), error.nativeErrorString(), "" ) );
+            break;
+          }
+          case zyppng::NetworkRequestError::NoError:
+            // should never happen
+            DBG << "BUG: Download error flag is set , but Error code is NoError" << std::endl;
+            break;
+        }
+
+        if ( excp ) {
+          (*report)->finish( spec.url(), errCode, error.toString() );
+          std::rethrow_exception( excp );
+        }
+      }
+      (*report)->finish( spec.url(), zypp::media::DownloadProgressReport::NO_ERROR, "" );
+    }
+  }
+
+  void MediaNetwork::getFile( const OnMediaLocation &file ) const
+  {
+    // Use absolute file name to prevent access of files outside of the
+    // hierarchy below the attach point.
+    getFileCopy( file, localPath(file.filename()).absolutename() );
+  }
+
+  void MediaNetwork::getFileCopy( const OnMediaLocation & file, const Pathname & targetFilename ) const
+  {
+    const auto &filename = file.filename();
+    Url fileurl(getFileUrl(filename));
+
+    DBG << "FILEURL IS: " << fileurl << std::endl;
+    DBG << "Downloading to: " << targetFilename << std::endl;
+
+    if( assert_dir( targetFilename.dirname() ) ) {
+      DBG << "assert_dir " << targetFilename.dirname() << " failed" << endl;
+      ZYPP_THROW( MediaSystemException(getFileUrl(file.filename()), "System error on " + targetFilename.dirname().asString()) );
+    }
+
+    zyppng::DownloadSpec spec = zyppng::DownloadSpec( fileurl, targetFilename, file.downloadSize() )
+      .setDeltaFile( file.deltafile() )
+      .setHeaderSize( file.headerSize())
+      .setHeaderChecksum( file.headerChecksum() )
+      .setTransferSettings( this->_settings );
+
+    callback::SendReport<DownloadProgressReport> report;
+    runRequest( spec, &report );
+  }
+
+  bool MediaNetwork::getDoesFileExist( const Pathname & filename ) const
+  {
+    try
+    {
+      const auto &targetFilePath = localPath(filename).absolutename();
+      Url fileurl(getFileUrl(filename));
+
+      zyppng::DownloadSpec spec = zyppng::DownloadSpec( fileurl, targetFilePath )
+        .setCheckExistsOnly( true )
+        .setTransferSettings( this->_settings );
+
+      runRequest( spec );
+      // if we get to here the request worked.
+      return true;
+    }
+    // unexpected exception
+    catch (MediaException & excpt_r)
+    {
+      ZYPP_RETHROW(excpt_r);
+    }
+
+    return false;
+  }
+
+  void MediaNetwork::getDir( const Pathname & dirname, bool recurse_r ) const
+  {
+    filesystem::DirContent content;
+    getDirInfo( content, dirname, /*dots*/false );
+
+    for ( filesystem::DirContent::const_iterator it = content.begin(); it != content.end(); ++it ) {
+        Pathname filename = dirname + it->name;
+        int res = 0;
+
+        switch ( it->type ) {
+        case filesystem::FT_NOT_AVAIL: // old directory.yast contains no typeinfo at all
+        case filesystem::FT_FILE:
+          getFile( OnMediaLocation( filename ) );
+          break;
+        case filesystem::FT_DIR: // newer directory.yast contain at least directory info
+          if ( recurse_r ) {
+            getDir( filename, recurse_r );
+          } else {
+            res = assert_dir( localPath( filename ) );
+            if ( res ) {
+              WAR << "Ignore error (" << res <<  ") on creating local directory '" << localPath( filename ) << "'" << endl;
+            }
+          }
+          break;
+        default:
+          // don't provide devices, sockets, etc.
+          break;
+        }
+    }
+  }
+
+  void MediaNetwork::getDirInfo( std::list<std::string> & retlist,
+                                const Pathname & dirname, bool dots ) const
+  {
+    getDirectoryYast( retlist, dirname, dots );
+  }
+
+  void MediaNetwork::getDirInfo( filesystem::DirContent & retlist,
+                              const Pathname & dirname, bool dots ) const
+  {
+    getDirectoryYast( retlist, dirname, dots );
+  }
+
+  } // namespace media
+} // namespace zypp
+//

--- a/zypp/media/MediaNetwork.h
+++ b/zypp/media/MediaNetwork.h
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------\
+|                          ____ _   __ __ ___                          |
+|                         |__  / \ / / . \ . \                         |
+|                           / / \ V /|  _/  _/                         |
+|                          / /__ | | | | | |                           |
+|                         /_____||_| |_| |_|                           |
+|                                                                      |
+\---------------------------------------------------------------------*/
+/** \file zypp/media/MediaNetwork.h
+ *
+*/
+#ifndef ZYPP_MEDIA_MEDIANETWORK_H
+#define ZYPP_MEDIA_MEDIANETWORK_H
+
+#include <zypp/base/Flags.h>
+#include <zypp/ZYppCallbacks.h>
+#include <zypp/media/MediaNetworkCommonHandler.h>
+
+namespace internal {
+  struct SharedData;
+}
+
+namespace zyppng {
+  class DownloadSpec;
+}
+
+namespace zypp {
+  namespace media {
+    //
+    //	CLASS NAME : MediaNetwork
+    /**
+     * @short Implementation class for FTP, HTTP and HTTPS MediaHandler
+     * @see MediaHandler
+     **/
+    class MediaNetwork : public MediaNetworkCommonHandler
+    {
+      protected:
+
+        void attachTo (bool next = false) override;
+        void releaseFrom( const std::string & ejectDev ) override;
+        void getFile( const OnMediaLocation & file ) const override;
+        void getFileCopy( const OnMediaLocation & file, const Pathname & targetFilename ) const override;
+        void getDir( const Pathname & dirname, bool recurse_r ) const override;
+        void getDirInfo( std::list<std::string> & retlist,
+                         const Pathname & dirname, bool dots = true ) const override;
+        void getDirInfo( filesystem::DirContent & retlist,
+                         const Pathname & dirname, bool dots = true ) const override;
+        /**
+         *
+         * \throws MediaException
+         *
+         */
+        void disconnectFrom() override;
+
+        /**
+         *
+         * \throws MediaException
+         *
+         */
+        bool getDoesFileExist( const Pathname & filename ) const override;
+
+        bool checkAttachPoint(const Pathname &apoint) const override;
+
+
+      public:
+
+        MediaNetwork( const Url &      url_r,
+                  const Pathname & attach_point_hint_r );
+
+        ~MediaNetwork() override { try { release(); } catch(...) {} }
+
+      private:
+
+        void runRequest ( const zyppng::DownloadSpec &spec, callback::SendReport<DownloadProgressReport> *report = nullptr ) const;
+
+      private:
+        mutable std::shared_ptr<::internal::SharedData> _shared;
+    };
+
+  } // namespace media
+} // namespace zypp
+
+#endif // ZYPP_MEDIA_MEDIANETWORK_H

--- a/zypp/media/ZsyncParser.cc
+++ b/zypp/media/ZsyncParser.cc
@@ -115,9 +115,46 @@ ZsyncParser::parse(std::string filename)
           size_t blkno = bl.addBlock(off, size);
           unsigned char rp[16];
           rp[0] = rp[1] = rp[2] = rp[3] = 0;
-          is.read((char *)rp + 4 - rsl, rsl);
+          try {
+            is.read((char *)rp + 4 - rsl, rsl);
+          } catch ( const std::exception &e ) {
+            if ( !is.good() ) {
+              if (is.bad())
+                throw zypp::Exception( "I/O error while reading" );
+              else if (is.eof())
+                throw zypp::Exception( "End of file reached successfully" );
+              else if (is.fail())
+                throw zypp::Exception( "Non-integer data encountered" );
+              else
+                throw zypp::Exception( "Unknown IO err" );
+            }
+          }
+
           bl.setRsum(blkno, rsl, rp[0] << 24 | rp[1] << 16 | rp[2] << 8 | rp[3], blksize);
-          is.read((char *)rp, csl);
+          try {
+            is.read((char *)rp, csl);
+          } catch ( const std::exception &e ) {
+            if ( !is.good() ) {
+              if (is.bad())
+                throw zypp::Exception( "I/O error while reading" );
+              else if (is.eof())
+                throw zypp::Exception( "End of file reached successfully" );
+              else if (is.fail())
+                throw zypp::Exception( "Non-integer data encountered" );
+              else
+                throw zypp::Exception( "Unknown IO err" );
+            }
+          }
+          if ( !is.good() ) {
+            if (is.bad())
+              throw zypp::Exception( "I/O error while reading" );
+            else if (is.eof())
+              throw zypp::Exception( "End of file reached successfully" );
+            else if (is.fail())
+              throw zypp::Exception( "Non-integer data encountered" );
+            else
+              throw zypp::Exception( "Unknown IO err" );
+          }
           bl.setChecksum(blkno, "MD4", csl, rp, blksize);
           off += size;
         }
@@ -143,4 +180,3 @@ ZsyncParser::getBlockList()
 
   } // namespace media
 } // namespace zypp
-


### PR DESCRIPTION
Set of a patches that add a much simpler version of the previous MediaNetwork tech preview. Instead of forking a external process and prefetching files this patch utilizes the event based Downloader code in the same process. The Downloader instance is reused between downloads, and combines small chunks from the server into bigger ones.

Chunk size is aligned to `filesize/max_concurrent_connections`, we do not want to reconnect to the same servers just to get another chunk that we could've requested in the first request. 

We also will enforce a minimum and maximum chunk size for relatively small and respectively relatively big files and have support for using zsync instead of metalink for file chunking and delta downloads.