### PR TITLE
Skip media.1/media download for http repo status calc

### DIFF
--- a/zypp/RepoInfo.h
+++ b/zypp/RepoInfo.h
@@ -521,6 +521,12 @@ namespace zypp
       LocaleSet getLicenseLocales( const std::string & name_r ) const;
      //@}
 
+      /**
+       * Returns true if this repository requires the media.1/media file to be included
+       * in the metadata status and repo status calculations.
+       */
+      bool requireStatusWithMediaFile () const;
+
     public:
       /**
        * Write a human-readable representation of this RepoInfo object

--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -928,7 +928,9 @@ namespace zypp
     switch ( repokind.toEnum() )
     {
       case RepoType::RPMMD_e :
-        status = RepoStatus( productdatapath/"repodata/repomd.xml") && RepoStatus( mediarootpath/"media.1/media" );
+        status = RepoStatus( productdatapath/"repodata/repomd.xml");
+        if ( info.requireStatusWithMediaFile() )
+          status = status && RepoStatus( mediarootpath/"media.1/media" );
         break;
 
       case RepoType::YAST2_e :

--- a/zypp/repo/Downloader.cc
+++ b/zypp/repo/Downloader.cc
@@ -221,6 +221,3 @@ void Downloader::defaultDownloadMasterIndex( MediaSetAccess & media_r, const Pat
 
 }// ns repo
 } // ns zypp
-
-
-

--- a/zypp/repo/yum/Downloader.cc
+++ b/zypp/repo/yum/Downloader.cc
@@ -16,6 +16,7 @@
 
 #include "Downloader.h"
 #include <zypp/repo/MediaInfoDownloader.h>
+#include <zypp/repo/SUSEMediaVerifier.h>
 #include <zypp-core/base/UserRequestException>
 #include <zypp/parser/xml/Reader.h>
 #include <zypp/parser/yum/RepomdFileReader.h>
@@ -200,8 +201,9 @@ namespace yum
 
   RepoStatus Downloader::status( MediaSetAccess & media_r )
   {
-    RepoStatus ret { media_r.provideOptionalFile( repoInfo().path() / "/repodata/repomd.xml" ) };
-    if ( !ret.empty() )	// else: mandatory master index is missing
+    const auto & ri = repoInfo();
+    RepoStatus ret { media_r.provideOptionalFile( ri.path() / "/repodata/repomd.xml" ) };
+    if ( !ret.empty() && ri.requireStatusWithMediaFile() )	// else: mandatory master index is missing
       ret = ret && RepoStatus( media_r.provideOptionalFile( "/media.1/media" ) );
     // else: mandatory master index is missing -> stay empty
     return ret;
@@ -209,6 +211,3 @@ namespace yum
 } // namespace yum
 } // namespace repo
 } // namespace zypp
-
-
-


### PR DESCRIPTION
This patch allows zypp to skip a extra media.1/media download to calculate if a repository needs to be refreshed. This optimisation only takes place if the repo does specify only downloading base urls.