### PR TITLE
Use --runposttrans if rpm supports it

### DIFF
--- a/zypp-core/base/inputstream.h
+++ b/zypp-core/base/inputstream.h
@@ -28,9 +28,9 @@ namespace zypp
   //
   /** Helper to create and pass std::istream.
    * The provided std::istream may either be std::cin,
-   * sone (gziped) file or an aleady existig \c std::istream.
+   * some (gziped) file or an already existing \c std::istream.
    *
-   * An optional \c name arument may be passed to the ctor,
+   * An optional \c name argument may be passed to the ctor,
    * to identify the stream in log messages, even if it is
    * not a file.
    *
@@ -120,7 +120,7 @@ namespace zypp
 
     /** Set the size of the input stream.
      * You may set it to whatever vaule is appropriate. E.g.
-     * <tt>*=10</tt> to compensate gzip comression. or the
+     * <tt>*=10</tt> to compensate gzip compression. or the
      * number of items, lines, ... The value is not used here,
      * just provided.
     */

--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -10,9 +10,13 @@
  */
 #include <iostream>
 #include <fstream>
+#include <optional>
 #include <zypp/base/LogTools.h>
 #include <zypp/base/NonCopyable.h>
 #include <zypp/base/Gettext.h>
+#include <zypp/base/Regex.h>
+#include <zypp/base/IOStream.h>
+#include <zypp/base/InputStream.h>
 #include <zypp/target/RpmPostTransCollector.h>
 
 #include <zypp/TmpPath.h>
@@ -20,7 +24,7 @@
 #include <zypp/HistoryLog.h>
 #include <zypp/ZYppCallbacks.h>
 #include <zypp/ExternalProgram.h>
-#include <zypp/target/rpm/RpmHeader.h>
+#include <zypp/target/rpm/RpmDb.h>
 #include <zypp/target/rpm/librpmDb.h>
 #include <zypp/ZConfig.h>
 #include <zypp/ZYppCallbacks.h>
@@ -35,7 +39,6 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
   namespace target
   {
-
     ///////////////////////////////////////////////////////////////////
     /// \class RpmPostTransCollector::Impl
     /// \brief RpmPostTransCollector implementation.
@@ -44,6 +47,22 @@ namespace zypp
     {
       friend std::ostream & operator<<( std::ostream & str, const Impl & obj );
       friend std::ostream & dumpOn( std::ostream & str, const Impl & obj );
+
+      /// <%posttrans script basename, pkgname> pairs.
+      using ScriptList = std::list< std::pair<std::string,std::string> >;
+
+      /// Data regarding the dumpfile used if `rpm --runposttrans` is supported
+      struct Dumpfile
+      {
+        Dumpfile( Pathname dumpfile_r )
+        : _dumpfile { std::move(dumpfile_r) }
+        {}
+
+        Pathname _dumpfile;         ///< The file holding the collected dump_posttrans: lines.
+        size_t _numscripts = 0;     ///< Number of scripts we collected (roughly estimated)
+        bool _runposttrans = true;  ///< Set to false if rpm lost --runposttrans support during transaction.
+      };
+
       public:
         Impl( const Pathname & root_r )
         : _root( root_r )
@@ -51,153 +70,261 @@ namespace zypp
         {}
 
         ~Impl()
-        { if ( !_scripts.empty() ) discardScripts(); }
+        {}
 
-        /** Extract and remember a packages %posttrans script for later execution. */
-        bool collectScriptFromPackage( const Pathname & rpmPackage_r )
+        bool hasPosttransScript( const Pathname & rpmPackage_r )
+        { return bool(getHeaderIfPosttrans( rpmPackage_r )); }
+
+        void collectPosttransInfo( const Pathname & rpmPackage_r, const std::vector<std::string> & runposttrans_r )
+        { if ( not collectDumpPosttransLines( runposttrans_r ) ) collectScriptForPackage( rpmPackage_r ); }
+
+        void collectPosttransInfo( const std::vector<std::string> & runposttrans_r )
+        { collectDumpPosttransLines( runposttrans_r ); }
+
+        void collectScriptFromHeader( rpm::RpmHeader::constPtr pkg )
         {
-          rpm::RpmHeader::constPtr pkg( rpm::RpmHeader::readPackage( rpmPackage_r, rpm::RpmHeader::NOVERIFY ) );
-          if ( ! pkg )
-          {
-            WAR << "Unexpectedly this is no package: " << rpmPackage_r << endl;
+          if ( pkg ) {
+            if ( not _scripts ) {
+              _scripts = ScriptList();
+            }
+
+            filesystem::TmpFile script( tmpDir(), pkg->ident() );
+            filesystem::addmod( script.path(), 0500 );  // script must be executable
+            script.autoCleanup( false );                // no autodelete; within a tmpdir
+            {
+              std::ofstream out( script.path().c_str() );
+              out << "#! " << pkg->tag_posttransprog() << endl
+                  << pkg->tag_posttrans() << endl;
+            }
+
+            _scripts->push_back( std::make_pair( script.path().basename(), pkg->tag_name() ) );
+            MIL << "COLLECT posttrans: '" << PathInfo( script.path() ) << "' for package: '" << pkg->tag_name() << "'" << endl;
+          }
+        }
+
+        void collectScriptForPackage( const Pathname & rpmPackage_r )
+        { collectScriptFromHeader( getHeaderIfPosttrans( rpmPackage_r ) ); }
+
+        /** Return whether runposttrans lines were collected.
+         * If runposttrans is supported, rpm issues at least one 'dump_posttrans: enabled' line with
+         * every install/remove. If no line is issued, rpm does not support --runposttrans. Interesting
+         * for \ref executeScripts is whether the final call to rpm supported it.
+         */
+        bool collectDumpPosttransLines( const std::vector<std::string> & runposttrans_r )
+        {
+          if ( runposttrans_r.empty()  ) {
+            if ( _dumpfile and _dumpfile->_runposttrans ) {
+              MIL << "LOST dump_posttrans support" <<  endl;
+              _dumpfile->_runposttrans = false;  // rpm was downgraded to a version not supporing --runposttrans
+            }
             return false;
           }
 
-          std::string prog( pkg->tag_posttransprog() );
-          if ( prog.empty() || prog == "<lua>" )	// by now leave lua to rpm
-            return false;
-
-          filesystem::TmpFile script( tmpDir(), rpmPackage_r.basename() );
-          filesystem::addmod( script.path(), 0500 );
-          script.autoCleanup( false );	// no autodelete; within a tmpdir
-          {
-            std::ofstream out( script.path().c_str() );
-            out << "#! " << pkg->tag_posttransprog() << endl
-                << pkg->tag_posttrans() << endl;
+          if ( not _dumpfile ) {
+            filesystem::TmpFile dumpfile( tmpDir(), "dumpfile" );
+            filesystem::addmod( dumpfile.path(), 0400 );  // dumpfile must be readable
+            dumpfile.autoCleanup( false );	// no autodelete; within a tmpdir
+            _dumpfile = Dumpfile( dumpfile.path() );
+            MIL << "COLLECT dump_posttrans to '" << _dumpfile->_dumpfile << endl;
           }
-          _scripts.push_back( std::make_pair( script.path().basename(), pkg->tag_name() ) );
-          MIL << "COLLECT posttrans: '" << PathInfo( script.path() ) << "' for package: '" << pkg->tag_name() << "'" << endl;
-          //DBG << "PROG:  " << pkg->tag_posttransprog() << endl;
-          //DBG << "SCRPT: " << pkg->tag_posttrans() << endl;
+
+          std::ofstream out( _dumpfile->_dumpfile.c_str(), std::ios_base::app );
+          for ( const auto & s : runposttrans_r ) {
+            out << s << endl;
+          }
+          _dumpfile->_numscripts += runposttrans_r.size();
+          MIL << "COLLECT " << runposttrans_r.size() << " dump_posttrans lines" << endl;
           return true;
         }
 
-        /** Execute the remembered scripts. */
-        bool executeScripts()
+        /** Execute the remembered scripts.
+         * Crucial is the mixed case, where scripts and dumpfile are present at the end.
+         * If rpm was updated in the transaction to a version supporting --runposttrans,
+         * run scripts and then the dumpfile.
+         * If rpm was downgraded in the transaction to a version no longer supporting
+         * --runposttrans, we need to extract missing %posttrans scripts from the dumpfile
+         * and execute them before the collected scripts.
+         */
+        void executeScripts( rpm::RpmDb & rpm_r )
         {
-          if ( _scripts.empty() )
-            return true;
+          if ( _dumpfile && not _dumpfile->_runposttrans ) {
+            // Here a downgraded rpm lost the ability to --runposttrans. Extract at least any
+            // missing %posttrans scripts collected in _dumpfile and prepend them to the _scripts.
+            MIL << "Extract missing %posttrans scripts and prepend them to the scripts." << endl;
+
+            // collectScriptFromHeader appends to _scripts, so we save here and append again later
+            std::optional<ScriptList> savedscripts;
+            if ( _scripts ) {
+              savedscripts = std::move(*_scripts);
+              _scripts = std::nullopt;
+            }
+
+            rpm::librpmDb::db_const_iterator it;
+            recallFromDumpfile( _dumpfile->_dumpfile, [&]( std::string n_r, std::string v_r, std::string r_r, std::string a_r ) -> void {
+              if ( it.findPackage( n_r, Edition( v_r, r_r ) ) && headerHasPosttrans( *it ) )
+                collectScriptFromHeader( *it );
+            } );
+
+            // append any savedscripts
+            if ( savedscripts ) {
+              if ( _scripts ) {
+                _scripts->splice( _scripts->end(), *savedscripts );
+              } else {
+                _scripts = std::move(*savedscripts);
+              }
+            }
+            _dumpfile = std::nullopt;
+          }
+
+          if ( not ( _scripts || _dumpfile ) )
+            return;  // Nothing todo
+
+          // ProgressReport counting the scripts ( 0:preparation, 1->n:for n scripts, n+1: indicate success)
+          callback::SendReport<ProgressReport> report;
+          ProgressData scriptProgress( [&]() -> ProgressData::value_type {
+            ProgressData::value_type ret = 1;
+            if ( _scripts )
+              ret += _scripts->size();
+            if ( _dumpfile )
+              ret += _dumpfile->_numscripts;
+            return ret;
+          }() );
+          scriptProgress.sendTo( ProgressReportAdaptor( ProgressData::ReceiverFnc(), report ) );
+          // Translator: progress bar label
+          std::string scriptProgressName { _("Running post-transaction scripts") };
+          // Translator: progress bar label; %1% is a script identifier like '%posttrans(mypackage-2-0.noarch)'
+          str::Format fmtScriptProgressRun { _("Running %1% script") };
+          // Translator: headline; %1% is a script identifier like '%posttrans(mypackage-2-0.noarch)'
+          str::Format fmtRipoff { _("%1% script output:") };
+          std::string sendRipoff;
 
           HistoryLog historylog;
 
-          Pathname noRootScriptDir( ZConfig::instance().update_scriptsPath() / tmpDir().basename() );
+          // lambda to prepare reports for a new script
+          auto startNewScript = [&] ( const std::string & scriptident_r ) -> void {
+            // scriptident_r : script identifier like "%transfiletriggerpostun(istrigger-2-0.noarch)"
+            sendRipoff = fmtRipoff % scriptident_r;
+            scriptProgress.name( fmtScriptProgressRun % scriptident_r );
+            scriptProgress.incr();
+          };
 
-          callback::SendReport<ProgressReport> report;
-          ProgressData scriptProgress( static_cast<ProgressData::value_type>(_scripts.size()) );
-          scriptProgress.sendTo( ProgressReportAdaptor( ProgressData::ReceiverFnc(), report ) );
-          str::Format fmtScriptProgress { _("Executing %%posttrans script '%1%'") };
-
-          bool firstScript = true;
-          str::Format fmtScriptFailedMsg { "warning: %%posttrans(%1%) scriptlet failed, exit status %2%\n" }; // like rpm would report it (intentionally not translated and NL-terminated)
-          while ( ! _scripts.empty() )
-          {
-            const auto &scriptPair = _scripts.front();
-            const std::string & script = scriptPair.first;
-            const std::string & pkgident( script.substr( 0, script.size()-6 ) );	// strip tmp file suffix
-
-            scriptProgress.name( fmtScriptProgress % pkgident );
-
-            bool canContinue = true;
-            if (firstScript)  {
-              firstScript = false;
-              canContinue = scriptProgress.toMin();
-            } else {
-              canContinue = scriptProgress.incr();
+          // lambda to send script output to reports
+          auto sendScriptOutput = [&] ( const std::string & line_r ) -> void {
+            OnScopeExit cleanup;  // in case we need it
+            if ( not sendRipoff.empty() ) {
+              historylog.comment( sendRipoff, true /*timestamp*/);
+              _myJobReport.set( "ripoff", std::cref(sendRipoff) );
+              cleanup.setDispose( [&]() -> void {
+                _myJobReport.erase( "ripoff" );
+                sendRipoff.clear();
+              } );
             }
+            historylog.comment( line_r );
+            _myJobReport.info( line_r );
+          };
 
-            if (!canContinue) {
-              str::Str msg;
-              msg << "Execution of %posttrans scripts cancelled";
-              WAR << msg << endl;
-              historylog.comment( msg, true /*timestamp*/);
-              _myJobReport.warning( msg );
-              return false;
-            }
+          // send the initial progress report
+          scriptProgress.name( scriptProgressName );
+          scriptProgress.toMin();
 
-            int npkgs = 0;
-            rpm::librpmDb::db_const_iterator it;
-            for ( it.findByName( scriptPair.second ); *it; ++it )
-              npkgs++;
+          // Scripts first...
+          if ( _scripts ) {
+            Pathname noRootScriptDir( ZConfig::instance().update_scriptsPath() / tmpDir().basename() );
+            // like rpm would report it (intentionally not translated and NL-terminated):
+            str::Format fmtScriptFailedMsg { "warning: %%posttrans(%1%) scriptlet failed, exit status %2%\n" };
+            str::Format fmtPosttrans { "%%posttrans(%1%)" };
 
-            MIL << "EXECUTE posttrans: " << script << " with argument: " << npkgs << endl;
-            ExternalProgram::Arguments cmd {
-              "/bin/sh",
-              (noRootScriptDir/script).asString(),
-              str::numstring( npkgs )
-            };
-            ExternalProgram prog( cmd, ExternalProgram::Stderr_To_Stdout, false, -1, true, _root );
-
-            // For now we continue to collect the lines and write the history file at the end.
-            // But JobReport lines are now sent immediately as they occur.
-            str::Str collect;
-            for( std::string line = prog.receiveLine(); ! line.empty(); line = prog.receiveLine() )
+            while ( ! _scripts->empty() )
             {
-              DBG << line;
-              collect << line;
-              _myJobReport.info( line );
-            }
+              const auto &scriptPair = _scripts->front();
+              const std::string & script = scriptPair.first;
+              const std::string & pkgident( script.substr( 0, script.size()-6 ) ); // strip tmp file suffix[6]
+              startNewScript( fmtPosttrans % pkgident );
 
-            //script was executed, remove it from the list
-            _scripts.pop_front();
+              int npkgs = 0;
+              rpm::librpmDb::db_const_iterator it;
+              for ( it.findByName( scriptPair.second ); *it; ++it )
+                npkgs++;
 
-            int ret = prog.close();
-            if ( ret != 0 )
-            {
-              const std::string & msg { fmtScriptFailedMsg % pkgident % ret };
-              WAR << msg;
-              collect << msg;
-              _myJobReport.info( msg ); // info!, as rpm would have reported it.
-            }
+              MIL << "EXECUTE posttrans: " << script << " with argument: " << npkgs << endl;
+              ExternalProgram::Arguments cmd {
+                "/bin/sh",
+                (noRootScriptDir/script).asString(),
+                str::numstring( npkgs )
+              };
+              ExternalProgram prog( cmd, ExternalProgram::Stderr_To_Stdout, false, -1, true, _root );
 
-            const std::string & scriptmsg( collect );
-            if ( ! scriptmsg.empty() )
-            {
-              str::Str msg;
-              msg << "Output of " << pkgident << " %posttrans script:\n" << scriptmsg;
-              historylog.comment( msg, true /*timestamp*/);
+              for( std::string line = prog.receiveLine(); ! line.empty(); line = prog.receiveLine() ) {
+                sendScriptOutput( line );
+              }
+              //script was executed, remove it from the list
+              _scripts->pop_front();
+
+              int ret = prog.close();
+              if ( ret != 0 )
+              {
+                std::string msg { fmtScriptFailedMsg % pkgident % ret };
+                WAR << msg;
+                sendScriptOutput( msg ); // info!, as rpm would have reported it.
+              }
             }
+            _scripts = std::nullopt;
           }
 
-          //show a final message
-          scriptProgress.name( _("Executing %posttrans scripts") );
-          scriptProgress.toMax();
-          _scripts.clear();
-          return true;
+          // ...then 'rpm --runposttrans'
+          int res = 0;  // Indicate a failed call to rpm itself! (a failed script is just a warning)
+          if ( _dumpfile ) {
+            res = rpm_r.runposttrans( _dumpfile->_dumpfile, [&] ( const std::string & line_r ) ->void {
+              if ( str::startsWith( line_r, "RIPOFF:" ) )
+                startNewScript( line_r.substr( 7 ) ); // new scripts ident sent by rpm
+              else
+                sendScriptOutput( line_r );
+            } );
+            if ( res != 0 )
+              _myJobReport.error( str::Format("rpm --runposttrans returned %1%.") % res );
+
+            _dumpfile = std::nullopt;
+          }
+
+          // send a final progress report
+          scriptProgress.name( scriptProgressName );
+          if ( res == 0 )
+            scriptProgress.toMax(); // Indicate 100%, in case Dumpfile::_numscripts estimation was off
+          return;
         }
 
-        /** Discard all remembered scrips. */
+        /** Discard all remembered scrips.
+         * As we are just logging the omitted actions, we don't pay further attention
+         * to the mixed case, where scripts and dumpfile are present (see executeScripts).
+         */
         void discardScripts()
         {
-          if ( _scripts.empty() )
-            return;
-
-          HistoryLog historylog;
+          if ( not ( _scripts || _dumpfile ) )
+            return;  // Nothing todo
 
           str::Str msg;
-          msg << "%posttrans scripts skipped while aborting:\n";
-          for ( const auto & script : _scripts )
-          {
-            const std::string & pkgident( script.first.substr( 0, script.first.size()-6 ) );	// strip tmp file suffix
-            WAR << "UNEXECUTED posttrans: " << script.first << endl;
-            msg << "    " << pkgident << "\n";
+
+          if ( _scripts ) {
+            // Legacy format logs all collected %posttrans
+            msg << "%posttrans scripts skipped while aborting:" << endl;
+            for ( const auto & script : *_scripts )
+            {
+              WAR << "UNEXECUTED posttrans: " << script.first << endl;
+              const std::string & pkgident( script.first.substr( 0, script.first.size()-6 ) ); // strip tmp file suffix[6]
+              msg << "    " << pkgident << "\n";
+            }
+            _scripts = std::nullopt;
           }
 
+          if ( _dumpfile ) {
+            msg << "%posttrans and %transfiletrigger scripts are not executed when aborting!" << endl;
+            _dumpfile = std::nullopt;
+          }
+
+          HistoryLog historylog;
           historylog.comment( msg, true /*timestamp*/);
           _myJobReport.warning( msg );
-
-          _scripts.clear();
         }
-
 
       private:
         /** Lazy create tmpdir on demand. */
@@ -208,12 +335,59 @@ namespace zypp
           return _ptrTmpdir->path();
         }
 
+        /** Return whether RpmHeader has a  %posttrans. */
+        bool headerHasPosttrans( rpm::RpmHeader::constPtr pkg_r ) const
+        {
+          bool ret = false;
+          if ( pkg_r ) {
+            std::string prog( pkg_r->tag_posttransprog() );
+            if ( not prog.empty() && prog != "<lua>" )  // by now leave lua to rpm
+              ret = true;
+          }
+          return ret;
+        }
+
+        /** Cache RpmHeader for consecutive hasPosttransScript / collectScriptForPackage calls.
+         * @return RpmHeader::constPtr IFF \a rpmPackage_r has a %posttrans
+         */
+        rpm::RpmHeader::constPtr getHeaderIfPosttrans( const Pathname & rpmPackage_r )
+        {
+          if ( _headercache.first == rpmPackage_r )
+            return _headercache.second;
+
+          rpm::RpmHeader::constPtr ret { rpm::RpmHeader::readPackage( rpmPackage_r, rpm::RpmHeader::NOVERIFY ) };
+          if ( ret ) {
+            if ( not headerHasPosttrans( ret ) )
+              ret = nullptr;
+          } else {
+            WAR << "Unexpectedly this is no package: " << rpmPackage_r << endl;
+          }
+          _headercache = std::make_pair( rpmPackage_r, ret );
+          return ret;
+        }
+
+        /** Retrieve "dump_posttrans: install" lines from \a dumpfile_r and pass n,v,r,a to the \a consumer_r. */
+        void recallFromDumpfile( const Pathname & dumpfile_r, std::function<void(std::string,std::string,std::string,std::string)> consume_r )
+        {
+          // dump_posttrans: install 10 terminfo-base-6.4.20230819-19.1.x86_64
+          static const str::regex rxInstalled { "^dump_posttrans: +install +[0-9]+ +(.+)-([^-]+)-([^-]+)\\.([^.]+)" };
+          str::smatch what;
+          iostr::forEachLine( InputStream( dumpfile_r ), [&]( int num_r, std::string line_r ) -> bool {
+            if( str::regex_match( line_r, what, rxInstalled ) )
+              consume_r( what[1], what[2], what[3], what[4] );
+            return true; // continue iostr::forEachLine
+          } );
+        }
+
       private:
         Pathname _root;
-        std::list< std::pair< std::string, std::string > > _scripts;
+        std::optional<ScriptList> _scripts;
+        std::optional<Dumpfile> _dumpfile;
         boost::scoped_ptr<filesystem::TmpDir> _ptrTmpdir;
 
-        UserDataJobReport _myJobReport; ///< JobReport with ContentType "cmdout/%posttrans"
+        UserDataJobReport _myJobReport;       ///< JobReport with ContentType "cmdout/%posttrans"
+
+        std::pair<Pathname,rpm::RpmHeader::constPtr> _headercache;
     };
 
     /** \relates RpmPostTransCollector::Impl Stream output */
@@ -237,11 +411,17 @@ namespace zypp
     RpmPostTransCollector::~RpmPostTransCollector()
     {}
 
-    bool RpmPostTransCollector::collectScriptFromPackage( const Pathname & rpmPackage_r )
-    { return _pimpl->collectScriptFromPackage( rpmPackage_r ); }
+    bool RpmPostTransCollector::hasPosttransScript( const Pathname & rpmPackage_r )
+    { return _pimpl->hasPosttransScript( rpmPackage_r ); }
 
-    bool RpmPostTransCollector::executeScripts()
-    { return _pimpl->executeScripts(); }
+    void RpmPostTransCollector::collectPosttransInfo( const Pathname & rpmPackage_r, const std::vector<std::string> & runposttrans_r )
+    { _pimpl->collectPosttransInfo( rpmPackage_r, runposttrans_r ); }
+
+    void RpmPostTransCollector::collectPosttransInfo( const std::vector<std::string> & runposttrans_r )
+    { _pimpl->collectPosttransInfo( runposttrans_r ); }
+
+    void RpmPostTransCollector::executeScripts( rpm::RpmDb & rpm_r )
+    { _pimpl->executeScripts( rpm_r ); }
 
     void RpmPostTransCollector::discardScripts()
     { return _pimpl->discardScripts(); }

--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -54,7 +54,7 @@ namespace zypp
         { if ( !_scripts.empty() ) discardScripts(); }
 
         /** Extract and remember a packages %posttrans script for later execution. */
-        bool collectScriptFromPackage( ManagedFile rpmPackage_r )
+        bool collectScriptFromPackage( const Pathname & rpmPackage_r )
         {
           rpm::RpmHeader::constPtr pkg( rpm::RpmHeader::readPackage( rpmPackage_r, rpm::RpmHeader::NOVERIFY ) );
           if ( ! pkg )
@@ -67,7 +67,7 @@ namespace zypp
           if ( prog.empty() || prog == "<lua>" )	// by now leave lua to rpm
             return false;
 
-          filesystem::TmpFile script( tmpDir(), rpmPackage_r->basename() );
+          filesystem::TmpFile script( tmpDir(), rpmPackage_r.basename() );
           filesystem::addmod( script.path(), 0500 );
           script.autoCleanup( false );	// no autodelete; within a tmpdir
           {
@@ -237,7 +237,7 @@ namespace zypp
     RpmPostTransCollector::~RpmPostTransCollector()
     {}
 
-    bool RpmPostTransCollector::collectScriptFromPackage( ManagedFile rpmPackage_r )
+    bool RpmPostTransCollector::collectScriptFromPackage( const Pathname & rpmPackage_r )
     { return _pimpl->collectScriptFromPackage( rpmPackage_r ); }
 
     bool RpmPostTransCollector::executeScripts()

--- a/zypp/target/RpmPostTransCollector.h
+++ b/zypp/target/RpmPostTransCollector.h
@@ -14,7 +14,6 @@
 #include <iosfwd>
 
 #include <zypp/base/PtrTypes.h>
-#include <zypp/ManagedFile.h>
 #include <zypp/Pathname.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -44,7 +43,7 @@ namespace zypp
         /** Extract and remember a packages %posttrans script for later execution.
          * \return whether a script was collected.
          */
-        bool collectScriptFromPackage( ManagedFile rpmPackage_r );
+        bool collectScriptFromPackage( const Pathname & rpmPackage_r );
 
         /** Execute the remembered scripts.
          * \return false if execution was aborted by a user callback

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1853,9 +1853,11 @@ namespace zypp
 
       } // for
 
-      // process all remembered posttrans scripts. If aborting,
-      // at least log omitted scripts.
-      if ( abort || (abort = !postTransCollector.executeScripts()) )
+      // Process any remembered %posttrans and/or %transfiletrigger(postun|in)
+      // scripts. If aborting, at least log if scripts were omitted.
+      if ( not abort )
+        postTransCollector.executeScripts( rpm() );
+      else
         postTransCollector.discardScripts();
 
       // Check presence of update scripts/messages. If aborting,

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1694,9 +1694,7 @@ namespace zypp
             try
             {
               progress.tryLevel( target::rpm::InstallResolvableReport::RPM_NODEPS_FORCE );
-              if ( postTransCollector.collectScriptFromPackage( localfile ) )
-                flags |= rpm::RPMINST_NOPOSTTRANS;
-              rpm().installPackage( localfile, flags );
+              rpm().installPackage( localfile, flags, &postTransCollector );
               HistoryLog().install(citem);
 
               if ( progress.aborted() )
@@ -1764,7 +1762,7 @@ namespace zypp
             attemptToModify();
             try
             {
-              rpm().removePackage( p, flags );
+              rpm().removePackage( p, flags, &postTransCollector );
               HistoryLog().remove(citem);
 
               if ( progress.aborted() )

--- a/zypp/target/rpm/RpmDb.h
+++ b/zypp/target/rpm/RpmDb.h
@@ -35,6 +35,7 @@ namespace zypp
 {
 namespace target
 {
+class RpmPostTransCollector;
 namespace rpm
 {
 
@@ -403,6 +404,8 @@ public:
    *
    * */
   void installPackage ( const Pathname & filename, RpmInstFlags flags = RPMINST_NONE );
+  /** \overload For delayed %posttrans %transfiletrigger(postun|in) execution if driven by Target::commit. */
+  void installPackage( const Pathname & filename, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r );
 
   /** remove rpm package
    *
@@ -416,6 +419,9 @@ public:
    * */
   void removePackage( const std::string & name_r, RpmInstFlags flags = RPMINST_NONE );
   void removePackage( Package::constPtr package, RpmInstFlags flags = RPMINST_NONE );
+  /** \overload For delayed %posttrans %transfiletrigger(postun|in) execution if driven by Target::commit. */
+  void removePackage( const std::string & name_r, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r );
+  void removePackage( Package::constPtr package, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r );
 
   /**
    * get backup dir for rpm config files
@@ -481,8 +487,8 @@ public:
   virtual std::ostream & dumpOn( std::ostream & str ) const;
 
 protected:
-  void doRemovePackage( const std::string & name_r, RpmInstFlags flags, callback::SendReport<RpmRemoveReport> & report );
-  void doInstallPackage( const Pathname & filename, RpmInstFlags flags, callback::SendReport<RpmInstallReport> & report );
+  void doRemovePackage( const std::string & name_r, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r, callback::SendReport<RpmRemoveReport> & report );
+  void doInstallPackage( const Pathname & filename, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r, callback::SendReport<RpmInstallReport> & report );
   void doRebuildDatabase(callback::SendReport<RebuildDBReport> & report);
 };
 

--- a/zypp/target/rpm/RpmDb.h
+++ b/zypp/target/rpm/RpmDb.h
@@ -19,6 +19,7 @@
 #include <list>
 #include <vector>
 #include <string>
+#include <functional>
 
 #include <zypp/Pathname.h>
 #include <zypp/ExternalProgram.h>
@@ -422,6 +423,12 @@ public:
   /** \overload For delayed %posttrans %transfiletrigger(postun|in) execution if driven by Target::commit. */
   void removePackage( const std::string & name_r, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r );
   void removePackage( Package::constPtr package, RpmInstFlags flags, RpmPostTransCollector* postTransCollector_r );
+
+  /** Run collected %posttrans and %transfiletrigger(postun|in) if `rpm --runposttrans` is supported.
+   * Output-function receives a "RIPOFF:%scriptident(packageident)" line for every script
+   * that is executed followed by lines the script outputs to stout/stderr.
+   */
+  int runposttrans( const Pathname & filename_r, std::function<void(const std::string&)> output_r );
 
   /**
    * get backup dir for rpm config files

--- a/zypp/target/rpm/RpmHeader.cc
+++ b/zypp/target/rpm/RpmHeader.cc
@@ -294,6 +294,15 @@ bool RpmHeader::isNosrc() const
   return has_tag( RPMTAG_SOURCEPACKAGE ) && ( has_tag( RPMTAG_NOSOURCE ) || has_tag( RPMTAG_NOPATCH ) );
 }
 
+std::string RpmHeader::ident() const
+{
+  static str::Format fmt { "%1%-%2%-%3%.%4%" };
+  std::string ret;
+  if ( not empty() )
+    ret = fmt % tag_name() % tag_version() % tag_release() % tag_arch();
+  return ret;
+}
+
 ///////////////////////////////////////////////////////////////////
 //
 //

--- a/zypp/target/rpm/RpmHeader.h
+++ b/zypp/target/rpm/RpmHeader.h
@@ -83,8 +83,10 @@ public:
 
   virtual ~RpmHeader();
 
-  bool isSrc() const;	//< Either 'src' or 'nosrc'
-  bool isNosrc() const;	//< Only 'nosrc'
+  bool isSrc() const;	///< Either 'src' or 'nosrc'
+  bool isNosrc() const;	///< Only 'nosrc'
+
+  std::string ident() const; ///< N-V-R.A or empty
 
 public:
 


### PR DESCRIPTION
[bsc#1041742](https://bugzilla.suse.com/show_bug.cgi?id=1041742)
The initial commits pass the existing `RpmPostTransCollector` down to the `RpmDB` layer and provide a new `RpmDb::runposttrans` call for a delayed execution of  `%posttrans` and `%transfiletrigger(postun|in) `scripts.

Then `RpmPostTransCollector` is adapted to collect either `%posttrans` scripts or  `dump_posttrans:` lines, depending on what rpm supports. `RpmPostTransCollector::executeScripts` is adapted accordingly. Execution of `%posttrans` scripts by libzypp itself is intentionally not interruptible via callbacks because the same is true for `rpm --runposttrans` execuition.

Todo:
- [x] Handle rpm downgrade (collected dump_posttrans lines can no longer be executed by rpm)
- [x] Adapt discardScripts