### PR TITLE
capability parse richdeps

### DIFF
--- a/zypp/Capability.cc
+++ b/zypp/Capability.cc
@@ -236,11 +236,15 @@ namespace zypp
       return relFromStr( pool_r, arch_r, name, op, ed, kind_r );
     }
 
-
+    /** Parse richdeps from string, otherwise fall back to the traditional parser. */
     sat::detail::IdType richOrRelFromStr( sat::detail::CPool * pool_r, const std::string & str_r, const ResKind & prefix_r, Capability::CtorFlag flag_r )
     {
-      if ( str_r[0] == '(' )
-        return sat::detail::PoolMember::myPool().parserpmrichdep( str_r.c_str() );
+      if ( str_r[0] == '(' ) {
+        sat::detail::IdType res { sat::detail::PoolMember::myPool().parserpmrichdep( str_r.c_str() ) };
+        if ( res ) return res;
+        // else: no richdep, so fall back to the ordinary parser which in
+        // case of doubt turns the string into a NAMED cap.
+      }
       return relFromStr( pool_r, Arch_empty, str_r, prefix_r, flag_r );
     }
 

--- a/zypp/Capability.h
+++ b/zypp/Capability.h
@@ -40,10 +40,10 @@ namespace zypp
   //
   /** A sat capability.
    *
-   * A Capability: <tt>"name[.arch] [op edition]"</tt>
+   * A Capability: <tt>"name[.arch] [op edition]"</tt> or a \c richdep[1]
    *
    * If a certain \ref ResKind is specified upon construction, the
-   * capabilities name part is prefixed, unless it already conatins a
+   * capabilities name part is prefixed, unless it already contains a
    * well known kind spec. If no \ref ResKind is specified, it's assumed
    * you refer to a package or the name is already prefixed:
    * \code
@@ -55,6 +55,9 @@ namespace zypp
    * Capability( "pattern:foo", ResKind::package ) ==> 'pattern:foo'
    * Capability( "package:foo", ResKind::pattern ) ==> 'foo'
    * \endcode
+   *
+   * [1] https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html
+   * \see \ref CapDetail
    */
   class Capability: protected sat::detail::PoolMember
   {
@@ -72,14 +75,17 @@ namespace zypp
       */
       //@{
       /** Ctor from string.
+       * \a str_r is parsed to see if it forms a richdep. Subsequent arguments are meaningless
+       * in that case. If it's no richdep we continue as described below.
+       *
        * \a str_r is parsed to check whether it contains an <tt>[op edition]</tt> part,
        * unless the \ref PARSED flag is passed to the ctor. In that case <tt>"name[.arch]"</tt>
        * is assumed.
-       * If \a str_r starts with a \c ( it is parsed as a richdep[1]. Subsequent arguments are
-       * meaningless in that case.
        *
-       * [1] https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html
-      */
+       * \ref Capability legacy is to parse everything unknown into a \ref NAMED
+       * cap. This is often used to turn user supplied search strings with an optional
+       * edition range restriction into \ref PoolQuery arguments ('/gcc[0-9]+/ >= 8').
+       */
       explicit Capability( const char * str_r, const ResKind & prefix_r = ResKind(), CtorFlag flag_r = UNPARSED );
       /** \overload */
       explicit Capability( const std::string & str_r, const ResKind & prefix_r = ResKind(), CtorFlag flag_r = UNPARSED );
@@ -295,9 +301,10 @@ namespace zypp
    * \endcode
    * or formed by some \c EXPRESSION:
    * \code
-   *   left_cap op right_cap
-   *   with op := AND|OR|WITH|NAMESPACE
+   *   ( left_cap op right_cap )
+   *   with op := and|or|if|unless|else|with|without
    * \endcode
+   *
    */
   class CapDetail: protected sat::detail::PoolMember
   {

--- a/zypp/Capability.h
+++ b/zypp/Capability.h
@@ -354,7 +354,7 @@ namespace zypp
       bool     hasArch()  const { return _archIfSimple; }
       IdString arch()     const { return _archIfSimple ? IdString( _archIfSimple ) : IdString(); }
       IdString name()     const { return isSimple()    ? IdString( _lhs ) : IdString(); }
-      Rel      op()       const { return isVersioned() ? Rel( _flag )     : Rel::ANY; }
+      Rel      op()       const { return isVersioned() ? Rel( _flag )     : isSimple() ? Rel::ANY : Rel::NONE; }
       Edition  ed()       const { return isVersioned() ? Edition( _rhs )  : Edition(); }
       //@}
 


### PR DESCRIPTION
Capability legacy is to parse everything unknown into a NAMED cap. Parsing from string must not return Capability::Null.

But more important: fix CapDetail to return Rel::NONE if an EXPRESSION is used as a NAMED cap.
This bug was disguised by the fact that we did not  parse richdeps (or other EXPRESSIONs) from user supplied strings before. Wrongly treating an EXPRESSION as NAMED for a query is a bug per se, but  with this fix it should at least match nothing, rather than everything.