### PR TITLE
MultiCurl: Make sure to reset the progress function when falling back

### DIFF
--- a/zypp/media/MediaMultiCurl.cc
+++ b/zypp/media/MediaMultiCurl.cc
@@ -1502,6 +1502,9 @@ void MediaMultiCurl::doGetFileCopy( const OnMediaLocation &srcFile , const Pathn
           file = fopen((*destNew).c_str(), "w+e");
           if (!file)
             ZYPP_THROW(MediaWriteException(destNew));
+
+          // use the default progressCallback
+          curl_easy_setopt(_curl, CURLOPT_PROGRESSFUNCTION, &MediaCurl::progressCallback);
           MediaCurl::doGetFileCopyFile(srcFile, dest, file, report, options | OPTION_NO_REPORT_START);
         }
     }


### PR DESCRIPTION
In some cases the MultiCurl backend can fall back to a normal Curl download, but if this happens after a metalink file was completely downloaded the progress function must be resetted to the default progress callback. Otherwise the alive callback is used which does not show any percentage updates.