### PR TITLE
Add missing include to fix build failure with new compiler in Debian

### DIFF
--- a/zypp/target/rpm/RpmHeader.cc
+++ b/zypp/target/rpm/RpmHeader.cc
@@ -11,6 +11,8 @@
 */
 #include "librpm.h"
 
+#include <cstring>
+
 #include <zypp/AutoDispose.h>
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
```
 /<<PKGBUILDDIR>>/zypp/target/rpm/RpmHeader.cc: In function ‘int unameToUid(const char*, uid_t*)’:
 /<<PKGBUILDDIR>>/zypp/target/rpm/RpmHeader.cc:41:16: error: ‘strcmp’ was not declared in this scope
    41 |     } else if (strcmp(thisUname, "root") == 0) {
```