### PR TITLE
Fix ProgressBar's calculation of the printed tag position

### DIFF
--- a/zypp-tui/output/Out.cc
+++ b/zypp-tui/output/Out.cc
@@ -71,7 +71,7 @@ std::string TermLine::get( unsigned width_r, SplitFlags flags_r, char exp_r ) co
 
     // else: less boring
     std::string tag( zypp::str::Str() << '<' << percentHint << "%>" );
-    pc = ( pc > tag.size() ? pc - tag.size() : 0 );
+    pc = pc > tag.size() ? (diff - tag.size()) * percentHint / 100 : 0;
     return zypp::str::Str() << l << std::string( pc, '.' ) << tag << std::string( diff-pc-tag.size(), '=' ) << r;
   }
   else if ( diff < 0 )


### PR DESCRIPTION
Observed (on a 80-wide terminal):

The <x%> tag does not move in the first 7%, while it does move in the last 7%. Printing the <50%> state shows 29 dots and 35 equals signs. The <10%> state even goes backwards compared to <9%>.

```
abcdefg <1%>=================================================================[/]
abcdefg <3%>=================================================================[-]
abcdefg <5%>=================================================================[\]
abcdefg <7%>=================================================================[|]
abcdefg ..<9%>===============================================================[/]
abcdefg .<10%>===============================================================[-]
abcdefg .............................<50%>===================================[\]
abcdefg .........................................................<91%>=======[|]
abcdefg ..........................................................<92%>======[/]
abcdefg ...........................................................<94%>=====[-]
abcdefg .............................................................<96%>===[\]
abcdefg ..............................................................<98%>==[|]
abcdefg ...............................................................<100%>[/]
abcdefg ..................................................................[done]
```

Expected (and implemented by this patch):

```
abcdefg <1%>=================================================================[/]
abcdefg .<3%>================================================================[-]
abcdefg ...<5%>==============================================================[\]
abcdefg ....<7%>=============================================================[|]
abcdefg .....<9%>============================================================[/]
abcdefg ......<10%>==========================================================[-]
abcdefg ................................<50%>================================[\]
abcdefg ..........................................................<91%>======[|]
abcdefg ..........................................................<92%>======[/]
abcdefg ............................................................<94%>====[-]
abcdefg .............................................................<96%>===[\]
abcdefg ..............................................................<98%>==[|]
abcdefg ...............................................................<100%>[/]
```

The progress bar is much like a slider control in a graphical UI.

The `pc` variable specifies the point on the progress bar where the knob is _centered_ on. The _left_ edge of the knob is offset left by _half_ its size. The expression `pc - tag.size()` should have been `pc - tag.size() / 2`. But either of these two GUI-centric expression can produce a negative value (which explains why the tag string stick so hard to the left during the initial x%), so for resolution-limited text mode, we need something different.
    
Instead, take the space available to ornamentation (`diff - tag.size()`), and _partition_ that into dots and equal signs. (The fix for the 9%->10% jump can be observed on e.g. a 75-wide terminal.)

Supplementary testcase for all this:

```c
struct app : public ztui::Application {};
int main() {
	app a;
	ztui::Out::ProgressBar bar(a.out(), "ID", "abcdefg");
	bar->range(100);
	for (const auto i : {1,3,5,7,9,10,50,91,92,94,96,98,100})
		{ bar->set(i); bar.print(); printf("\n"); }
}
```