### PR TITLE
Fix discovery of libproxy on newer cmake

### DIFF
--- a/cmake/modules/Findlibproxy.cmake
+++ b/cmake/modules/Findlibproxy.cmake
@@ -4,4 +4,4 @@
 
 INCLUDE ( FindPkgConfig )
 
-PKG_SEARCH_MODULE( LIBPROXY libproxy-1.0 )
+PKG_CHECK_MODULES( LIBPROXY libproxy-1.0 )


### PR DESCRIPTION
Semantics of PKG_SEARCH_MODULES seems to have changed with more recent cmake versions, use PKG_CHECK_MODULES instead.