### PR TITLE
Revert "Color download progress bar"

### DIFF
--- a/zypp-tui/output/OutNormal.cc
+++ b/zypp-tui/output/OutNormal.cc
@@ -262,7 +262,7 @@ void OutNormal::dwnldProgressStart( const zypp::Url & uri )
     outstr.rhs << '[' ;
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << (ColorContext::HIGHLIGHT << outline) << PROGRESS_FLUSH;
+  cout << outline << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
 
   _newline = false;
@@ -303,7 +303,7 @@ void OutNormal::dwnldProgress( const zypp::Url & uri, int value, long rate )
   outstr.rhs << ']';
 
   std::string outline( outstr.get( termwidth() ) );
-  cout << (ColorContext::HIGHLIGHT << outline) << PROGRESS_FLUSH;
+  cout << outline << PROGRESS_FLUSH;
   // no _oneup if CRUSHed // _oneup = (outline.length() > termwidth());
   _newline = false;
 }
@@ -317,36 +317,34 @@ void OutNormal::dwnldProgressEnd( const zypp::Url & uri, long rate, zypp::TriBoo
     cout << ColorContext::MSG_STATUS;
 
   TermLine outstr( TermLine::SF_CRUSH | TermLine::SF_EXPAND, '.' );
-  ColorStream lhs { outstr.lhs.stream(), ColorContext::HIGHLIGHT };
-  ColorStream rhs { outstr.rhs.stream(), ColorContext::HIGHLIGHT };
   if ( _isatty )
   {
     if( _oneup )
       cout << ansi::tty::clearLN << ansi::tty::cursorUP;
     cout << ansi::tty::clearLN;
-    lhs << _("Retrieving:") << " ";
+    outstr.lhs << _("Retrieving:") << " ";
     if ( verbosity() == DEBUG )
-      lhs << uri;
+      outstr.lhs << uri;
     else
-      lhs << zypp::Pathname(uri.getPathName()).basename();
-    lhs << ' ';
-    rhs << '[';
+      outstr.lhs << zypp::Pathname(uri.getPathName()).basename();
+    outstr.lhs << ' ';
+    outstr.rhs << '[';
     if ( zypp::indeterminate( error ) )
       // Translator: download progress bar result: "........[not found]"
-      rhs << CHANGEString(_("not found") );
+      outstr.rhs << CHANGEString(_("not found") );
     else if ( error )
       // Translator: download progress bar result: "............[error]"
-      rhs << NEGATIVEString(_("error") );
+      outstr.rhs << NEGATIVEString(_("error") );
     else
       // Translator: download progress bar result: ".............[done]"
-      rhs << _("done");
+      outstr.rhs << _("done");
   }
   else
-    rhs << ( zypp::indeterminate( error ) ? _("not found") : ( error ? _("error") : _("done") ) );
+    outstr.rhs << ( zypp::indeterminate( error ) ? _("not found") : ( error ? _("error") : _("done") ) );
 
   if ( rate > 0 )
-    rhs << " (" << zypp::ByteCount(rate) << "/s)";
-  rhs << ']';
+    outstr.rhs << " (" << zypp::ByteCount(rate) << "/s)";
+  outstr.rhs << ']';
 
   std::string outline( outstr.get( termwidth() ) );
   cout << outline << endl << std::flush;


### PR DESCRIPTION
This reverts the code originally added in zypper's commit f141cf5579a460cb46093dfa130f25b03efaefce and which was later moved to libzypp.

Cyan is already used for the output of RPM scriptlets. Avoid this colorific collision between download progress bar and scriptlet output. See
https://github.com/openSUSE/zypper/pull/475#issuecomment-1382740585 for picture.

The download bar is already distinguishable from the preceding status line by the long streak of dashes/dots.