### PR TITLE
Only refresh geoip if a geoip host is used

### DIFF
--- a/zypp/RepoManager.h
+++ b/zypp/RepoManager.h
@@ -635,10 +635,10 @@ namespace zypp
     { modifyService( service.alias(), service ); }
 
     /*!
-     * Checks with configured geoIP servers ( usually download.opensuse.org ) if there is new geoip data available, caches the results
-     * in the metadata cache for 24hrs.
+     * Checks for any of the given \a urls if there is no geoip data available, caches the results
+     * in the metadata cache for 24hrs. The given urls need to be configured as valid geoIP targets ( usually download.opensuse.org )
      */
-    void refreshGeoIp ();
+    void refreshGeoIp ( const RepoInfo::url_set &urls );
 
   private:
     /**

--- a/zypp/base/Algorithm.h
+++ b/zypp/base/Algorithm.h
@@ -66,6 +66,18 @@ namespace zypp
       return cnt;
     }
 
+    template <class Container, class Elem>
+    bool contains ( const Container &c, const Elem &elem )
+    {
+      return ( std::find( c.begin(), c.end(), elem ) != c.end() );
+    }
+
+    template <class Container, class Fnc >
+    bool any_of ( const Container &c, Fnc &&cb )
+    {
+      return std::any_of( c.begin(), c.end(), std::forward<Fnc>(cb) );
+    }
+
   /////////////////////////////////////////////////////////////////
 } // namespace zypp
 ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch updates the geoip code to only contact the server for geoip data if the refreshing repository uses a configured geoip hostname in it's repodata.