### PR TITLE
CombinedProgressData: reportAlive if source OR target ProgressData ha…

### DIFF
--- a/zypp-core/ui/progressdata.cc
+++ b/zypp-core/ui/progressdata.cc
@@ -89,7 +89,8 @@ namespace zypp
         return false;	// aborted by user
       }
     }
-    else if ( _d->_state == END )
+
+    if ( _d->_state == END )
     {
       DBG << str::form( "{#%u|%s} END", numericId(), name().c_str() ) << endl;
     }

--- a/zypp-core/ui/progressdata.cc
+++ b/zypp-core/ui/progressdata.cc
@@ -140,7 +140,7 @@ namespace zypp
 
   bool CombinedProgressData::operator()( const ProgressData &progress )
   {
-    if ( progress.reportAlive() || ( _weight == 0 ) )
+    if ( progress.reportAlive() || _pd.reportAlive() || ( _weight == 0 ) )
       return _pd.tick();
 
     // factor [0,1] of increase in subtask ( ie: before 0,2 now 0.5 )
@@ -150,7 +150,7 @@ namespace zypp
     // real increment of the parent task
     float real_increment = parent_factor*increment;
     _last_value = progress.val();
-    return _pd.incr( (int)( (_pd.max()-_pd.min()) * real_increment) );
+    return _pd.incr( (ProgressData::value_type)( (_pd.max()-_pd.min()) * real_increment) );
   }
 
   /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…s no range

If the target `_pd` has no range,  `_pd.max-_pd.min == 0` and so `parent_factor=_weight/0 == INFINITY`.
And so `_pd` is wrongly incremented (by `-2147483648`). Actually the value should not be touched if the `ProgressData` has no range.