### PR TITLE
CheckAccessDeleted: fix running_in_container detection

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -89,13 +89,16 @@ namespace zypp
         const Pathname linkTarget = filesystem::readlink( path );
         if ( linkTarget.empty() ) return IGNORE;
 
+        // Pipe or socket 'type:[inode]' or an 'anon_inode:<file-type>'
+        // They may or may not belong to a container... (bsc#1218291)
+        if ( linkTarget.relative() ) return IGNORE;
+
         // get stat info for the target file
         const PathInfo linkStat( linkTarget );
 
-        // Non-existent path could be anything. Pipe or socket (type:[inode])
-        // or an 'anon_inode:<file-type>'. (bsc#1218291)
+        // Non-existent path means it's not reachable by us.
         if ( !linkStat.isExist() )
-          return IGNORE;
+          return CONTAINER;
 
         // If the file exists, it could simply mean it exists in and outside a container, check inode to be safe
         if ( linkStat.ino() != procInfoStat.ino())


### PR DESCRIPTION
[bsc#1218782](https://bugzilla.suse.com/show_bug.cgi?id=1218782)

This restores the previous behavior - which was known to work for flatpacks - for /proc/PID/fd symlinks pointing to a file (i.e. readlinkd returning an absolute path). Only links to pipe or socket 'type:[inode]' or an 'anon_inode:<file-type>' are ignored.