### PR TITLE
CheckAccessDeleted: fix 'running in container' filter

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -92,9 +92,10 @@ namespace zypp
         // get stat info for the target file
         const PathInfo linkStat( linkTarget );
 
-        // Non-existent path means it's not reachable by us.
+        // Non-existent path could be anything. Pipe or socket (type:[inode])
+        // or an 'anon_inode:<file-type>'. (bsc#1218291)
         if ( !linkStat.isExist() )
-          return CONTAINER;
+          return IGNORE;
 
         // If the file exists, it could simply mean it exists in and outside a container, check inode to be safe
         if ( linkStat.ino() != procInfoStat.ino())


### PR DESCRIPTION
[bsc#1218291](https://bugzilla.suse.com/show_bug.cgi?id=1218291)