### PR TITLE
Resolver: Fix missing --[no]-recommends initialization in update (fix…

### DIFF
--- a/zypp-core/TriBool.h
+++ b/zypp-core/TriBool.h
@@ -55,6 +55,10 @@ namespace zypp
     return ret;
   }
 
+  /** Convert TriBool to bool returning \a default_r if indeterminate.*/
+  inline bool tri2bool( const TriBool & val_r, bool default_r )
+  { return indeterminate(val_r) ? default_r : bool(val_r); }
+
   /////////////////////////////////////////////////////////////////
 } // namespace zypp
 ///////////////////////////////////////////////////////////////////

--- a/zypp/solver/detail/Resolver.h
+++ b/zypp/solver/detail/Resolver.h
@@ -80,9 +80,7 @@ class Resolver : private base::NonCopyable
     bool _upgradeMode:1;              // Resolver has been called with doUpgrade
     bool _updateMode:1;               // Resolver has been called with doUpdate
     bool _verifying:1;                // The system will be checked
-    bool _onlyRequires:1;             // do install required resolvables only
     bool _solveSrcPackages:1;         // whether to generate solver jobs for selected source packges.
-    bool _cleandepsOnRemove:1;        // whether removing a package should also remove no longer needed requirements
     bool _ignoreAlreadyRecommended:1; // ignore recommended packages that have already been recommended by the installed packages
     //@}
 


### PR DESCRIPTION
…es #openSUSE/zypper#459)

Remove local copies of _onlyRequires and _cleandepsOnRemove in Resolver. Like all the other settings they should be directly kept in SATSolver. So once set, they directly affect the next solver run. There is no benfit in setting them late in Resolver::solverInit.