### PR TITLE
Do not clean up MediaSetAccess before using the geoip file

### DIFF
--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -2619,11 +2619,10 @@ namespace zypp
           return;
         }
 
+        MediaSetAccess acc( url );
         zypp::ManagedFile file;
         try {
-
           // query the file from the server
-          MediaSetAccess acc( url );
           file = zypp::ManagedFile (acc.provideOptionalFile("/geoip"), filesystem::unlink );
 
         } catch ( const zypp::Exception &e  ) {


### PR DESCRIPTION
Due to a exception handler scope the MediaSetAccess handle was cleaned up too early, causing the file to vanish before it was parsed.