### PR TITLE
Add ProblemSolution::skipsPatchesOnly (for openSUSE/zypper#514)

### DIFF
--- a/zypp/ProblemSolution.h
+++ b/zypp/ProblemSolution.h
@@ -24,7 +24,7 @@ namespace zypp
   ///
   /// All problems should have at least 2-3 (mutually exclusive) solutions:
   ///
-  ///    -	 Undo: Do not perform the offending transaction
+  ///    - Undo: Do not perform the offending transaction
   ///	 (do not install the package that had unsatisfied requirements,
   ///	  do not remove	 the package that would break other packages' requirements)
   ///
@@ -49,7 +49,7 @@ namespace zypp
     /** Constructor. */
     ProblemSolution( std::string description, std::string details );
 
-   /** Destructor. */
+    /** Destructor. */
     virtual ~ProblemSolution();
 
 
@@ -90,6 +90,9 @@ namespace zypp
      **/
     void addAction( SolutionAction_Ptr action );
 
+  public:
+    /** The solution contains only 'do not install patch:' actions. */
+    bool skipsPatchesOnly() const;
 
   private:
     struct Impl;

--- a/zypp/solver/detail/SolutionAction.cc
+++ b/zypp/solver/detail/SolutionAction.cc
@@ -55,6 +55,8 @@ SolutionAction::~SolutionAction()
 {
 }
 
+bool SolutionAction::skipsPatchesOnly() const
+{ return false; }
 
 //---------------------------------------------------------------------------
 
@@ -166,6 +168,9 @@ TransactionSolutionAction::execute(ResolverInternal & resolver) const
     }
     return ret;
 }
+
+bool TransactionSolutionAction::skipsPatchesOnly() const
+{ return _action == KEEP && _item.isKind<Patch>(); }
 
 bool
 InjectSolutionAction::execute(ResolverInternal & resolver) const

--- a/zypp/solver/detail/SolutionAction.h
+++ b/zypp/solver/detail/SolutionAction.h
@@ -60,6 +60,10 @@ namespace zypp
              * Returns 'true' on success, 'false' on error.
              **/
             virtual bool execute (ResolverInternal & resolver) const = 0;
+
+        public:
+            /** The solution contains only 'do not install patch:' actions. */
+            virtual bool skipsPatchesOnly() const;
         };
 
 
@@ -117,7 +121,11 @@ namespace zypp
           TransactionKind action() const { return _action; }
 
           // ---------------------------------- methods
-            virtual bool execute(ResolverInternal & resolver) const;
+          virtual bool execute(ResolverInternal & resolver) const;
+
+        public:
+            /** The solution contains only 'do not install patch:' actions. */
+            bool skipsPatchesOnly() const override;
 
         protected:
 


### PR DESCRIPTION
Libzypp intentionally does not expose `SolutionAction`, so we offer it in `ProblemSolution`.