### PR TITLE
multicurl: propagate ssl settings stored in repo url

### DIFF
--- a/doc/autoinclude/EnvironmentVariables.doc
+++ b/doc/autoinclude/EnvironmentVariables.doc
@@ -30,8 +30,11 @@
 \li (\c ZYPP_LIBSAT_FULLLOG=1) deprecated since \c libzypp-10.x, prefer \c ZYPP_LIBSOLV_FULLLOG
 \li \c LIBSOLV_DEBUGMASK=<INT> Pass value to libsolv::pool_setdebugmask
 
+\li \c ZYPP_MEDIANETWORK=1 Turn on the media network backend (the upcoming default).
 \li \c ZYPP_MEDIA_CURL_DEBUG=<1|2> Log http headers, if \c 2 also log server responses.
 \li \c ZYPP_MEDIA_CURL_IPRESOLVE=<4|6> Tell curl to resolve names to IPv4/IPv6 addresses only.
+\li \c ZYPP_METALINK_DEBUG=1 Log URL and priority of the mirrors parsed from a metalink file.
+\li \c ZYPP_MULTICURL=0 Turn off multicurl (metalink and zsync) and fall back to plain libcurl.
 
 \li \c ZYPP_RPM_DEBUG=1 Log verbose output from all rpm commands.
 

--- a/zypp-curl/curlhelper.cc
+++ b/zypp-curl/curlhelper.cc
@@ -355,10 +355,11 @@ Url clearQueryString(const Url &url)
 }
 
 // bsc#933839: propagate proxy settings passed in the repo URL
+// boo#1127591: propagate ssl settings passed in the repo URL
 zypp::Url propagateQueryParams( zypp::Url url_r, const zypp::Url & template_r )
 {
   using namespace std::literals::string_literals;
-  for ( const std::string &param : { "proxy"s, "proxyport"s, "proxyuser"s, "proxypass"s} )
+  for ( const std::string &param : { "proxy"s, "proxyport"s, "proxyuser"s, "proxypass"s, "ssl_capath"s, "ssl_verify"s } )
   {
     const std::string & value( template_r.getQueryParam( param ) );
     if ( ! value.empty() )

--- a/zypp-curl/parser/metalinkparser.cc
+++ b/zypp-curl/parser/metalinkparser.cc
@@ -23,6 +23,19 @@
 
 using namespace zypp::base;
 
+namespace zypp::env
+{
+  /** Hack to circumvent the currently poor --root support. */
+  inline bool ZYPP_METALINK_DEBUG()
+  {
+    static bool val = [](){
+      const char * env = getenv("ZYPP_METALINK_DEBUG");
+      return( env && zypp::str::strToBool( env, true ) );
+    }();
+    return val;
+  }
+}
+
 namespace zypp::media {
   enum ParserState {
     STATE_START,
@@ -414,9 +427,7 @@ MetaLinkParser::~MetaLinkParser()
 void
 MetaLinkParser::parse(const Pathname &filename)
 {
-  MIL << "Begin parse " << filename << std::endl;
   parse(InputStream(filename));
-  MIL << "End parse " << filename << std::endl;
 }
 
 void
@@ -431,6 +442,11 @@ MetaLinkParser::parse(const InputStream &is)
       parseBytes(buf, is.stream().gcount());
     }
   parseEnd();
+  MIL << "Parsed " << pd->urls.size() << " mirrors from " << is.path() << std::endl;
+  if ( env::ZYPP_METALINK_DEBUG() ) {
+    for ( const auto &mirr : pd->urls )
+      DBG << "- " << mirr.priority << " " << mirr.url << std::endl;
+  }
 }
 
 void

--- a/zypp-curl/parser/zsyncparser.cc
+++ b/zypp-curl/parser/zsyncparser.cc
@@ -25,6 +25,19 @@
 using std::endl;
 using namespace zypp::base;
 
+namespace zypp::env
+{
+  /** Hack to circumvent the currently poor --root support. */
+  inline bool ZYPP_METALINK_DEBUG()
+  {
+    static bool val = [](){
+      const char * env = getenv("ZYPP_METALINK_DEBUG");
+      return( env && zypp::str::strToBool( env, true ) );
+    }();
+    return val;
+  }
+}
+
 namespace zypp {
   namespace media {
 
@@ -163,6 +176,11 @@ ZsyncParser::parse( const Pathname &filename )
         }
     }
   is.close();
+  MIL << "Parsed " << urls.size() << " mirrors from " << filename << std::endl;
+  if ( env::ZYPP_METALINK_DEBUG() ) {
+    for ( const auto &url : urls )
+      DBG << "- " <<  url << std::endl;
+  }
 }
 
 std::vector<Url>


### PR DESCRIPTION
[bsc#1127591](https://bugzilla.opensuse.org/show_bug.cgi?id=1127591)
fixes #335
