### PR TITLE
Properly reset range requests

### DIFF
--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -1035,6 +1035,7 @@ bool MediaCurl::doGetDoesFileExist( const Pathname & filename ) const
   // reset curl settings
   if (  _url.getScheme() == "http" ||  _url.getScheme() == "https" )
   {
+    curl_easy_setopt( _curl, CURLOPT_RANGE, NULL );
     curl_easy_setopt( _curl, CURLOPT_NOBODY, 0L);
     if ( ret != 0 ) {
       ZYPP_THROW(MediaCurlSetOptException(url, _curlError));


### PR DESCRIPTION
[bsc#1204548](https://bugzilla.suse.com/show_bug.cgi?id=1204548)

Stupid C error. All the error handling locations properly reset the head/range request curl settings. But the most important case, when the task succeeded, failed to reset the range request. Subsequent tasks using the same curl handle continue to request just 2 byte. Fortunately this happens only if `?head_requests=no` is set in the URL.

Now using a RAII guard to make sure the options are reset no matter how the function is left.

