### PR TITLE
Curl: trim custom headers (bsc#1212187)

### DIFF
--- a/zypp-curl/ng/network/request.cc
+++ b/zypp-curl/ng/network/request.cc
@@ -371,7 +371,8 @@ namespace zyppng {
       setCurlOption(CURLOPT_PROXY_TRANSFER_MODE, 1L );
 #endif
 
-      // append settings custom headers to curl
+      // Append settings custom headers to curl.
+      // TransferSettings assert strings are trimmed (HTTP/2 RFC 9113)
       for ( const auto &header : locSet.headers() ) {
         if ( !z_func()->addRequestHeader( header.c_str() ) )
           ZYPP_THROW(zypp::media::MediaCurlInitException(_url));

--- a/zypp-curl/transfersettings.cc
+++ b/zypp-curl/transfersettings.cc
@@ -65,6 +65,17 @@ namespace zypp
       { return new Impl( *this ); }
 
     public:
+      void safeAddHeader( std::string val_r ) {
+        // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space.
+        // Trim and discard empty header.
+        val_r = str::trim( std::move(val_r) );
+        if ( not val_r.empty() )
+          _headers.push_back( std::move(val_r) );
+        else
+          WAR << "Discard empty header" << endl;
+      }
+
+    public:
       std::vector<std::string> _headers;
       std::string _useragent;
       std::string _username;
@@ -103,10 +114,9 @@ namespace zypp
 
 
     void TransferSettings::addHeader( const std::string & val_r )
-    { if ( ! val_r.empty() ) _impl->_headers.push_back(val_r); }
-
+    { _impl->safeAddHeader( val_r ); }
     void TransferSettings::addHeader( std::string && val_r )
-    { if ( ! val_r.empty() ) _impl->_headers.push_back(std::move(val_r)); }
+    { _impl->safeAddHeader( std::move(val_r) ); }
 
     const TransferSettings::Headers &TransferSettings::headers() const
     {
@@ -115,10 +125,10 @@ namespace zypp
     }
 
     void TransferSettings::setUserAgentString( const std::string &val_r )
-    { _impl->_useragent = str::rtrim( val_r ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
+    { _impl->_useragent = str::trim( val_r ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
 
     void TransferSettings::setUserAgentString( std::string && val_r )
-    { _impl->_useragent = str::rtrim( std::move(val_r) ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
+    { _impl->_useragent = str::trim( std::move(val_r) ); }  // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
 
     const std::string &TransferSettings::userAgentString() const
     { return _impl->_useragent; }

--- a/zypp-curl/transfersettings.h
+++ b/zypp-curl/transfersettings.h
@@ -23,9 +23,13 @@ namespace zypp
   namespace media
   {
 
-    /**
-     * Holds transfer setting
-     */
+    ///////////////////////////////////////////////////////////////////
+    /// \brief Holds transfer setting
+    ///
+    /// \note bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a
+    /// space. The class asserts \ref headers and \ref userAgentString
+    /// return trimmed strings. Strings are trimmed when set. Empty
+    //  strings are discarded.
     class TransferSettings
     {
     public:
@@ -37,18 +41,18 @@ namespace zypp
       /** reset the settings to the defaults */
       void reset();
 
-      /** add a header, on the form "Foo: Bar" */
+      /** add a header, on the form "Foo: Bar" (trims)*/
       void addHeader( std::string && val_r );
       void addHeader( const std::string & val_r );
 
-      /** returns a list of all added headers */
+      /** returns a list of all added headers (trimmed) */
       const Headers &headers() const;
 
-      /** sets the user agent ie: "Mozilla v3" */
+      /** sets the user agent ie: "Mozilla v3" (trims) */
       void setUserAgentString( std::string && val_r );
       void setUserAgentString( const std::string &val_r );
 
-      /** user agent string */
+      /** user agent string (trimmed)*/
       const std::string &userAgentString() const;
 
 

--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -254,11 +254,11 @@ namespace internal {
     // agent string.
     // The target could be not initialized, and then this information
     // is guessed.
-    static const std::string _value(
-      str::trim( str::form(
-        "X-ZYpp-AnonymousId: %s",
-        Target::anonymousUniqueId( Pathname()/*guess root*/ ).c_str() ) )
-      );
+    // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
+    static const std::string _value( str::trim( str::form(
+      "X-ZYpp-AnonymousId: %s",
+      Target::anonymousUniqueId( Pathname()/*guess root*/ ).c_str()
+    )));
     return _value.c_str();
   }
 
@@ -268,11 +268,11 @@ namespace internal {
     // agent string.
     // The target could be not initialized, and then this information
     // is guessed.
-    static const std::string _value(
-      str::trim( str::form(
-        "X-ZYpp-DistributionFlavor: %s",
-        Target::distributionFlavor( Pathname()/*guess root*/ ).c_str() ) )
-      );
+    // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
+    static const std::string _value( str::trim( str::form(
+      "X-ZYpp-DistributionFlavor: %s",
+      Target::distributionFlavor( Pathname()/*guess root*/ ).c_str()
+    )));
     return _value.c_str();
   }
 
@@ -283,7 +283,7 @@ namespace internal {
     // The target could be not initialized, and then this information
     // is guessed.
     // bsc#1212187: HTTP/2 RFC 9113 forbids fields ending with a space
-    static const std::string _value( str::rtrim( str::form(
+    static const std::string _value( str::trim( str::form(
       "ZYpp " LIBZYPP_VERSION_STRING " (curl %s) %s"
       , curl_version_info(CURLVERSION_NOW)->version
       , Target::targetDistribution( Pathname()/*guess root*/ ).c_str()
@@ -635,18 +635,15 @@ void MediaCurl::setupEasy()
 
 #if CURLVERSION_AT_LEAST(7,18,0)
   // bnc #306272
-    SET_OPTION(CURLOPT_PROXY_TRANSFER_MODE, 1L );
+  SET_OPTION(CURLOPT_PROXY_TRANSFER_MODE, 1L );
 #endif
-  // append settings custom headers to curl
-  for ( const auto &header : vol_settings.headers() )
-  {
-    // MIL << "HEADER " << *it << std::endl;
-
-      _customHeaders = curl_slist_append(_customHeaders, header.c_str());
-      if ( !_customHeaders )
-          ZYPP_THROW(MediaCurlInitException(_url));
+  // Append settings custom headers to curl.
+  // TransferSettings assert strings are trimmed (HTTP/2 RFC 9113)
+  for ( const auto &header : vol_settings.headers() ) {
+    _customHeaders = curl_slist_append(_customHeaders, header.c_str());
+    if ( !_customHeaders )
+      ZYPP_THROW(MediaCurlInitException(_url));
   }
-
   SET_OPTION(CURLOPT_HTTPHEADER, _customHeaders);
 }
 


### PR DESCRIPTION
HTTP/2 RFC 9113 forbids fields ending with a space. So we make sure custom headers are trimmed.