### PR TITLE
zypp.conf: Introduce 'download.connect_timeout' [60 sec.] (bsc#1208329)

### DIFF
--- a/zypp-media/mediaconfig.cc
+++ b/zypp-media/mediaconfig.cc
@@ -14,8 +14,6 @@
 #include <zypp-core/Pathname.h>
 #include <zypp-core/base/String.h>
 
-#define  CONNECT_TIMEOUT        60
-
 namespace zypp {
 
   class MediaConfigPrivate {
@@ -27,7 +25,7 @@ namespace zypp {
       , download_max_download_speed	( 0 )
       , download_max_silent_tries	( 5 )
       , download_transfer_timeout	( 180 )
-      , download_connect_timeout        ( CONNECT_TIMEOUT )
+      , download_connect_timeout        ( 60 )
     { }
 
     Pathname credentials_global_dir_path;
@@ -76,6 +74,12 @@ namespace zypp {
 
       } else if ( entry == "download.max_silent_tries" ) {
         str::strtonum(value, d->download_max_silent_tries);
+        return true;
+
+      } else if ( entry == "download.connect_timeout" ) {
+        str::strtonum(value, d->download_connect_timeout);
+        if ( d->download_connect_timeout < 0 )
+          d->download_connect_timeout = 0;
         return true;
 
       } else if ( entry == "download.transfer_timeout" ) {

--- a/zypp.conf
+++ b/zypp.conf
@@ -182,6 +182,17 @@
 # download.max_silent_tries = 5
 
 ##
+## Maximum time in seconds that you allow the connection phase to the server to take.
+##
+## This only limits the connection phase, it has no impact once it has connected.
+## (see also CURLOPT_CONNECTTIMEOUT)
+##
+## Valid values:  Integer
+## Default value: 60
+##
+# download.connect_timeout = 60
+
+##
 ## Maximum time in seconds that you allow a transfer operation to take.
 ##
 ## This is useful for preventing your batch jobs from hanging for hours due


### PR DESCRIPTION
Maximum time in seconds that you allow the connection phase to the server to take. This only limits the connection phase, it has no impact once it has connected. (see also CURLOPT_CONNECTTIMEOUT)