### PR TITLE
Expand RepoVars in URLs downloading a .repo file

### DIFF
--- a/zypp/RepoManager.cc
+++ b/zypp/RepoManager.cc
@@ -468,9 +468,11 @@ namespace zypp
 
   std::list<RepoInfo> readRepoFile( const Url & repo_file )
   {
-    ManagedFile local = MediaSetAccess::provideFileFromUrl(repo_file);
+    repo::RepoVariablesUrlReplacer replaceVars;
+    Url repoFileUrl { replaceVars(repo_file) };
 
-    DBG << "reading repo file " << repo_file << ", local path: " << local << endl;
+    ManagedFile local = MediaSetAccess::provideFileFromUrl( repoFileUrl );
+    DBG << "reading repo file " << repoFileUrl << ", local path: " << local << endl;
 
     return repositories_in_file(local);
   }

--- a/zypp/RepoManager.h
+++ b/zypp/RepoManager.h
@@ -37,7 +37,9 @@ namespace zypp
     * Parses \a repo_file and returns a list of \ref RepoInfo objects
     * corresponding to repositories found within the file.
     *
-    * \param repo_file Valid URL of the repo file.
+    * \param repo_file Valid URL of the repo file. The URL is subject to
+    * repo variable expansion.
+    *
     * \return found list<RepoInfo>
     *
     * \throws MediaException If the access to the url fails
@@ -427,7 +429,7 @@ namespace zypp
 
    /**
     * \short Adds repositores from a repo file to the list of known repositories.
-    * \param url Url of the repo file
+    * \param url Url of the repo file. The URL is subject to repo variable expansion.
     *
     * \throws repo::RepoAlreadyExistsException If the repo clash some
     *         unique attribute like alias

--- a/zypp/parser/RepoFileReader.cc
+++ b/zypp/parser/RepoFileReader.cc
@@ -138,7 +138,7 @@ namespace zypp
     static void repositories_in_stream( const InputStream &is,
                                         const RepoFileReader::ProcessRepo &callback,
                                         const ProgressData::ReceiverFnc &progress )
-    {
+    try {
       RepoFileParser dict(is);
       for_( its, dict.sectionsBegin(), dict.sectionsEnd() )
       {
@@ -220,6 +220,10 @@ namespace zypp
         //if (!progress.tick())
         //  ZYPP_THROW(AbortRequestException());
       }
+    }
+    catch ( Exception & ex ) {
+      ex.addHistory( "Parsing .repo file "+is.name() );
+      ZYPP_RETHROW( ex );
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/zypp/parser/ServiceFileReader.cc
+++ b/zypp/parser/ServiceFileReader.cc
@@ -40,7 +40,7 @@ namespace zypp
     void ServiceFileReader::Impl::parseServices( const Pathname & file,
                                   const ServiceFileReader::ProcessService & callback/*,
                                   const ProgressData::ReceiverFnc &progress*/ )
-    {
+    try {
       InputStream is(file);
       if( is.stream().fail() )
       {
@@ -147,6 +147,10 @@ namespace zypp
         if ( !callback(service) )
           ZYPP_THROW(AbortRequestException());
       }
+    }
+    catch ( Exception & ex ) {
+      ex.addHistory( "Parsing .service file "+file.asString() );
+      ZYPP_RETHROW( ex );
     }
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[bsc#1212160](https://bugzilla.suse.com/show_bug.cgi?id=1212160)
Convenient and helps documentation as it may refer to a single command for a bunch of distributions. 
Like e.g.`zypper ar 'https://server.my/$releasever/my.repo'`

