### PR TITLE
Fix bsc 1213673

### DIFF
--- a/zypp-curl/ng/network/private/downloaderstates/basicdownloader_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/basicdownloader_p.cc
@@ -167,7 +167,7 @@ namespace zyppng {
   {
     auto &sm = stateMachine();
     const off_t expFSize = sm._spec.expectedFileSize();
-    if ( expFSize  > 0 && expFSize < dlnow ) {
+    if ( expFSize  > 0 && expFSize < req.downloadedByteCount() ) {
       sm._requestDispatcher->cancel( req, NetworkRequestErrorPrivate::customError( NetworkRequestError::ExceededMaxLen ) );
       return;
     }

--- a/zypp-curl/ng/network/private/downloaderstates/metalinkinfo_p.cc
+++ b/zypp-curl/ng/network/private/downloaderstates/metalinkinfo_p.cc
@@ -143,7 +143,7 @@ namespace zyppng {
 
     if ( _detectedMetaType != MetaDataType::None ) {
       // this is a metalink file change the expected filesize
-      if ( zypp::ByteCount( 2, zypp::ByteCount::MB) < static_cast<zypp::ByteCount::SizeType>( dlnow ) ) {
+      if ( zypp::ByteCount( 2, zypp::ByteCount::MB) < req.downloadedByteCount() ) {
         WAR << "Metadata file exceeds 2MB in filesize, aborting."<<std::endl;
         sm._requestDispatcher->cancel( req, NetworkRequestErrorPrivate::customError( NetworkRequestError::ExceededMaxLen ) );
         return;


### PR DESCRIPTION
In some cases when downloading very small files we can run into issues when the URL
is protected by credentials:

Curl will by default first try to send a request without credentials to the server
and only if the server responds with HTTP-401, Curl issues a 2nd request this time
including the configured credentials.

Until Curl detects this situation it will call the progress callback with the currently
downloaded bytes in the request. So if the server sends a big payload with the HTTP-401
response the code triggered the FileSizeExceeded error and cancelled.

This patch works around this issue by checking against the bytes
actually written into the target file instead of dlnow reported by Curl.