### PR TITLE
Fix zypp/Arch.h for clang (fixes #478)

### DIFF
--- a/zypp-tui/output/Out.h
+++ b/zypp-tui/output/Out.h
@@ -446,8 +446,8 @@ public:
   };
   ZYPP_DECLARE_FLAGS(Type,TypeBit);
 
-  static constexpr Type TYPE_NONE	= TypeBit(0x00);
-  static constexpr Type TYPE_ALL	= TypeBit(0xff);
+  static constexpr Type TYPE_NONE       = Type(0x00);
+  static constexpr Type TYPE_ALL	= Type(0xff);
 
   using PromptId = unsigned;
 

--- a/zypp/Arch.h
+++ b/zypp/Arch.h
@@ -134,8 +134,11 @@ namespace zypp
     /** */
     static std::string asString( const CompatSet & cset )
     {
-      return str::join( make_transform_iterator( cset.begin(), std::mem_fn(&Arch::asString) ),
-                        make_transform_iterator( cset.end(), std::mem_fn(&Arch::asString) ) );
+      // Explicitely select the overload we want, clang seems to choke if there is a static overload for the
+      // member function we want to capture in std::mem_fn (fixes GH-478)
+      const std::string & (Arch::*memfn)( ) const = &Arch::asString;
+      return str::join( make_transform_iterator( cset.begin(), std::mem_fn( memfn ) ),
+                        make_transform_iterator( cset.end(), std::mem_fn( memfn ) ) );
     }
 
   public:


### PR DESCRIPTION
Clang seems to have issues with picking the overload in std::men_fn if there is a static overload of a member function. We need to explicitely specify the correct type of the function pointer.
To make sure this would not break compiling a application with clang that builds against libzypp this patch works around the problem.