### PR TITLE
Calling zypp commit plugins if zypp will be called while an transactional update

### DIFF
--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -81,6 +81,17 @@
 
 #include <optional>
 
+namespace zypp::env {
+  inline bool TRANSACTIONAL_UPDATE()
+  {
+    static bool val = [](){
+      const char * env = getenv("TRANSACTIONAL_UPDATE");
+      return( env && zypp::str::strToBool( env, true ) );
+    }();
+    return val;
+  }
+} // namespace zypp::env
+
 using std::endl;
 
 ///////////////////////////////////////////////////////////////////
@@ -1352,7 +1363,8 @@ namespace zypp
       // Prepare execution of commit plugins:
       ///////////////////////////////////////////////////////////////////
       PluginExecutor commitPlugins;
-      if ( root() == "/" && ! policy_r.dryRun() )
+
+      if ( (root() == "/" || zypp::env::TRANSACTIONAL_UPDATE) && ! policy_r.dryRun() )
       {
         commitPlugins.load( ZConfig::instance().pluginsPath()/"commit" );
       }


### PR DESCRIPTION
We need this for the boot plugin in order to speed up the boot process after transactional update. 
Otherwise no commit plugin will be called. 
We have already had discussed this in the Chat:

"The typical --root use case is a bare metal installation, where no inner plugins are available at all. So no one missed it. At least no one asked for it.
We have no means to detect whether the inner plugin and the outer libzypp fit together (on protocol level). OTOH it's a one-way communication anyway. The plugin is not able to influence libzypp's behavior. If it does not speak our language it's killed.
If it's important for you, we have bool isTransactionalServer = ( fsinfo.f_type == BTRFS_SUPER_MAGIC && PathInfo( "/usr/sbin/transactional-update" ).isFile() );.  It should be doable to enable the chrooted execution of CommitPlugins for TransactionalServer. Then we see whether issues arise from this.
If we should, please open a bug so we have a reference for the chages file."

I have tested it while an transactional update and it seems that all commit plugins are working correctly.