### PR TITLE
Return a absolute path if a deltafile was found

### DIFF
--- a/zypp/repo/yum/Downloader.cc
+++ b/zypp/repo/yum/Downloader.cc
@@ -62,6 +62,9 @@ namespace yum
             deltafile = fn;
         }
       }
+      if ( !deltafile.empty() )
+        return dir/deltafile;
+
       return deltafile;
     }
   } // namespace
@@ -209,6 +212,3 @@ namespace yum
 } // namespace yum
 } // namespace repo
 } // namespace zypp
-
-
-


### PR DESCRIPTION
This patch fixes a issue with the deltafile lookup, only a relative path was returned which broke the deltafile code in the downloader backends.