### PR TITLE
curl: Trim user agent string (bsc#1212187)

### DIFF
--- a/zypp-curl/transfersettings.cc
+++ b/zypp-curl/transfersettings.cc
@@ -114,11 +114,11 @@ namespace zypp
       return _impl->_headers;
     }
 
-    void TransferSettings::setUserAgentString( const std::string && val_r )
-    { _impl->_useragent = val_r; }
+    void TransferSettings::setUserAgentString( const std::string &val_r )
+    { _impl->_useragent = str::rtrim( val_r ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
 
     void TransferSettings::setUserAgentString( std::string && val_r )
-    { _impl->_useragent = std::move(val_r); }
+    { _impl->_useragent = str::rtrim( std::move(val_r) ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
 
     const std::string &TransferSettings::userAgentString() const
     { return _impl->_useragent; }

--- a/zypp-curl/transfersettings.h
+++ b/zypp-curl/transfersettings.h
@@ -46,7 +46,7 @@ namespace zypp
 
       /** sets the user agent ie: "Mozilla v3" */
       void setUserAgentString( std::string && val_r );
-      void setUserAgentString( const std::string && val_r );
+      void setUserAgentString( const std::string &val_r );
 
       /** user agent string */
       const std::string &userAgentString() const;

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -282,18 +282,18 @@ namespace internal {
     // agent string.
     // The target could be not initialized, and then this information
     // is guessed.
-    static const std::string _value(
-      str::form(
-        "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s"
-        , curl_version_info(CURLVERSION_NOW)->version
-        , Target::targetDistribution( Pathname()/*guess root*/ ).c_str()
-        )
-      );
+    // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
+    static const std::string _value( str::rtrim( str::form(
+      "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s"
+      , curl_version_info(CURLVERSION_NOW)->version
+      , Target::targetDistribution( Pathname()/*guess root*/ ).c_str()
+    )));
     return _value.c_str();
   }
 
   /// Attempt to work around certain issues by autoretry in MediaCurl::getFileCopy
   /// E.g. curl error: 92: HTTP/2 PROTOCOL_ERROR as in bsc#1205843, zypper/issues/457,...
+  /// ma: These errors were caused by a space terminated user agent string (bsc#1212187)
   class MediaCurlExceptionMayRetryInternaly : public media::MediaCurlException
   {
   public:


### PR DESCRIPTION
HTTP/2 RFC 9113 forbids fields ending with a space. Violation results in curl error: 92: HTTP/2 PROTOCOL_ERROR.