### PR TITLE
Disable multicurl by default

### DIFF
--- a/doc/autoinclude/EnvironmentVariables.doc
+++ b/doc/autoinclude/EnvironmentVariables.doc
@@ -34,13 +34,13 @@
 \li \c ZYPP_MEDIA_CURL_DEBUG=<1|2> Log http headers, if \c 2 also log server responses.
 \li \c ZYPP_MEDIA_CURL_IPRESOLVE=<4|6> Tell curl to resolve names to IPv4/IPv6 addresses only.
 \li \c ZYPP_METALINK_DEBUG=1 Log URL and priority of the mirrors parsed from a metalink file.
-\li \c ZYPP_MULTICURL=0 Turn off multicurl (metalink and zsync) and fall back to plain libcurl.
+\li \c ZYPP_MULTICURL=1 Turn on multicurl (metalink and zsync) instead of plain libcurl
 
 \li \c ZYPP_RPM_DEBUG=1 Log verbose output from all rpm commands.
 
 \subsection zypp-envars-mediabackend Selecting the mediabackend to use.
 
-\li \c ZYPP_MULTICURL=0 Turn off multicurl (metalink and zsync) and fall back to plain libcurl.
+\li \c ZYPP_MULTICURL=1 Turn on multicurl (metalink and zsync) instead of plain libcurl
 \li \c ZYPP_MEDIANETWORK=1 Turn on the new multithreaded backend (experimental)
 
 \subsection zypp-envars-plugin Variables related to plugins

--- a/package/libzypp.changes
+++ b/package/libzypp.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Aug 17 06:44:11 UTC 2023 - Dirk Müller <dmueller@suse.com>
+
+- disable MULTICURL by default, set ZYPP_MULTICURL=1
+
+-------------------------------------------------------------------
 Wed Aug 16 16:54:34 CEST 2023 - ma@suse.de
 
 - Fix zypp-tui/output/Out.h to build with clang.

--- a/zypp/media/MediaHandlerFactory.cc
+++ b/zypp/media/MediaHandlerFactory.cc
@@ -82,12 +82,12 @@ namespace zypp::media {
           WAR << "MediaNetwork backend enabled" << std::endl;
           which = network;
         }
-        else if ( getenvIs( "ZYPP_MULTICURL", "0" ) ) {
-          WAR << "multicurl manually disabled." << std::endl;
-          which = curl;
+        else if ( getenvIs( "ZYPP_MULTICURL", "1" ) ) {
+          WAR << "multicurl manually enabled." << std::endl;
+          which = multicurl;
         }
         else
-          which = multicurl;
+          which = curl;
       }
       // Finally use the default
       std::unique_ptr<MediaNetworkCommonHandler> handler;


### PR DESCRIPTION
Multicurl is not quite an improvement anymore. It picks up chunks based on the filesize that make it connect to 4-5 mirrors for each file. The thing is that the connection overhead on high latency mirrors is so high that there isn't a way to get decent performance, and given the really bad connection reusage we are always in tcp slow start.