### PR TITLE
Prevent SINGLE_RPMTRANS from downloading packages if --dry-run.

### DIFF
--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1454,14 +1454,14 @@ namespace zypp
       bool singleTransMode = policy_r.singleTransModeEnabled();
 
       DBG << "commit log file is set to: " << HistoryLog::fname() << endl;
-      if ( ! policy_r.dryRun() || policy_r.downloadMode() == DownloadOnly || singleTransMode )
+      if ( ! policy_r.dryRun() || policy_r.downloadMode() == DownloadOnly )
       {
         // Prepare the package cache. Pass all items requiring download.
         CommitPackageCache packageCache;
         packageCache.setCommitList( steps.begin(), steps.end() );
 
         bool miss = false;
-        if ( policy_r.downloadMode() != DownloadAsNeeded || singleTransMode )
+        if ( policy_r.downloadMode() != DownloadAsNeeded  )
         {
           // Preload the cache. Until now this means pre-loading all packages.
           // Once DownloadInHeaps is fully implemented, this will change and


### PR DESCRIPTION
Just the combination --dry-run --download-only will download packages in order to perform a file-conflict check.

@bzeller did we have a bug or issue number for this?