### PR TITLE
Fix strncpy() string concatenation warning

### DIFF
--- a/zypp/media/MediaCurl.cc
+++ b/zypp/media/MediaCurl.cc
@@ -389,6 +389,13 @@ void MediaCurl::setCookieFile( const Pathname &fileName )
   _cookieFile = fileName;
 }
 
+void MediaCurl::setCurlError(const char* error)
+{
+  // FIXME(dmllr): Use strlcpy if available for better performance
+  strncpy(_curlError, error, sizeof(_curlError)-1);
+  _curlError[sizeof(_curlError)-1] = '\0';
+}
+
 ///////////////////////////////////////////////////////////////////
 
 void MediaCurl::checkProtocol(const Url &url) const

--- a/zypp/media/MediaCurl.h
+++ b/zypp/media/MediaCurl.h
@@ -162,13 +162,16 @@ class MediaCurl : public MediaNetworkCommonHandler
   private:
     std::string _currentCookieFile;
     static Pathname _cookieFile;
+    char _curlError[ CURL_ERROR_SIZE ];
 
     mutable std::string _lastRedirect;	///< to log/report redirections
 
   protected:
     CURL *_curl;
-    char _curlError[ CURL_ERROR_SIZE ];
     curl_slist *_customHeaders;
+
+    const char* curlError() const { return _curlError; };
+    void setCurlError(const char* error);
 };
 ZYPP_DECLARE_OPERATORS_FOR_FLAGS(MediaCurl::RequestOptions);
 


### PR DESCRIPTION
strncpy() does not terminate a string that is excessively long, which triggers a compiler warning with gcc 13. add setCurlError function that encapsulates the termination.