### PR TITLE
Improve download of optional files (fixes #416)

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -183,8 +183,7 @@ IMPL_PTR_TYPE(MediaSetAccess);
   {
     try
     {
-      if ( doesFileExist( file, media_nr ) )
-        return provideFile( OnMediaLocation( file, media_nr ), PROVIDE_NON_INTERACTIVE );
+      return provideFile( OnMediaLocation( file, media_nr ).setOptional( true ), PROVIDE_NON_INTERACTIVE );
     }
     catch ( const media::MediaFileNotFoundException & excpt_r )
     { ZYPP_CAUGHT( excpt_r ); }
@@ -205,7 +204,8 @@ IMPL_PTR_TYPE(MediaSetAccess);
 
     ManagedFile tmpFile = filesystem::TmpFile::asManagedFile();
 
-    Pathname file = access.provideFile( OnMediaLocation(path, 1), options );
+    bool optional { options & PROVIDE_NON_INTERACTIVE };
+    Pathname file = access.provideFile( OnMediaLocation(path, 1).setOptional( optional ), options );
 
     //prevent the file from being deleted when MediaSetAccess gets out of scope
     if ( filesystem::hardlinkCopy(file, tmpFile) != 0 )

--- a/zypp/media/MediaCurl.h
+++ b/zypp/media/MediaCurl.h
@@ -110,7 +110,7 @@ class MediaCurl : public MediaNetworkCommonHandler
     };
 
   protected:
-//     /** Callback sending just an alive trigger to the UI, without stats (e.g. during metalink download). */
+    /** Callback sending just an alive trigger to the UI, without stats (e.g. during metalink download). */
     static int aliveCallback( void *clientp, double dltotal, double dlnow, double ultotal, double ulnow );
     /** Callback reporting download progress. */
     static int progressCallback( void *clientp, double dltotal, double dlnow, double ultotal, double ulnow );


### PR DESCRIPTION
Avoid an additional HEAD request to check whether the file is actually present. To avoid failing progress reports in case the optional file is not present, the progress report start is delayed until we actually receive some data.