### PR TITLE
Do not unconditionally release a medium if provideFile failed (bsc#12…

### DIFF
--- a/zypp/MediaSetAccess.cc
+++ b/zypp/MediaSetAccess.cc
@@ -293,20 +293,6 @@ IMPL_PTR_TYPE(MediaSetAccess);
 
         do
         {
-          if (user != media::MediaChangeReport::EJECT) // no use in calling this again
-          {
-            DBG << "Media couldn't provide file " << file << " , releasing." << endl;
-            try
-            {
-              media_mgr.release(media);
-            }
-            catch (const Exception & excpt_r)
-            {
-                ZYPP_CAUGHT(excpt_r);
-                MIL << "Failed to release media " << media << endl;
-            }
-          }
-
           // set up the reason
           media::MediaChangeReport::Error reason = media::MediaChangeReport::INVALID;
 


### PR DESCRIPTION
[bsc#1211661](https://bugzilla.suse.com/show_bug.cgi?id=1211661)

MediaSetAccess continues and re-uses an attached medium as long as files are provided successfully. Unconditionally releasing the medium after a file could not be provided is not needed. We can continue with the next file, if there is one.

We can leave it to the exception handling. If the MediaSetAccess goes out of scope, it's released anyway. If the exception is handled earlier, we can continue to use it.

Only in case we interactively request a new medium from the user, the medium needs to be discarded. But this case calls MediaManager::releaseAll anyway.