### PR TITLE
Avoid calling getsockopt when we know the info already

### DIFF
--- a/zypp-core/zyppng/io/private/socket_p.h
+++ b/zypp-core/zyppng/io/private/socket_p.h
@@ -36,6 +36,8 @@ namespace zyppng {
       _protocol( protocol )
     { }
 
+    static Socket::Ptr wrapSocket( int fd, int domain, int type, int protocol, Socket::SocketState state );
+
     bool initSocket () ;
     void setError ( Socket::SocketError error, std::string &&err, bool emit = true );
     bool handleConnectError ( int error );


### PR DESCRIPTION
This patch hopefully fixes logging on WSL, getsockopt seems to not be fully supported but the code required it when accepting new socket connections. However we already know the required infos ( domain, protocol, type ) from the listening socket that accepts the incoming connections.