### PR TITLE
Open rpmdb just once during execution of %posttrans scripts

### DIFF
--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -234,6 +234,7 @@ namespace zypp
             str::Format fmtScriptFailedMsg { "warning: %%posttrans(%1%) scriptlet failed, exit status %2%\n" };
             str::Format fmtPosttrans { "%%posttrans(%1%)" };
 
+            rpm::librpmDb::db_const_iterator it;  // Open DB only once
             while ( ! _scripts->empty() )
             {
               const auto &scriptPair = _scripts->front();
@@ -242,9 +243,8 @@ namespace zypp
               startNewScript( fmtPosttrans % pkgident );
 
               int npkgs = 0;
-              rpm::librpmDb::db_const_iterator it;
               for ( it.findByName( scriptPair.second ); *it; ++it )
-                npkgs++;
+                ++npkgs;
 
               MIL << "EXECUTE posttrans: " << script << " with argument: " << npkgs << endl;
               ExternalProgram::Arguments cmd {


### PR DESCRIPTION
[bsc#1216412](https://bugzilla.suse.com/show_bug.cgi?id=1216412). If rpm warnings are issued on dbopen, this should at least reduce their amount.