### PR TITLE
Add ZYPP_API for exported functions and switch to visibility=hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ OPTION (ENABLE_BUILD_DOCS "Build documentation by default?" OFF)
 OPTION (ENABLE_BUILD_TRANS "Build translation files by default?" OFF)
 OPTION (ENABLE_BUILD_TESTS "Build and run test suite by default?" OFF)
 OPTION (ENABLE_ZSTD_COMPRESSION "Build with zstd compression support?" OFF)
+OPTION (ENABLE_VISIBILITY_HIDDEN "Build with hidden visibility by default?" OFF)
 OPTION (ENABLE_ZCHUNK_COMPRESSION "Build with zchunk compression support?" OFF)
 # Helps with bug https://bugzilla.gnome.org/show_bug.cgi?id=784550 , Segfault during signal emission when slots are cleared
 OPTION (ENABLE_SIGC_BLOCK_WORKAROUND "Enable a workaround for older sigcpp libraries?" OFF )
@@ -97,9 +98,12 @@ SET( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -pthread -fno-strict-aliasing -fPIC -g 
 SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -fno-strict-aliasing -fPIC -g -Wall -Wp,-D_GLIBCXX_ASSERTIONS" )
 
 SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden -Woverloaded-virtual -Wnon-virtual-dtor -ftemplate-backtrace-limit=0" )
+IF ( ENABLE_VISIBILITY_HIDDEN )
+  SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden" )
+ENDIF( ENABLE_VISIBILITY_HIDDEN )
 
-set( CMAKE_C_FLAGS_RELEASE     "${CMAKE_C_FLAGS} -O3 -DZYPP_NDEBUG -DNDEBUG" )
-set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -DZYPP_NDEBUG -DNDEBUG" )
+set( CMAKE_C_FLAGS_RELEASE     "${CMAKE_C_FLAGS} -O2 -DZYPP_NDEBUG -DNDEBUG" )
+set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2 -DZYPP_NDEBUG -DNDEBUG" )
 
 IF(${CC_FORMAT_SECURITY})
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=format-security")

--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -38,6 +38,13 @@
 %bcond_with sigc_block_workaround
 %endif
 
+
+%if 0%{?suse_version} > 1500 || 0%{?sle_version} >= 150600
+%bcond_without visibility_hidden
+%else
+%bcond_with visibility_hidden
+%endif
+
 # Distros using just zypper may want to enable this as default earlier
 %bcond_with enable_preview_single_rpmtrans_as_default_for_zypper
 
@@ -236,7 +243,7 @@ Group:          Documentation/HTML
 Developer documentation for libzypp.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 mkdir build
@@ -261,6 +268,7 @@ cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_SKIP_RPATH=1 \
       -DCMAKE_INSTALL_LIBEXECDIR=%{_libexecdir} \
+      %{?with_visibility_hidden:-DENABLE_VISIBILITY_HIDDEN=1} \
       %{?with_zchunk:-DENABLE_ZCHUNK_COMPRESSION=1} \
       %{?with_zstd:-DENABLE_ZSTD_COMPRESSION=1} \
       %{?with_sigc_block_workaround:-DENABLE_SIGC_BLOCK_WORKAROUND=1} \

--- a/zypp-core/ByteCount.h
+++ b/zypp-core/ByteCount.h
@@ -14,6 +14,7 @@
 
 #include <iosfwd>
 
+#include <zypp/Globals.h>
 #include <zypp-core/base/Unit.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -27,7 +28,7 @@ namespace zypp
   /** Store and operate with byte count.
    *
   */
-  class ByteCount
+  class ZYPP_API ByteCount
   {
     friend std::ostream & operator<<( std::ostream & str, const ByteCount & obj );
 

--- a/zypp-core/Date.h
+++ b/zypp-core/Date.h
@@ -29,7 +29,7 @@ namespace zypp
   //
   /** Store and operate on date (time_t).
   */
-  class Date
+  class ZYPP_API Date
   {
     friend std::ostream & operator<<( std::ostream & str, const Date & obj );
 
@@ -255,10 +255,10 @@ namespace zypp
   /** \relates Date XML output.
    * Print \c time_t and \c text attribute. Allow alternate node name [date].
    */
-  std::ostream & dumpAsXmlOn( std::ostream & str, const Date & obj, const std::string & name_r = "date" );
+  std::ostream & dumpAsXmlOn( std::ostream & str, const Date & obj, const std::string & name_r = "date" ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
-  class DateFormatException : public Exception
+  class ZYPP_API DateFormatException : public Exception
   {
   public:
     DateFormatException( const std::string & msg ) : Exception( msg )

--- a/zypp-core/ExternalProgram.h
+++ b/zypp-core/ExternalProgram.h
@@ -61,7 +61,7 @@ namespace zypp {
      *
      * \endcode
      */
-    class ExternalProgram : public zypp::externalprogram::ExternalDataSource
+    class ZYPP_API ExternalProgram : public zypp::externalprogram::ExternalDataSource
     {
 
     public:

--- a/zypp-core/Globals.h
+++ b/zypp-core/Globals.h
@@ -54,8 +54,10 @@
 #ifdef ZYPP_DLL	//defined if zypp is compiled as DLL
   #define ZYPP_API	ZYPP_DECL_EXPORT
   #define ZYPP_LOCAL	ZYPP_DECL_HIDDEN
+  #define ZYPP_TESTS	ZYPP_DECL_EXPORT
 #else
   #define ZYPP_API      ZYPP_DECL_IMPORT
+  #define ZYPP_TESTS	ZYPP_DECL_IMPORT
   #define ZYPP_LOCAL
 #endif
 

--- a/zypp-core/Pathname.h
+++ b/zypp-core/Pathname.h
@@ -16,6 +16,8 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 { /////////////////////////////////////////////////////////////////
@@ -41,7 +43,7 @@ namespace zypp
      * \todo Add support for handling extensions incl. stripping
      * extensions from basename (basename("/path/foo.baa", ".baa") ==> "foo")
     */
-    class Pathname
+    class ZYPP_API Pathname
     {
     public:
       /** Default ctor: an empty path. */

--- a/zypp-core/Url.h
+++ b/zypp-core/Url.h
@@ -88,7 +88,7 @@ namespace zypp
    * \endcode
    *
    */
-  class Url
+  class ZYPP_API Url
   {
   public:
     /**
@@ -846,20 +846,20 @@ namespace zypp
     url::UrlRef m_impl;
   };
 
-  std::ostream & operator<<( std::ostream & str, const Url & url );
+  std::ostream & operator<<( std::ostream & str, const Url & url ) ZYPP_API;
 
   /**
    * needed for std::set
    */
-  bool operator<( const Url &lhs, const Url &rhs );
+  bool operator<( const Url &lhs, const Url &rhs ) ZYPP_API;
 
   /**
    * needed for find
    */
-  bool operator==( const Url &lhs, const Url &rhs );
+  bool operator==( const Url &lhs, const Url &rhs ) ZYPP_API;
 
 
-  bool operator!=( const Url &lhs, const Url &rhs );
+  bool operator!=( const Url &lhs, const Url &rhs ) ZYPP_API;
 
   ////////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp-core/base/Exception.h
+++ b/zypp-core/base/Exception.h
@@ -143,7 +143,7 @@ namespace zypp
    * in the remaining code of zypp. If we can, we should try to wrap
    * the blocxx macros and typedef the classes in here.
    **/
-  class Exception : public std::exception
+  class ZYPP_API Exception : public std::exception
   {
     friend std::ostream & operator<<( std::ostream & str, const Exception & obj );
 
@@ -321,7 +321,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates Exception Stream output */
-  std::ostream & operator<<( std::ostream & str, const Exception & obj );
+  std::ostream & operator<<( std::ostream & str, const Exception & obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
   namespace exception_detail

--- a/zypp-core/base/ExternalDataSource.h
+++ b/zypp-core/base/ExternalDataSource.h
@@ -24,7 +24,7 @@ namespace zypp {
     /**
      * @short Bidirectional stream to external data
      */
-    class ExternalDataSource
+    class ZYPP_API ExternalDataSource
     {
     protected:
       FILE *inputfile;

--- a/zypp-core/base/Gettext.h
+++ b/zypp-core/base/Gettext.h
@@ -14,6 +14,8 @@
 #ifndef ZYPP_BASE_GETTEXT_H
 #define ZYPP_BASE_GETTEXT_H
 
+#include <zypp/Globals.h>
+
 #ifdef ZYPP_DLL //defined if zypp is compiled as DLL
 
 /** Just tag text for translation. */
@@ -50,11 +52,11 @@ namespace zypp
   { /////////////////////////////////////////////////////////////////
 
     /** Return translated text. */
-    const char * dgettext( const char * msgid );
+    const char * dgettext( const char * msgid ) ZYPP_API;
 
     /** Return translated text (plural form). */
     const char * dngettext( const char * msgid1, const char * msgid2,
-                            unsigned long n );
+                            unsigned long n ) ZYPP_API;
 
     /////////////////////////////////////////////////////////////////
   } // namespace gettext

--- a/zypp-core/base/IOStream.h
+++ b/zypp-core/base/IOStream.h
@@ -43,7 +43,7 @@ namespace zypp
      *
      * \see \ref forEachLine
      */
-    std::string getline( std::istream & str );
+    std::string getline( std::istream & str ) ZYPP_API;
 
     /** Copy istream to ostream.
      * \return reference to the ostream.
@@ -109,7 +109,7 @@ namespace zypp
      * }
      * \endcode
      */
-    class EachLine : private base::NonCopyable
+    class ZYPP_API EachLine : private base::NonCopyable
     {
       public:
         /** Ctor taking a stream and reading the 1st line from it. */
@@ -183,7 +183,7 @@ namespace zypp
      *
      * \return Number if lines consumed (negative if aborted by callback).
      */
-     int forEachLine( std::istream & str_r, const function<bool(int, std::string)>& consume_r );
+     int forEachLine( std::istream & str_r, const function<bool(int, std::string)>& consume_r ) ZYPP_API;
 
      /** \ref simpleParseFile modifications before consuming a line. */
      enum ParseFlag
@@ -198,7 +198,7 @@ namespace zypp
      ZYPP_DECLARE_OPERATORS_FOR_FLAGS( ParseFlags );
 
      /** Simple lineparser optionally trimming and skipping comments. */
-     int simpleParseFile( std::istream & str_r, ParseFlags flags_r, function<bool(int, std::string)> consume_r );
+     int simpleParseFile( std::istream & str_r, ParseFlags flags_r, function<bool(int, std::string)> consume_r ) ZYPP_API;
 
      /** \overload trimming lines, skipping '#'-comments and empty lines. */
      inline int simpleParseFile( std::istream & str_r, function<bool(int, std::string)> consume_r )

--- a/zypp-core/base/IOTools.h
+++ b/zypp-core/base/IOTools.h
@@ -48,7 +48,7 @@ namespace zypp::io {
   };
   ReadAllResult readAll ( int fd, void *buf, size_t size );
 
-  class TimeoutException : public Exception
+  class ZYPP_API TimeoutException : public Exception
   {
   public:
     /** Ctor taking message.

--- a/zypp-core/base/LogControl.cc
+++ b/zypp-core/base/LogControl.cc
@@ -228,7 +228,7 @@ namespace zypp
     LogClient &operator=(const LogClient &) = delete;
     LogClient &operator=(LogClient &&) = delete;
 
-    ~LogClient() { ::close(_sockFD); }
+    ~LogClient() { if (_sockFD >= 0) ::close(_sockFD); }
 
     /*!
      * Tries to connect to the log threads socket, returns true on success or

--- a/zypp-core/base/LogControl.h
+++ b/zypp-core/base/LogControl.h
@@ -32,7 +32,7 @@ namespace zypp
      * Expect \a formated_r to be a formated log line without trailing \c NL.
      * Ready to be written to the log.
      */
-    struct LineWriter
+    struct ZYPP_API LineWriter
     {
       virtual void writeOut( const std::string & /*formated_r*/ )
       {}
@@ -69,7 +69,7 @@ namespace zypp
      * If \c mode_r is not \c 0, \c file_r persissions are changed
      * accordingly. \c "-" logs to \c cerr.
     */
-    struct FileLineWriter : public StreamLineWriter
+    struct ZYPP_API FileLineWriter : public StreamLineWriter
     {
       FileLineWriter( const Pathname & file_r, mode_t mode_r = 0 );
       protected:
@@ -93,7 +93,7 @@ namespace zypp
      * \note A Singleton using a Singleton implementation class,
      * that's why there is no _pimpl like in other classes.
     */
-    class LogControl
+    class ZYPP_API LogControl
     {
       friend std::ostream & operator<<( std::ostream & str, const LogControl & obj );
 
@@ -111,7 +111,7 @@ namespace zypp
        * Return a formated logline without trailing \c NL.
        * Ready to be written to the log.
       */
-      struct LineFormater
+      struct ZYPP_API LineFormater
       {
         virtual std::string format( const std::string & /*group_r*/,
                                     logger::LogLevel    /*level_r*/,
@@ -187,7 +187,7 @@ namespace zypp
       /** Exchange LineWriter for the lifetime of this object.
        * \see \ref log::LineWriter
       */
-      struct TmpLineWriter
+      struct ZYPP_API TmpLineWriter
       {
         TmpLineWriter( const shared_ptr<LineWriter> & writer_r = shared_ptr<LineWriter>() )
           : _writer( LogControl::instance().getLineWriter() )
@@ -218,7 +218,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates LogControl Stream output */
-    std::ostream & operator<<( std::ostream & str, const LogControl & obj );
+    std::ostream & operator<<( std::ostream & str, const LogControl & obj ) ZYPP_API;
 
     /////////////////////////////////////////////////////////////////
   } // namespace base

--- a/zypp-core/base/Logger.h
+++ b/zypp-core/base/Logger.h
@@ -15,6 +15,8 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 #ifndef ZYPP_NDEBUG
 namespace zypp
@@ -174,8 +176,8 @@ namespace zypp
                                        LogLevel     level_r,
                                        const char * file_r,
                                        const char * func_r,
-                                       const int    line_r );
-      extern bool isExcessive();
+                                       const int    line_r ) ZYPP_API;
+      extern bool isExcessive() ZYPP_API;
 
       /////////////////////////////////////////////////////////////////
     } // namespace logger

--- a/zypp-core/base/PtrTypes.h
+++ b/zypp-core/base/PtrTypes.h
@@ -16,6 +16,7 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
@@ -637,8 +638,8 @@ namespace zypp
 /** Forward declaration of Ptr types */
 #define DEFINE_PTR_TYPE(NAME) \
 class NAME;                                                      \
-extern void intrusive_ptr_add_ref( const NAME * );               \
-extern void intrusive_ptr_release( const NAME * );               \
+extern void intrusive_ptr_add_ref( const NAME * ) ZYPP_API;               \
+extern void intrusive_ptr_release( const NAME * ) ZYPP_API;               \
 typedef zypp::intrusive_ptr<NAME>       NAME##_Ptr;        \
 typedef zypp::intrusive_ptr<const NAME> NAME##_constPtr;
 

--- a/zypp-core/base/ReferenceCounted.h
+++ b/zypp-core/base/ReferenceCounted.h
@@ -14,6 +14,7 @@
 
 #include <iosfwd>
 
+#include <zypp-core/Globals.h>
 #include <zypp-core/base/PtrTypes.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -30,7 +31,7 @@ namespace zypp
     /** Base class for reference counted objects.
      * \todo Make counter thread safe.
     */
-    class ReferenceCounted
+    class ZYPP_API ReferenceCounted
     {
       /** Stream output via dumpOn. */
       friend std::ostream & operator<<( std::ostream & str, const ReferenceCounted & obj );

--- a/zypp-core/base/Regex.h
+++ b/zypp-core/base/Regex.h
@@ -64,14 +64,14 @@ namespace zypp
     /// Return whether a \ref regex matches a specific string. An optionally
     /// passed \ref smatch object will contain the match reults.
     //////////////////////////////////////////////////////////////////
-    bool regex_match( const char * s, smatch & matches, const regex & regex );
+    bool regex_match( const char * s, smatch & matches, const regex & regex ) ZYPP_API;
 
     /** \copydoc regex_match \relates regex \ingroup ZYPP_STR_REGEX */
     inline bool regex_match(const std::string & s, smatch & matches, const regex & regex)
     { return regex_match( s.c_str(), matches, regex ); }
 
     /** \copydoc regex_match \relates regex \ingroup ZYPP_STR_REGEX */
-    bool regex_match( const char * s, const regex & regex );
+    bool regex_match( const char * s, const regex & regex ) ZYPP_API;
 
     /** \copydoc regex_match \relates regex \ingroup ZYPP_STR_REGEX */
     inline bool regex_match( const std::string & s, const regex & regex )
@@ -83,7 +83,7 @@ namespace zypp
      *
      * \note Using backreferences in the replacement string is NOT supported.
      */
-    std::string regex_substitute ( const std::string & s, const regex & regex, const std::string &replacement, bool global = true );
+    std::string regex_substitute ( const std::string & s, const regex & regex, const std::string &replacement, bool global = true ) ZYPP_API;
 
     //////////////////////////////////////////////////////////////////
     /// \class regex
@@ -91,7 +91,7 @@ namespace zypp
     ///
     /// \ingroup ZYPP_STR_REGEX
     //////////////////////////////////////////////////////////////////
-    class regex
+    class ZYPP_API regex
     {
     public:
 
@@ -164,7 +164,7 @@ namespace zypp
     /// If \c n is out of range, or if \c n is an unmatched sub-expression,
     /// then an empty string is returned.
     //////////////////////////////////////////////////////////////////
-    class smatch
+    class ZYPP_API smatch
     {
     public:
       smatch();

--- a/zypp-core/base/String.h
+++ b/zypp-core/base/String.h
@@ -167,14 +167,14 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
     /** Printf style construction of std::string. */
     std::string form( const char * format, ... )
-    __attribute__ ((format (printf, 1, 2)));
+    __attribute__ ((format (printf, 1, 2))) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
     /** Return string describing the \a error_r code.
      * Like ::strerror, but the numerical value is included in
      * the string as well.
     */
-    std::string strerror( int errno_r );
+    std::string strerror( int errno_r ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
     /** Assert \c free called for allocated <tt>char *</tt>.
@@ -417,10 +417,10 @@ namespace zypp
     */
     //@{
     /** Return \c true if str is <tt>1, true, yes, on, always</tt> (or a nonzero number). */
-    bool strToTrue( const C_Str & str );
+    bool strToTrue( const C_Str & str ) ZYPP_API;
 
     /** Return \c false if str is <tt>0, false, no, off, never</tt>. */
-    bool strToFalse( const C_Str & str );
+    bool strToFalse( const C_Str & str ) ZYPP_API;
 
     /** Parse \c str into a bool depending on the default value.
      * If the \c default is true, look for a legal \c false string.
@@ -441,28 +441,28 @@ namespace zypp
     }
 
     /** Parse \c str into a bool if it's a legal \c true or \c false string; else \c indeterminate. */
-    TriBool strToTriBool( const C_Str & str );
+    TriBool strToTriBool( const C_Str & str ) ZYPP_API;
 
     //@}
 
     /**
      * \short Return a string with all occurrences of \c from_r replaced with \c to_r.
      */
-    std::string gsub( const std::string & str_r, const std::string & from_r, const std::string & to_r );
+    std::string gsub( const std::string & str_r, const std::string & from_r, const std::string & to_r ) ZYPP_API;
 
     /** \overload A function is called on demand to compute each replacement value.
      */
-    std::string gsubFun( const std::string & str_r, const std::string & from_r, function<std::string()> to_r );
+    std::string gsubFun( const std::string & str_r, const std::string & from_r, function<std::string()> to_r ) ZYPP_API;
 
     /**
      * \short Replace all occurrences of \c from_r with \c to_r in \c str_r (inplace).
      * A reference to \c str_r is also returned for convenience.
      */
-    std::string & replaceAll( std::string & str_r, const std::string & from_r, const std::string & to_r );
+    std::string & replaceAll( std::string & str_r, const std::string & from_r, const std::string & to_r ) ZYPP_API;
 
     /** \overload A function is called on demand to compute each replacement value.
      */
-    std::string & replaceAllFun( std::string & str_r, const std::string & from_r, const function<std::string()>& to_r );
+    std::string & replaceAllFun( std::string & str_r, const std::string & from_r, const function<std::string()>& to_r ) ZYPP_API;
 
     /** Enhance readability: insert gaps at regular distance
      * \code
@@ -500,8 +500,8 @@ namespace zypp
       TRIM    = (L_TRIM|R_TRIM)
     };
 
-    std::string trim( const std::string & s, const Trim trim_r = TRIM );
-    std::string trim( std::string && s, const Trim trim_r = TRIM );
+    std::string trim( const std::string & s, const Trim trim_r = TRIM ) ZYPP_API;
+    std::string trim( std::string && s, const Trim trim_r = TRIM ) ZYPP_API;
 
     inline std::string ltrim( const std::string & s )
     { return trim( s, L_TRIM ); }
@@ -916,7 +916,7 @@ namespace zypp
        * For use when printing \a c separated values, and where
        * \ref joinEscaped() is too heavy.
        */
-      std::string escape( const C_Str & str_r, const char c = ' ' );
+      std::string escape( const C_Str & str_r, const char c = ' ' ) ZYPP_API;
 
       /** Escape \a next_r and append it to \a str_r using separator \a sep_r. */
       inline void appendEscaped( std::string & str_r, const C_Str & next_r, const char sep_r = ' ' )
@@ -930,13 +930,13 @@ namespace zypp
       }
 
       /** Return \a str_r with '\'-escaped chars occurring in \a special_r (and '\'). */
-      std::string bEscape( std::string str_r, const C_Str & special_r );
+      std::string bEscape( std::string str_r, const C_Str & special_r ) ZYPP_API;
 
       /** Escape plain STRING \a str_r for use in a regex (not anchored by "^" or "$"). */
-      std::string rxEscapeStr( std::string str_r );
+      std::string rxEscapeStr( std::string str_r ) ZYPP_API;
 
       /** Escape GLOB \a str_r for use in a regex (not anchored by "^" or "$"). */
-      std::string rxEscapeGlob( std::string str_r );
+      std::string rxEscapeGlob( std::string str_r ) ZYPP_API;
 
       //! \todo unsecape()
 
@@ -962,8 +962,8 @@ namespace zypp
     /** Return lowercase version of \a s
      * \todo improve
     */
-    std::string toLower( const std::string & s );
-    std::string toLower( std::string && s );
+    std::string toLower( const std::string & s ) ZYPP_API;
+    std::string toLower( std::string && s ) ZYPP_API;
     /** \overload */
     inline std::string toLower( const char * s )
     { return( s ? toLower( std::string(s) ) : std::string() ); }
@@ -971,8 +971,8 @@ namespace zypp
     /** Return uppercase version of \a s
      * \todo improve
     */
-    std::string toUpper( const std::string & s );
-    std::string toUpper( std::string && s );
+    std::string toUpper( const std::string & s ) ZYPP_API;
+    std::string toUpper( std::string && s ) ZYPP_API;
     /** \overload */
     inline std::string toUpper( const char * s )
     { return( s ? toUpper( std::string(s) ) : std::string() ); }
@@ -995,19 +995,19 @@ namespace zypp
     { return ::strcasestr( str_r, val_r ); }
     //@}
 
-    std::string stripFirstWord( std::string & line, const bool ltrim_first = true );
+    std::string stripFirstWord( std::string & line, const bool ltrim_first = true ) ZYPP_API;
 
-    std::string stripLastWord( std::string & line, const bool rtrim_first = true );
-
-    /** Return stream content up to (but not returning) the next newline.
-     * \see \ref receiveUpTo
-     */
-    std::string getline( std::istream & str, bool trim = false );
+    std::string stripLastWord( std::string & line, const bool rtrim_first = true ) ZYPP_API;
 
     /** Return stream content up to (but not returning) the next newline.
      * \see \ref receiveUpTo
      */
-    std::string getline( std::istream & str, const Trim trim_r );
+    std::string getline( std::istream & str, bool trim = false ) ZYPP_API;
+
+    /** Return stream content up to (but not returning) the next newline.
+     * \see \ref receiveUpTo
+     */
+    std::string getline( std::istream & str, const Trim trim_r ) ZYPP_API;
 
     /** Return stream content up to the next ocurrence of \c delim_r or EOF
      * \c delim_r, if found, is always read from the stream. Whether it is

--- a/zypp-core/base/StringV.h
+++ b/zypp-core/base/StringV.h
@@ -177,7 +177,7 @@ namespace zypp
       //@}
 
       /** \ref split working horse */
-      unsigned _split( std::string_view line_r, std::string_view sep_r, Trim trim_r, WordConsumer && fnc_r );
+      unsigned _split( std::string_view line_r, std::string_view sep_r, Trim trim_r, WordConsumer && fnc_r ) ZYPP_API;
 
       /** \ref splitRx working horse */
       unsigned _splitRx(std::string_view line_r, const regex & rx_r, const WordConsumer& fnc_r );

--- a/zypp-core/base/Unit.h
+++ b/zypp-core/base/Unit.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <utility>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 { /////////////////////////////////////////////////////////////////
@@ -40,7 +42,7 @@ namespace zypp
      * static const Unit T( 1099511627776, "T", 3 );
      * \endcode
     */
-      class Unit
+      class ZYPP_API Unit
       {
       public:
         using ValueType = long long;

--- a/zypp-core/base/inputstream.h
+++ b/zypp-core/base/inputstream.h
@@ -53,7 +53,7 @@ namespace zypp
    *                     "my stream's name" ) );
    * \endcode
   */
-  class InputStream
+  class ZYPP_API InputStream
   {
   public:
     /** Default ctor providing \c std::cin. */

--- a/zypp-core/base/userrequestexception.h
+++ b/zypp-core/base/userrequestexception.h
@@ -61,7 +61,7 @@ namespace zypp
    * }
    * \endcode
   */
-  class UserRequestException : public Exception
+  class ZYPP_API UserRequestException : public Exception
   {
     public:
       enum Kind { UNSPECIFIED, IGNORE, SKIP, RETRY, ABORT };
@@ -84,7 +84,7 @@ namespace zypp
 
   /** Convenience macro to declare more specific PluginScriptExceptions. */
 #define declException( EXCP, KIND )					\
-  struct EXCP : public UserRequestException {				\
+  struct ZYPP_API EXCP : public UserRequestException {				\
     explicit								\
     EXCP( const std::string & msg_r = std::string() )			\
       : UserRequestException( KIND, msg_r )				\

--- a/zypp-core/fs/PathInfo.h
+++ b/zypp-core/fs/PathInfo.h
@@ -68,7 +68,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates FileType Stram output. */
-    extern std::ostream & operator<<( std::ostream & str, FileType obj );
+    extern std::ostream & operator<<( std::ostream & str, FileType obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 
@@ -166,7 +166,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates StatMode Stream output. */
-    extern std::ostream & operator<<( std::ostream & str, const StatMode & obj );
+    extern std::ostream & operator<<( std::ostream & str, const StatMode & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 
@@ -218,7 +218,7 @@ namespace zypp
      *
      * \note For convenience PathInfo is available as zypp::PathInfo too.
      **/
-    class PathInfo
+    class ZYPP_API PathInfo
     {
       friend std::ostream & operator<<( std::ostream & str, const PathInfo & obj );
 
@@ -387,7 +387,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates PathInfo Stream output. */
-    extern std::ostream & operator<<( std::ostream & str, const PathInfo & obj );
+    extern std::ostream & operator<<( std::ostream & str, const PathInfo & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 
@@ -401,7 +401,7 @@ namespace zypp
      *
      * @return 0 on success, errno on failure
      **/
-    int mkdir( const Pathname & path, unsigned mode = 0755 );
+    int mkdir( const Pathname & path, unsigned mode = 0755 ) ZYPP_API;
 
     /**
      * Like 'mkdir -p'. No error if directory exists. Make parent directories
@@ -410,14 +410,14 @@ namespace zypp
      *
      * @return 0 on success, errno on failure
      **/
-    int assert_dir( const Pathname & path, unsigned mode = 0755 );
+    int assert_dir( const Pathname & path, unsigned mode = 0755 ) ZYPP_API;
 
     /**
      * Like '::rmdir'. Delete a directory, which must be empty.
      *
      * @return 0 on success, errno on failure
      **/
-    int rmdir( const Pathname & path );
+    int rmdir( const Pathname & path ) ZYPP_API;
 
     /**
      * Like 'rm -r DIR'. Delete a directory, recursively removing its contents.
@@ -425,7 +425,7 @@ namespace zypp
      * @return 0 on success, ENOTDIR if path is not a directory, otherwise the
      * commands return value.
      **/
-    int recursive_rmdir( const Pathname & path );
+    int recursive_rmdir( const Pathname & path ) ZYPP_API;
 
     /**
      * Like 'rm -r DIR/ *'. Delete directory contents, but keep the directory itself.
@@ -433,7 +433,7 @@ namespace zypp
      * @return 0 on success, ENOTDIR if path is not a directory, otherwise the
      * commands return value.
      **/
-    int clean_dir( const Pathname & path );
+    int clean_dir( const Pathname & path ) ZYPP_API;
 
     /**
      * Like 'cp -a srcpath destpath'. Copy directory tree. srcpath/destpath must be
@@ -442,7 +442,7 @@ namespace zypp
      * @return 0 on success, ENOTDIR if srcpath/destpath is not a directory, EEXIST if
      * 'basename srcpath' exists in destpath, otherwise the commands return value.
      **/
-    int copy_dir( const Pathname & srcpath, const Pathname & destpath );
+    int copy_dir( const Pathname & srcpath, const Pathname & destpath ) ZYPP_API;
 
     /**
      * Like 'cp -a srcpath/. destpath'. Copy the content of srcpath recursively
@@ -452,7 +452,7 @@ namespace zypp
      * EEXIST if srcpath and destpath are equal, otherwise the commands
      * return value.
      */
-    int copy_dir_content( const Pathname & srcpath, const Pathname & destpath);
+    int copy_dir_content( const Pathname & srcpath, const Pathname & destpath) ZYPP_API;
 
     /**
      * Invoke callback function \a fnc_r for each entry in directory \a dir_r.
@@ -466,7 +466,7 @@ namespace zypp
      *
      * @return 0 on success, -1 if aborted by callback, errno > 0 on ::readdir failure.
      */
-    int dirForEach( const Pathname & dir_r, const function<bool(const Pathname &, const char *const)>& fnc_r );
+    int dirForEach( const Pathname & dir_r, const function<bool(const Pathname &, const char *const)>& fnc_r ) ZYPP_API;
 
     /**
      * Return content of directory via retlist. If dots is false
@@ -481,7 +481,7 @@ namespace zypp
      **/
 
     int readdir( std::list<std::string> & retlist,
-                 const Pathname & path, bool dots = true );
+                 const Pathname & path, bool dots = true ) ZYPP_API;
 
     /**
      * Return content of directory via retlist. If dots is false
@@ -496,7 +496,7 @@ namespace zypp
      **/
 
     int readdir( std::list<Pathname> & retlist,
-                 const Pathname & path, bool dots = true );
+                 const Pathname & path, bool dots = true ) ZYPP_API;
 
     /** Listentry returned by readdir. */
     struct DirEntry {
@@ -518,7 +518,7 @@ namespace zypp
     /** Returned by readdir. */
     using DirContent = std::list<DirEntry>;
 
-    std::ostream & operator<<( std::ostream & str, const DirContent & obj );
+    std::ostream & operator<<( std::ostream & str, const DirContent & obj ) ZYPP_API;
 
     /**
      * Return content of directory via retlist. If dots is false
@@ -531,19 +531,19 @@ namespace zypp
      * @return 0 on success, errno on failure.
      **/
     int readdir( DirContent & retlist, const Pathname & path,
-                 bool dots = true, PathInfo::Mode statmode = PathInfo::STAT );
+                 bool dots = true, PathInfo::Mode statmode = PathInfo::STAT ) ZYPP_API;
 
     /**
      * Simiar to \sa dirForEach, except that the callback takes a \sa DirEntry as second argument
      */
-    int dirForEachExt( const Pathname & dir_r, const function<bool(const Pathname &, const DirEntry &)> &fnc_r );
+    int dirForEachExt( const Pathname & dir_r, const function<bool(const Pathname &, const DirEntry &)> &fnc_r ) ZYPP_API;
 
     /**
      * Check if the specified directory is empty.
      * \param path The path of the directory to check.
      * \return 0 if directory is empty, -1 if not, errno > 0 on failure.
      */
-    int is_empty_dir(const Pathname & path);
+    int is_empty_dir(const Pathname & path) ZYPP_API;
 
     //@}
 
@@ -557,11 +557,12 @@ namespace zypp
      *
      * @return 0 on success, errno on failure
      **/
-    int assert_file( const Pathname & path, unsigned mode = 0644 );
+    int assert_file( const Pathname & path, unsigned mode = 0644 ) ZYPP_API;
+
     /**
      * Like \ref assert_file but enforce \a mode even if the file already exists.
      */
-    int assert_file_mode( const Pathname & path, unsigned mode = 0644 );
+    int assert_file_mode( const Pathname & path, unsigned mode = 0644 ) ZYPP_API;
 
     /**
      * Change file's modification and access times.
@@ -569,14 +570,14 @@ namespace zypp
      * \return 0 on success, errno on failure
      * \see man utime
      */
-    int touch (const Pathname & path);
+    int touch (const Pathname & path) ZYPP_API;
 
     /**
      * Like '::unlink'. Delete a file (symbolic link, socket, fifo or device).
      *
      * @return 0 on success, errno on failure
      **/
-    int unlink( const Pathname & path );
+    int unlink( const Pathname & path ) ZYPP_API;
 
     /**
      * Like '::rename'. Renames a file, moving it between directories if
@@ -586,7 +587,7 @@ namespace zypp
      *
      * @return 0 on success, errno on failure
      **/
-    int rename( const Pathname & oldpath, const Pathname & newpath );
+    int rename( const Pathname & oldpath, const Pathname & newpath ) ZYPP_API;
 
     /** Exchanges two files or directories.
      *
@@ -622,7 +623,7 @@ namespace zypp
      * @return 0 on success, EINVAL if file is not a file, EISDIR if
      * destiantion is a directory, otherwise the commands return value.
      **/
-    int copy( const Pathname & file, const Pathname & dest );
+    int copy( const Pathname & file, const Pathname & dest ) ZYPP_API;
 
     /**
      * Like '::symlink'. Creates a symbolic link named newpath which contains
@@ -630,7 +631,7 @@ namespace zypp
      *
      * @return 0 on success, errno on failure.
      **/
-    int symlink( const Pathname & oldpath, const Pathname & newpath );
+    int symlink( const Pathname & oldpath, const Pathname & newpath ) ZYPP_API;
 
     /**
      * Like '::link'. Creates a hard link named newpath to an existing file
@@ -638,14 +639,14 @@ namespace zypp
      *
      * @return 0 on success, errno on failure.
      **/
-    int hardlink( const Pathname & oldpath, const Pathname & newpath );
+    int hardlink( const Pathname & oldpath, const Pathname & newpath ) ZYPP_API;
 
     /**
      * Create \a newpath as hardlink or copy of \a oldpath.
      *
      * @return 0 on success, errno on failure.
      */
-    int hardlinkCopy( const Pathname & oldpath, const Pathname & newpath );
+    int hardlinkCopy( const Pathname & oldpath, const Pathname & newpath ) ZYPP_API;
 
     /**
      * Like '::readlink'. Return the contents of the symbolic link
@@ -674,7 +675,7 @@ namespace zypp
      *   it is returned. If \a path_r is a broken or a cyclic link, an empty
      *   Pathname is returned and the event logged.
      */
-    Pathname expandlink( const Pathname & path_r );
+    Pathname expandlink( const Pathname & path_r ) ZYPP_API;
 
     /**
      * Like 'cp file dest'. Copy file to dest dir.

--- a/zypp-core/fs/TmpPath.h
+++ b/zypp-core/fs/TmpPath.h
@@ -37,7 +37,7 @@ namespace zypp {
      *
      * Principally serves as base class, but standalone usable.
      **/
-    class TmpPath
+    class ZYPP_API TmpPath
     {
       public:
         /**
@@ -124,7 +124,7 @@ namespace zypp {
      * TmpFile provides the Pathname of the temporary file, or an empty
      * path in case of any error.
      **/
-    class TmpFile : public TmpPath
+    class ZYPP_API TmpFile : public TmpPath
     {
       public:
         /**
@@ -178,7 +178,7 @@ namespace zypp {
      * TmpDir provides the Pathname of the temporary directory , or an empty
      * path in case of any error.
      **/
-    class TmpDir : public TmpPath
+    class ZYPP_API TmpDir : public TmpPath
     {
       public:
         /**
@@ -213,7 +213,7 @@ namespace zypp {
   } // namespace filesystem
 
   /** Global access to the zypp.TMPDIR (created on demand, deleted when libzypp is unloaded) */
-  Pathname myTmpDir();	// implemented in ZYppImpl.cc
+  Pathname myTmpDir() ZYPP_API;	// implemented in ZYppImpl.cc
 
 } // namespace zypp
 

--- a/zypp-core/onmedialocation.h
+++ b/zypp-core/onmedialocation.h
@@ -33,7 +33,7 @@ namespace zypp
   ///
   /// Media number \c 0 usually indicates no media access.
   ///////////////////////////////////////////////////////////////////
-  class OnMediaLocation
+  class ZYPP_API OnMediaLocation
   {
     friend std::ostream & operator<<( std::ostream & str, const OnMediaLocation & obj );
     friend std::ostream & dumpOn( std::ostream & str, const OnMediaLocation & obj );

--- a/zypp-core/parser/parseexception.h
+++ b/zypp-core/parser/parseexception.h
@@ -30,7 +30,7 @@ namespace zypp
     //	CLASS NAME : ParseException
     //
     /** */
-    class ParseException : public Exception
+    class ZYPP_API ParseException : public Exception
     {
     public:
       /** Default ctor */

--- a/zypp-core/parser/sysconfig.h
+++ b/zypp-core/parser/sysconfig.h
@@ -21,7 +21,7 @@ namespace zypp {
     namespace sysconfig {
 
       /** Read sysconfig file \a path_r and return <tt>(key,valye)</tt> pairs. */
-      std::map<std::string,std::string> read( const Pathname & _path );
+      std::map<std::string,std::string> read( const Pathname & _path ) ZYPP_API;
 
       /** Add or change a value in sysconfig file \a path_r.
        *
@@ -53,7 +53,7 @@ namespace zypp {
        * \endcode
        */
       bool write( const Pathname & path_r, const std::string & key_r, const std::string & val_r,
-                  const std::string & newcomment_r = std::string() );
+                  const std::string & newcomment_r = std::string() ) ZYPP_API;
 
       /** Convenience to add or change a string-value in sysconfig file \a path_r.
        *
@@ -63,7 +63,7 @@ namespace zypp {
        * \see \ref write
        */
       bool writeStringVal( const Pathname & path_r, const std::string & key_r, const std::string & val_r,
-                           const std::string & newcomment_r = std::string() );
+                           const std::string & newcomment_r = std::string() ) ZYPP_API;
 
     } // namespace sysconfig
   } // namespace base

--- a/zypp-core/parser/xml/XmlEscape.h
+++ b/zypp-core/parser/xml/XmlEscape.h
@@ -25,7 +25,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
     namespace detail
     {
-      struct EscapedString
+      struct ZYPP_API EscapedString
       {
         EscapedString( const std::string & in_r ) : _in( in_r ) {}
         std::ostream & dumpOn( std::ostream & str ) const;
@@ -48,11 +48,11 @@ namespace zypp
      * The \ref detail::EscapedString can be dumped to an ostream and implicitly
      * converts into a std::string.
      */
-    inline detail::EscapedString escape( const std::string & in_r )
+    ZYPP_API inline detail::EscapedString escape( const std::string & in_r )
     { return detail::EscapedString( in_r ); }
 
     /** Unescape xml special charaters (<tt>&amp; -> &</tt>; from IoBind library) */
-    ZYPP_API std::string unescape( const std::string & in_r );
+    std::string unescape( const std::string & in_r ) ZYPP_API;
 
   } // namespace xml
   /////////////////////////////////////////////////////////////////

--- a/zypp-core/ui/progressdata.h
+++ b/zypp-core/ui/progressdata.h
@@ -128,7 +128,7 @@ namespace zypp
    * The different ammount of triggers is due to different rules for sending
    * percent or 'still alive' messages.
    */
-  class ProgressData : public base::ProvideNumericId<ProgressData,unsigned>
+  class ZYPP_API ProgressData : public base::ProvideNumericId<ProgressData,unsigned>
   {
     public:
       using value_type = long long;
@@ -390,7 +390,7 @@ namespace zypp
    *
    * \endcode
    */
-  class CombinedProgressData
+  class ZYPP_API CombinedProgressData
   {
   public:
     /**

--- a/zypp-core/url/UrlBase.h
+++ b/zypp-core/url/UrlBase.h
@@ -36,7 +36,7 @@ namespace zypp
      * to modify a view option combination and a ViewOption::has()
      * method, to check if a specified option is enabled or not.
      */
-    struct ViewOption
+    struct ZYPP_API ViewOption
     {
       /** @{ */
       /**
@@ -48,14 +48,14 @@ namespace zypp
        *
        * This option is \b enabled by default.
        */
-      static const ViewOption WITH_SCHEME;
+      static const ViewOption WITH_SCHEME ZYPP_API;
       /**
        * Option to include username in the URL string.
        *
        * This option depends on a enabled WITH_SCHEME and
        * WITH_HOST options and is \b enabled by default.
        */
-      static const ViewOption WITH_USERNAME;
+      static const ViewOption WITH_USERNAME ZYPP_API;
       /**
        * Option to include password in the URL string.
        *
@@ -64,27 +64,27 @@ namespace zypp
        * \b disabled by default, causing to hide the
        * password in the URL authority.
        */
-      static const ViewOption WITH_PASSWORD;
+      static const ViewOption WITH_PASSWORD ZYPP_API;
       /**
        * Option to include hostname in the URL string.
        *
        * This option depends on a enabled WITH_SCHEME
        * option and is \b enabled by default.
        */
-      static const ViewOption WITH_HOST;
+      static const ViewOption WITH_HOST ZYPP_API;
       /**
        * Option to include port number in the URL string.
        *
        * This option depends on a enabled WITH_SCHEME and
        * WITH_HOST options and is \b enabled by default.
        */
-      static const ViewOption WITH_PORT;
+      static const ViewOption WITH_PORT ZYPP_API;
       /**
        * Option to include path name in the URL string.
        *
        * This option is \b enabled by default.
        */
-      static const ViewOption WITH_PATH_NAME;
+      static const ViewOption WITH_PATH_NAME ZYPP_API;
       /**
        * Option to include path parameters in the URL string.
        *
@@ -92,19 +92,19 @@ namespace zypp
        * option and is \b disabled by default, causing to
        * hide the path parameters.
        */
-      static const ViewOption WITH_PATH_PARAMS;
+      static const ViewOption WITH_PATH_PARAMS ZYPP_API;
       /**
        * Option to include query string in the URL string.
        *
        * This option is \b enabled by default.
        */
-      static const ViewOption WITH_QUERY_STR;
+      static const ViewOption WITH_QUERY_STR ZYPP_API;
       /**
        * Option to include fragment string in the URL string.
        *
        * This option is \b enabled by default.
        */
-      static const ViewOption WITH_FRAGMENT;
+      static const ViewOption WITH_FRAGMENT ZYPP_API;
       /** @} */
 
       /** @{ */
@@ -118,7 +118,7 @@ namespace zypp
        * This option depends on a enabled WITH_SCHEME view
        * option and is enabled by default.
        */
-      static const ViewOption EMPTY_AUTHORITY;
+      static const ViewOption EMPTY_AUTHORITY ZYPP_API;
       /**
        * Explicitely include the "/" path character.
        *
@@ -130,7 +130,7 @@ namespace zypp
        * This option depends on a enabled WITH_PATH_NAME view
        * option and is enabled by default.
        */
-      static const ViewOption EMPTY_PATH_NAME;
+      static const ViewOption EMPTY_PATH_NAME ZYPP_API;
       /**
        * Explicitely include the path parameters separator ";".
        *
@@ -140,7 +140,7 @@ namespace zypp
        * This option depends on a enabled EMPTY_PATH_NAME view
        * option and is disabled by default.
        */
-      static const ViewOption EMPTY_PATH_PARAMS;
+      static const ViewOption EMPTY_PATH_PARAMS ZYPP_API;
       /**
        * Explicitely include the query string separator "?".
        *
@@ -151,7 +151,7 @@ namespace zypp
        * This option depends on a enabled WITH_QUERY_STR view
        * option and is disabled by default.
        */
-      static const ViewOption EMPTY_QUERY_STR;
+      static const ViewOption EMPTY_QUERY_STR ZYPP_API;
       /**
        * Explicitely include the fragment string separator "#".
        *
@@ -162,7 +162,7 @@ namespace zypp
        * This option depends on a enabled WITH_FRAGMENT view
        * option and is disabled by default.
        */
-      static const ViewOption EMPTY_FRAGMENT;
+      static const ViewOption EMPTY_FRAGMENT ZYPP_API;
       /** @} */
 
       /** @{ */
@@ -174,7 +174,7 @@ namespace zypp
        *   WITH_PORT,      WITH_PATH_NAME,   WITH_QUERY_STR,
        *   WITH_FRAGMENT,  EMPTY_AUTHORITY,  EMPTY_PATH_NAME.
        */
-      static const ViewOption DEFAULTS;
+      static const ViewOption DEFAULTS ZYPP_API;
       /** @} */
 
 

--- a/zypp-core/url/UrlException.h
+++ b/zypp-core/url/UrlException.h
@@ -28,7 +28,7 @@ namespace zypp
     /**
      * Base class for all URL exceptions.
      */
-    class UrlException: public zypp::Exception
+    class ZYPP_API UrlException: public zypp::Exception
     {
     public:
       UrlException()
@@ -46,7 +46,7 @@ namespace zypp
     /**
      * Thrown if the encoded string contains a NUL byte (%00).
      */
-    class UrlDecodingException: public UrlException
+    class ZYPP_API UrlDecodingException: public UrlException
     {
     public:
       UrlDecodingException()
@@ -64,7 +64,7 @@ namespace zypp
     /**
      * Thrown if the url or a component can't be parsed at all.
      */
-    class UrlParsingException: public UrlException
+    class ZYPP_API UrlParsingException: public UrlException
     {
     public:
       UrlParsingException()
@@ -82,7 +82,7 @@ namespace zypp
     /**
      * Thrown if a url component is invalid.
      */
-    class UrlBadComponentException: public UrlException
+    class ZYPP_API UrlBadComponentException: public UrlException
     {
     public:
       UrlBadComponentException()
@@ -101,7 +101,7 @@ namespace zypp
     /**
      * Thrown if scheme does not allow a component.
      */
-    class UrlNotAllowedException: public UrlException
+    class ZYPP_API UrlNotAllowedException: public UrlException
     {
     public:
       UrlNotAllowedException()
@@ -121,7 +121,7 @@ namespace zypp
      * Thrown if a feature e.g. parsing of a component
      * is not supported for the url/scheme.
      */
-    class UrlNotSupportedException: public UrlException
+    class ZYPP_API UrlNotSupportedException: public UrlException
     {
     public:
       UrlNotSupportedException()

--- a/zypp-core/url/UrlUtils.h
+++ b/zypp-core/url/UrlUtils.h
@@ -83,7 +83,7 @@ namespace zypp
      */
     std::string
     encode(const std::string &str, const std::string &safe = "",
-                                   EEncoding         eflag = E_DECODED);
+                                   EEncoding         eflag = E_DECODED) ZYPP_API;
 
 
     // ---------------------------------------------------------------
@@ -103,7 +103,7 @@ namespace zypp
      *         a encoded NUL byte (\c "%00") was found in \p str.
      */
     std::string
-    decode(const std::string &str, bool allowNUL = false);
+    decode(const std::string &str, bool allowNUL = false) ZYPP_API;
 
 
     // ---------------------------------------------------------------
@@ -117,7 +117,7 @@ namespace zypp
      *         e.g. %20 for a ' ' (space).
      */
     std::string
-    encode_octet(const unsigned char c);
+    encode_octet(const unsigned char c) ZYPP_API;
 
 
     // ---------------------------------------------------------------
@@ -140,7 +140,7 @@ namespace zypp
      *         if \p hex does not point to two hexadecimal characters.
      */
     int
-    decode_octet(const char *hex);
+    decode_octet(const char *hex) ZYPP_API;
 
 
     // ---------------------------------------------------------------

--- a/zypp-curl/auth/curlauthdata.h
+++ b/zypp-curl/auth/curlauthdata.h
@@ -19,7 +19,7 @@ namespace zypp {
     /**
      * Curl HTTP authentication data.
      */
-    class CurlAuthData : public AuthData {
+    class ZYPP_API CurlAuthData : public AuthData {
     public:
       /**
        * Default constructor. Initializes username and password to empty strings

--- a/zypp-media/auth/authdata.h
+++ b/zypp-media/auth/authdata.h
@@ -27,7 +27,7 @@ namespace zypp {
  * Class for handling media authentication data. This is the most generic
  * class containing only username and password members.
  */
-class AuthData
+class ZYPP_API AuthData
 {
 public:
   AuthData()

--- a/zypp-media/filecheckexception.h
+++ b/zypp-media/filecheckexception.h
@@ -14,7 +14,7 @@
 
 namespace zypp {
 
-  class FileCheckException : public Exception
+  class ZYPP_API FileCheckException : public Exception
   {
   public:
     FileCheckException(std::string msg)
@@ -22,7 +22,7 @@ namespace zypp {
     {}
   };
 
-  class CheckSumCheckException : public FileCheckException
+  class ZYPP_API CheckSumCheckException : public FileCheckException
   {
   public:
     CheckSumCheckException(std::string msg)
@@ -30,7 +30,7 @@ namespace zypp {
     {}
   };
 
-  class SignatureCheckException : public FileCheckException
+  class ZYPP_API SignatureCheckException : public FileCheckException
   {
   public:
     SignatureCheckException(std::string msg)

--- a/zypp-media/mediaexception.h
+++ b/zypp-media/mediaexception.h
@@ -33,7 +33,7 @@ namespace zypp
     /** Just inherits Exception to separate media exceptions
      *
      **/
-    class MediaException : public Exception
+    class ZYPP_API MediaException : public Exception
     {
     public:
       /** Ctor taking message.
@@ -52,7 +52,7 @@ namespace zypp
       ~MediaException() noexcept override;
     };
 
-    class MediaMountException : public MediaException
+    class ZYPP_API MediaMountException : public MediaException
     {
     public:
       MediaMountException()
@@ -93,7 +93,7 @@ namespace zypp
       std::string _cmdout;
     };
 
-    class MediaUnmountException : public MediaException
+    class ZYPP_API MediaUnmountException : public MediaException
     {
     public:
       /** Ctor taking message.
@@ -114,7 +114,7 @@ namespace zypp
       std::string _path;
     };
 
-    class MediaJammedException : public MediaException
+    class ZYPP_API MediaJammedException : public MediaException
     {
     public:
       /** Ctor taking message.
@@ -131,7 +131,7 @@ namespace zypp
     private:
     };
 
-    class MediaBadFilenameException : public MediaException
+    class ZYPP_API MediaBadFilenameException : public MediaException
     {
     public:
       MediaBadFilenameException(std::string  filename_r)
@@ -146,7 +146,7 @@ namespace zypp
       std::string _filename;
     };
 
-    class MediaNotOpenException : public MediaException
+    class ZYPP_API MediaNotOpenException : public MediaException
     {
     public:
       MediaNotOpenException(std::string  action_r)
@@ -160,7 +160,7 @@ namespace zypp
       std::string _action;
     };
 
-    class MediaFileNotFoundException : public MediaException
+    class ZYPP_API MediaFileNotFoundException : public MediaException
     {
     public:
       MediaFileNotFoundException(const Url & url_r,
@@ -177,7 +177,7 @@ namespace zypp
       std::string _filename;
     };
 
-    class MediaWriteException : public MediaException
+    class ZYPP_API MediaWriteException : public MediaException
     {
     public:
       MediaWriteException(const Pathname & filename_r)
@@ -191,7 +191,7 @@ namespace zypp
       std::string _filename;
     };
 
-    class MediaNotAttachedException : public MediaException
+    class ZYPP_API MediaNotAttachedException : public MediaException
     {
     public:
       MediaNotAttachedException(const Url & url_r)
@@ -205,7 +205,7 @@ namespace zypp
       std::string _url;
     };
 
-    class MediaBadAttachPointException : public MediaException
+    class ZYPP_API MediaBadAttachPointException : public MediaException
     {
     public:
       MediaBadAttachPointException(const Url & url_r)
@@ -219,7 +219,7 @@ namespace zypp
       std::string _url;
     };
 
-    class MediaCurlInitException : public MediaException
+    class ZYPP_API MediaCurlInitException : public MediaException
     {
     public:
       MediaCurlInitException(const Url & url_r)
@@ -233,7 +233,7 @@ namespace zypp
       std::string _url;
     };
 
-    class MediaSystemException : public MediaException
+    class ZYPP_API MediaSystemException : public MediaException
     {
     public:
       MediaSystemException(const Url & url_r,
@@ -250,7 +250,7 @@ namespace zypp
       std::string _message;
     };
 
-    class MediaNotAFileException : public MediaException
+    class ZYPP_API MediaNotAFileException : public MediaException
     {
     public:
       MediaNotAFileException(const Url & url_r,
@@ -267,7 +267,7 @@ namespace zypp
       std::string _path;
     };
 
-    class MediaNotADirException : public MediaException
+    class ZYPP_API MediaNotADirException : public MediaException
     {
     public:
       MediaNotADirException(const Url & url_r,
@@ -284,7 +284,7 @@ namespace zypp
       std::string _path;
     };
 
-    class MediaBadUrlException : public MediaException
+    class ZYPP_API MediaBadUrlException : public MediaException
     {
     public:
       MediaBadUrlException(const Url & url_r,
@@ -300,7 +300,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaBadUrlEmptyHostException : public MediaBadUrlException
+    class ZYPP_API MediaBadUrlEmptyHostException : public MediaBadUrlException
     {
     public:
       MediaBadUrlEmptyHostException(const Url & url_r)
@@ -311,7 +311,7 @@ namespace zypp
       std::ostream & dumpOn( std::ostream & str ) const override;
     };
 
-    class MediaBadUrlEmptyFilesystemException : public MediaBadUrlException
+    class ZYPP_API MediaBadUrlEmptyFilesystemException : public MediaBadUrlException
     {
     public:
       MediaBadUrlEmptyFilesystemException(const Url & url_r)
@@ -322,7 +322,7 @@ namespace zypp
       std::ostream & dumpOn( std::ostream & str ) const override;
     };
 
-    class MediaBadUrlEmptyDestinationException : public MediaBadUrlException
+    class ZYPP_API MediaBadUrlEmptyDestinationException : public MediaBadUrlException
     {
     public:
       MediaBadUrlEmptyDestinationException(const Url & url_r)
@@ -333,7 +333,7 @@ namespace zypp
       std::ostream & dumpOn( std::ostream & str ) const override;
     };
 
-    class MediaUnsupportedUrlSchemeException : public MediaBadUrlException
+    class ZYPP_API MediaUnsupportedUrlSchemeException : public MediaBadUrlException
     {
     public:
       MediaUnsupportedUrlSchemeException(const Url & url_r)
@@ -344,7 +344,7 @@ namespace zypp
       std::ostream & dumpOn( std::ostream & str ) const override;
     };
 
-    class MediaNotSupportedException : public MediaException
+    class ZYPP_API MediaNotSupportedException : public MediaException
     {
     public:
       MediaNotSupportedException(const Url & url_r)
@@ -357,7 +357,7 @@ namespace zypp
       std::string _url;
     };
 
-    class MediaCurlException : public MediaException
+    class ZYPP_API MediaCurlException : public MediaException
     {
     public:
       MediaCurlException(const Url & url_r,
@@ -377,7 +377,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaCurlSetOptException : public MediaException
+    class ZYPP_API MediaCurlSetOptException : public MediaException
     {
     public:
       MediaCurlSetOptException(const Url & url_r, std::string  msg_r)
@@ -392,7 +392,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaNotDesiredException : public MediaException
+    class ZYPP_API MediaNotDesiredException : public MediaException
     {
     public:
       MediaNotDesiredException(const Url & url_r)
@@ -406,7 +406,7 @@ namespace zypp
       std::string  _url;
     };
 
-    class MediaIsSharedException : public MediaException
+    class ZYPP_API MediaIsSharedException : public MediaException
     {
     public:
       /**
@@ -423,7 +423,7 @@ namespace zypp
       std::string _name;
     };
 
-    class MediaNotEjectedException: public MediaException
+    class ZYPP_API MediaNotEjectedException: public MediaException
     {
     public:
       MediaNotEjectedException()
@@ -442,7 +442,7 @@ namespace zypp
       std::string _name;
     };
 
-    class MediaUnauthorizedException: public MediaException
+    class ZYPP_API MediaUnauthorizedException: public MediaException
     {
     public:
       MediaUnauthorizedException()
@@ -477,7 +477,7 @@ namespace zypp
       std::string _hint;
     };
 
-    class MediaForbiddenException : public MediaException
+    class ZYPP_API MediaForbiddenException : public MediaException
     {
     public:
       MediaForbiddenException(const Url & url_r, const std::string & msg = "")
@@ -491,7 +491,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaTimeoutException : public MediaException
+    class ZYPP_API MediaTimeoutException : public MediaException
     {
     public:
       MediaTimeoutException(const Url & url_r, const std::string & msg = "")
@@ -505,7 +505,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaFileSizeExceededException : public MediaException
+    class ZYPP_API MediaFileSizeExceededException : public MediaException
     {
     public:
       MediaFileSizeExceededException(const Url & url_r, const ByteCount &cnt_r, const std::string & msg = "")
@@ -523,7 +523,7 @@ namespace zypp
     };
 
     /** For HTTP 503 and similar. */
-    class MediaTemporaryProblemException : public MediaException
+    class ZYPP_API MediaTemporaryProblemException : public MediaException
     {
     public:
       MediaTemporaryProblemException(const Url & url_r, const std::string & msg = "")
@@ -537,7 +537,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaBadCAException : public MediaException
+    class ZYPP_API MediaBadCAException : public MediaException
     {
     public:
       MediaBadCAException(const Url & url_r, const std::string & msg = "")
@@ -551,7 +551,7 @@ namespace zypp
       std::string _msg;
     };
 
-    class MediaInvalidCredentialsException : public MediaException
+    class ZYPP_API MediaInvalidCredentialsException : public MediaException
     {
     public:
       MediaInvalidCredentialsException( const std::string & msg = "" )
@@ -560,7 +560,7 @@ namespace zypp
       ~MediaInvalidCredentialsException() noexcept override {}
     };
 
-    class MediaRequestCancelledException : public MediaException
+    class ZYPP_API MediaRequestCancelledException : public MediaException
     {
     public:
       MediaRequestCancelledException( const std::string & msg = "" )

--- a/zypp-media/mount.cc
+++ b/zypp-media/mount.cc
@@ -63,7 +63,7 @@ void Mount::mount( const std::string & source,
                    const std::string & target,
                    const std::string & filesystem,
                    const std::string & options,
-                   const Environment & environment )
+                   const Environment & environment)
 {
   const char *const argv[] = {
     "/bin/mount",

--- a/zypp-media/ng/worker/provideworker.h
+++ b/zypp-media/ng/worker/provideworker.h
@@ -39,7 +39,7 @@ namespace zyppng::worker {
     std::map<std::string, std::string> extraKeys = {};
   };
 
-  class RequestCancelException : public zypp::media::MediaException
+  class ZYPP_API RequestCancelException : public zypp::media::MediaException
   {
   public:
     RequestCancelException();

--- a/zypp/Application.h
+++ b/zypp/Application.h
@@ -24,7 +24,7 @@ namespace zypp
   /// \class Application
   /// \brief Class representing an application (appdata.xml)
   ///////////////////////////////////////////////////////////////////
-  class Application : public ResObject
+  class ZYPP_API Application : public ResObject
   {
   public:
     using Self = Application;

--- a/zypp/Arch.h
+++ b/zypp/Arch.h
@@ -33,7 +33,7 @@ namespace zypp
   //
   /** Architecture.
   */
-  class Arch
+  class ZYPP_API Arch
   {
   public:
     /** Default ctor \ref Arc_noarch. */
@@ -162,142 +162,142 @@ namespace zypp
    * confuse this with \ref Arch_noarch, which is in fact an
    * architecture.
   */
-  extern const Arch Arch_empty;
+  extern const Arch Arch_empty ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_noarch;
+  extern const Arch Arch_noarch ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_pentium4;
+  extern const Arch Arch_pentium4 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_pentium3;
+  extern const Arch Arch_pentium3 ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_x86_64_v4;
+  extern const Arch Arch_x86_64_v4 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_x86_64_v3;
+  extern const Arch Arch_x86_64_v3 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_x86_64_v2;
+  extern const Arch Arch_x86_64_v2 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_x86_64;
+  extern const Arch Arch_x86_64 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_athlon;
+  extern const Arch Arch_athlon ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_i686;
+  extern const Arch Arch_i686 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_i586;
+  extern const Arch Arch_i586 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_i486;
+  extern const Arch Arch_i486 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_i386;
+  extern const Arch Arch_i386 ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_s390x;
+  extern const Arch Arch_s390x ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_s390;
+  extern const Arch Arch_s390 ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_ppc64le;
+  extern const Arch Arch_ppc64le ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_ppc64p7;
+  extern const Arch Arch_ppc64p7 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_ppc64;
+  extern const Arch Arch_ppc64 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_ppc;
+  extern const Arch Arch_ppc ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_ia64;
+  extern const Arch Arch_ia64 ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_alphaev67;
+  extern const Arch Arch_alphaev67 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_alphaev6;
+  extern const Arch Arch_alphaev6 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_alphapca56;
+  extern const Arch Arch_alphapca56 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_alphaev56;
+  extern const Arch Arch_alphaev56 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_alphaev5;
+  extern const Arch Arch_alphaev5 ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_alpha;
-
-   /** \relates Arch */
-  extern const Arch Arch_sparc64v;
-  /** \relates Arch */
-  extern const Arch Arch_sparc64;
-  /** \relates Arch */
-  extern const Arch Arch_sparcv9v;
-  /** \relates Arch */
-  extern const Arch Arch_sparcv9;
-  /** \relates Arch */
-  extern const Arch Arch_sparcv8;
-  /** \relates Arch */
-  extern const Arch Arch_sparc;
-
-  /** \relates Arch */
-  extern const Arch Arch_aarch64;
-
-  /** \relates Arch */
-  extern const Arch Arch_armv7tnhl;	/* exists? */
-  /** \relates Arch */
-  extern const Arch Arch_armv7thl;	/* exists? */
-
-  /** \relates Arch */
-  extern const Arch Arch_armv7hnl,	/* legacy: */Arch_armv7nhl;
-  /** \relates Arch */
-  extern const Arch Arch_armv7hl;
-  /** \relates Arch */
-  extern const Arch Arch_armv6hl;
-
-  /** \relates Arch */
-  extern const Arch Arch_armv8hl;
-  /** \relates Arch */
-  extern const Arch Arch_armv8l;
-  /** \relates Arch */
-  extern const Arch Arch_armv7l;
-  /** \relates Arch */
-  extern const Arch Arch_armv6l;
-  /** \relates Arch */
-  extern const Arch Arch_armv5tejl;
-  /** \relates Arch */
-  extern const Arch Arch_armv5tel;
-  /** \relates Arch */
-  extern const Arch Arch_armv5tl;
-  /** \relates Arch */
-  extern const Arch Arch_armv5l;
-  /** \relates Arch */
-  extern const Arch Arch_armv4tl;
-  /** \relates Arch */
-  extern const Arch Arch_armv4l;
-  /** \relates Arch */
-  extern const Arch Arch_armv3l;
-
-  /** \relates Arch */
-  extern const Arch Arch_riscv64;
+  extern const Arch Arch_alpha ZYPP_API;
 
    /** \relates Arch */
-  extern const Arch Arch_sh3;
+  extern const Arch Arch_sparc64v ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sparc64 ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sparcv9v ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sparcv9 ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sparcv8 ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sparc ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_sh4;
-  /** \relates Arch */
-  extern const Arch Arch_sh4a;
+  extern const Arch Arch_aarch64 ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_m68k;
+  extern const Arch Arch_armv7tnh ZYPP_API;	/* exists? */
+  /** \relates Arch */
+  extern const Arch Arch_armv7thl ZYPP_API;	/* exists? */
 
   /** \relates Arch */
-  extern const Arch Arch_mips;
+  extern const Arch Arch_armv7hnl,	/* legacy: */Arch_armv7nhl ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_mipsel;
+  extern const Arch Arch_armv7hl ZYPP_API;
   /** \relates Arch */
-  extern const Arch Arch_mips64;
-  /** \relates Arch */
-  extern const Arch Arch_mips64el;
+  extern const Arch Arch_armv6hl ZYPP_API;
 
   /** \relates Arch */
-  extern const Arch Arch_loong64;
+  extern const Arch Arch_armv8hl ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv8l ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv7l ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv6l ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv5tejl ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv5tel ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv5tl ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv5l ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv4tl ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv4l ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_armv3l ZYPP_API;
+
+  /** \relates Arch */
+  extern const Arch Arch_riscv64 ZYPP_API;
+
+   /** \relates Arch */
+  extern const Arch Arch_sh3 ZYPP_API;
+
+  /** \relates Arch */
+  extern const Arch Arch_sh4 ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_sh4a ZYPP_API;
+
+  /** \relates Arch */
+  extern const Arch Arch_m68k ZYPP_API;
+
+  /** \relates Arch */
+  extern const Arch Arch_mips ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_mipsel ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_mips64 ZYPP_API;
+  /** \relates Arch */
+  extern const Arch Arch_mips64el ZYPP_API;
+
+  /** \relates Arch */
+  extern const Arch Arch_loong64 ZYPP_API;
   //@}
 
   ///////////////////////////////////////////////////////////////////

--- a/zypp/Callback.h
+++ b/zypp/Callback.h
@@ -146,7 +146,7 @@ namespace zypp
   { /////////////////////////////////////////////////////////////////
 
     /**  */
-    struct ReportBase
+    struct ZYPP_API ReportBase
     {
       typedef callback::UserData UserData;
       typedef UserData::ContentType ContentType;
@@ -165,7 +165,7 @@ namespace zypp
 
     /**  */
     template<class TReport>
-      struct ReceiveReport : public TReport
+      struct ZYPP_API ReceiveReport : public TReport
       {
         typedef TReport                   ReportType;
         typedef ReceiveReport<TReport>    Receiver;
@@ -194,7 +194,7 @@ namespace zypp
 
     /**  */
     template<class TReport>
-      struct DistributeReport
+      struct ZYPP_API DistributeReport
       {
        public:
         typedef TReport                   ReportType;
@@ -233,7 +233,7 @@ namespace zypp
 
     /**  */
     template<class TReport>
-      struct SendReport : private zypp::base::NonCopyable
+      struct ZYPP_API SendReport : private zypp::base::NonCopyable
       {
         typedef TReport                   ReportType;
         typedef ReceiveReport<TReport>    Receiver;
@@ -281,7 +281,7 @@ namespace zypp
      * \endcode
     */
     template<class TReport>
-      struct TempConnect
+      struct ZYPP_API TempConnect
       {
         typedef TReport                   ReportType;
         typedef ReceiveReport<TReport>    Receiver;

--- a/zypp/CapMatch.h
+++ b/zypp/CapMatch.h
@@ -13,6 +13,7 @@
 #define ZYPP_CAPMATCH_H
 
 #include <iosfwd>
+#include <zypp/Globals.h>
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
@@ -34,7 +35,7 @@ namespace zypp
    *   ( !CapMatch::irrelevant )     == CapMatch::irrelevant // true
    * \endcode
   */
-  class CapMatch
+  class ZYPP_API CapMatch
   {
     enum Result { NOMATCH, MATCH, IRRELEVANT };
 
@@ -93,7 +94,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates CapMatch Stream output */
-  std::ostream & operator<<( std::ostream & str, const CapMatch & obj );
+  std::ostream & operator<<( std::ostream & str, const CapMatch & obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/Capabilities.h
+++ b/zypp/Capabilities.h
@@ -32,7 +32,7 @@ namespace zypp
    * which must be skipped on iteration or size calculation
    * (\see \ref detail::isDepMarkerId).
    */
-  class Capabilities
+  class ZYPP_API Capabilities
   {
     public:
       typedef Capability value_type;

--- a/zypp/Capability.h
+++ b/zypp/Capability.h
@@ -59,7 +59,7 @@ namespace zypp
    * [1] https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html
    * \see \ref CapDetail
    */
-  class Capability: protected sat::detail::PoolMember
+  class ZYPP_API Capability: protected sat::detail::PoolMember
   {
     public:
       enum CtorFlag { PARSED, UNPARSED };
@@ -271,10 +271,10 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates Capability Stream output */
-  std::ostream & operator<<( std::ostream & str, const Capability & obj );
+  std::ostream & operator<<( std::ostream & str, const Capability & obj ) ZYPP_API;
 
   /** \relates Capability Detailed stream output */
-  std::ostream & dumpOn( std::ostream & str, const Capability & obj );
+  std::ostream & dumpOn( std::ostream & str, const Capability & obj ) ZYPP_API;
 
   /** \relates Capability */
   inline bool operator==( const Capability & lhs, const Capability & rhs )
@@ -306,7 +306,7 @@ namespace zypp
    * \endcode
    *
    */
-  class CapDetail: protected sat::detail::PoolMember
+  class ZYPP_API CapDetail: protected sat::detail::PoolMember
   {
     public:
       enum Kind
@@ -384,13 +384,13 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates CapDetail Stream output */
-  std::ostream & operator<<( std::ostream & str, const CapDetail & obj );
+  std::ostream & operator<<( std::ostream & str, const CapDetail & obj ) ZYPP_API;
 
   /** \relates CapDetail Stream output */
-  std::ostream & operator<<( std::ostream & str, CapDetail::Kind obj );
+  std::ostream & operator<<( std::ostream & str, CapDetail::Kind obj ) ZYPP_API;
 
   /** \relates CapDetail Stream output */
-  std::ostream & operator<<( std::ostream & str, CapDetail::CapRel obj );
+  std::ostream & operator<<( std::ostream & str, CapDetail::CapRel obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
 

--- a/zypp/Changelog.h
+++ b/zypp/Changelog.h
@@ -16,6 +16,7 @@
 #include <list>
 #include <utility>
 
+#include <zypp/Globals.h>
 #include <zypp/Date.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -54,7 +55,7 @@ namespace zypp
   using Changelog = std::list<ChangelogEntry>;
 
   /** \relates ChangelogEntry */
-  std::ostream & operator<<( std::ostream & out, const ChangelogEntry & obj );
+  std::ostream & operator<<( std::ostream & out, const ChangelogEntry & obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/CountryCode.h
+++ b/zypp/CountryCode.h
@@ -27,7 +27,7 @@ namespace zypp
   /// In fact the class will not prevent to use a non iso country code.
   /// Just a warning will appear in the log.
   ///////////////////////////////////////////////////////////////////
-  class CountryCode : public IdStringType<CountryCode>
+  class ZYPP_API CountryCode : public IdStringType<CountryCode>
   {
   public:
     /** Default Ctor: \ref noCode */

--- a/zypp/CpeId.h
+++ b/zypp/CpeId.h
@@ -14,6 +14,7 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
 #include <zypp/base/PtrTypes.h>
 #include <zypp/base/Flags.h>
 #include <zypp/base/EnumClass.h>
@@ -28,7 +29,7 @@ namespace zypp
   /// See http://cpe.mitre.org/ for more information on the
   /// Common Platform Enumearation.
   ///////////////////////////////////////////////////////////////////
-  class CpeId : public base::SetRelationMixin<CpeId>
+  class ZYPP_API CpeId : public base::SetRelationMixin<CpeId>
   {
   public:
     /** WFN attribute value */

--- a/zypp/Dep.h
+++ b/zypp/Dep.h
@@ -26,7 +26,7 @@ namespace zypp
   /** Enumeration class of dependency types.
    * \ingroup g_EnumerationClass
   */
-  struct Dep
+  struct ZYPP_API Dep
   {
     friend bool operator==( const Dep & lhs, const Dep & rhs );
     friend bool operator!=( const Dep & lhs, const Dep & rhs );
@@ -39,15 +39,15 @@ namespace zypp
      * \see \ref zypp::Dep::inSwitch
     */
     //@{
-    static const Dep PROVIDES;
-    static const Dep PREREQUIRES;
-    static const Dep REQUIRES;
-    static const Dep CONFLICTS;
-    static const Dep OBSOLETES;
-    static const Dep RECOMMENDS;
-    static const Dep SUGGESTS;
-    static const Dep ENHANCES;
-    static const Dep SUPPLEMENTS;
+    static const Dep PROVIDES ZYPP_API;
+    static const Dep PREREQUIRES ZYPP_API;
+    static const Dep REQUIRES ZYPP_API;
+    static const Dep CONFLICTS ZYPP_API;
+    static const Dep OBSOLETES ZYPP_API;
+    static const Dep RECOMMENDS ZYPP_API;
+    static const Dep SUGGESTS ZYPP_API;
+    static const Dep ENHANCES ZYPP_API;
+    static const Dep SUPPLEMENTS ZYPP_API;
     //@}
 
     /** Enumarators provided \b only for use \ref inSwitch statement.
@@ -78,12 +78,12 @@ namespace zypp
     /** String representation of dependency type.
      * \return The constants names lowercased.
     */
-    const std::string & asString() const;
+    const std::string & asString() const ZYPP_API;
 
     /** Translated dependency type (capitalized).
      * \return The capitalized constants names translated.
     */
-    std::string asUserString() const;
+    std::string asUserString() const ZYPP_API;
 
     /** Enumarator provided for use in \c switch statement. */
     for_use_in_switch inSwitch() const

--- a/zypp/Digest.h
+++ b/zypp/Digest.h
@@ -22,7 +22,7 @@
 
 namespace zypp {
 
-  struct DigestReport : public callback::ReportBase
+  struct ZYPP_API DigestReport : public callback::ReportBase
   {
     virtual bool askUserToAcceptNoDigest( const zypp::Pathname &file );
     virtual bool askUserToAccepUnknownDigest( const Pathname &file, const std::string &name );

--- a/zypp/DiskUsageCounter.h
+++ b/zypp/DiskUsageCounter.h
@@ -29,7 +29,7 @@ namespace zypp
   /// \class DiskUsageCounter
   /// \brief Compute disk space occupied by packages across partitions/directories
   ///////////////////////////////////////////////////////////////////
-  class DiskUsageCounter
+  class ZYPP_API DiskUsageCounter
   {
 
   public:
@@ -213,10 +213,10 @@ namespace zypp
   ZYPP_DECLARE_OPERATORS_FOR_FLAGS(DiskUsageCounter::MountPoint::HintFlags);
 
   /** \relates DiskUsageCounter::MountPoint Stream output */
-  std::ostream & operator<<( std::ostream & str, const DiskUsageCounter::MountPoint & obj );
+  std::ostream & operator<<( std::ostream & str, const DiskUsageCounter::MountPoint & obj ) ZYPP_API;
 
   /** \relates DiskUsageCounter::MountPointSet Stream output */
-  std::ostream & operator<<( std::ostream & str, const DiskUsageCounter::MountPointSet & obj );
+  std::ostream & operator<<( std::ostream & str, const DiskUsageCounter::MountPointSet & obj ) ZYPP_API;
 
   /** \relates DiskUsageCounter Stream output */
   inline std::ostream & operator<<( std::ostream & str, const DiskUsageCounter & obj )

--- a/zypp/DownloadMode.h
+++ b/zypp/DownloadMode.h
@@ -14,6 +14,8 @@
 
 #include <iosfwd>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 { /////////////////////////////////////////////////////////////////
@@ -53,7 +55,7 @@ namespace zypp
   }
 
   /** \relates DownloadMode Stream output. */
-  std::ostream & operator<<( std::ostream & str, DownloadMode obj );
+  std::ostream & operator<<( std::ostream & str, DownloadMode obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/Edition.h
+++ b/zypp/Edition.h
@@ -57,7 +57,7 @@ namespace zypp
    *
    * \ingroup g_BackendSpecific
   */
-  class Edition : public IdStringType<Edition>
+  class ZYPP_API Edition : public IdStringType<Edition>
   {
     public:
       /** Type of an epoch. */
@@ -169,7 +169,7 @@ namespace zypp
       using MatchRange = Range<Edition, Match>;
 
     private:
-      static int _doCompare( const char * lhs,  const char * rhs );
+      static int _doCompare( const char * lhs,  const char * rhs ) ZYPP_API;
       static int _doMatch( const char * lhs,  const char * rhs );
 
     private:

--- a/zypp/Fetcher.h
+++ b/zypp/Fetcher.h
@@ -102,7 +102,7 @@ namespace zypp
   * type (md5,sha1,sha256) is auto detected by looking at the cheksums
   * length. No need to somehow encode it in the filename.
   */
-  class Fetcher
+  class ZYPP_API Fetcher
   {
     friend std::ostream & operator<<( std::ostream & str,
                                       const Fetcher & obj );

--- a/zypp/FileChecker.h
+++ b/zypp/FileChecker.h
@@ -44,7 +44,7 @@ namespace zypp
   /**
    * \short Checks for a valid checksum and interacts with the user.
    */
-   class ChecksumFileChecker
+   class ZYPP_TESTS ChecksumFileChecker
    {
    public:
      typedef CheckSumCheckException ExceptionType;
@@ -67,7 +67,7 @@ namespace zypp
    /**
     * \short Checks for the validity of a signature
     */
-   class SignatureFileChecker
+   class ZYPP_TESTS SignatureFileChecker
    {
    public:
      typedef SignatureCheckException ExceptionType;

--- a/zypp/Glob.h
+++ b/zypp/Glob.h
@@ -54,7 +54,7 @@ namespace zypp
      * \endcode
      * \see Manual page glob(3)
      */
-    class Glob : private base::NonCopyable
+    class ZYPP_API Glob : private base::NonCopyable
     {
       public:
         using size_type = size_t;

--- a/zypp/HistoryLogData.h
+++ b/zypp/HistoryLogData.h
@@ -36,16 +36,16 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
   struct HistoryActionID
   {
-    static const HistoryActionID NONE;
+    static const HistoryActionID NONE ZYPP_API;
 
-    static const HistoryActionID INSTALL;
-    static const HistoryActionID REMOVE;
-    static const HistoryActionID REPO_ADD;
-    static const HistoryActionID REPO_REMOVE;
-    static const HistoryActionID REPO_CHANGE_ALIAS;
-    static const HistoryActionID REPO_CHANGE_URL;
-    static const HistoryActionID STAMP_COMMAND;
-    static const HistoryActionID PATCH_STATE_CHANGE;
+    static const HistoryActionID INSTALL ZYPP_API;
+    static const HistoryActionID REMOVE ZYPP_API;
+    static const HistoryActionID REPO_ADD ZYPP_API;
+    static const HistoryActionID REPO_REMOVE ZYPP_API;
+    static const HistoryActionID REPO_CHANGE_ALIAS ZYPP_API;
+    static const HistoryActionID REPO_CHANGE_URL ZYPP_API;
+    static const HistoryActionID STAMP_COMMAND ZYPP_API;
+    static const HistoryActionID PATCH_STATE_CHANGE ZYPP_API;
 
     enum ID
     {
@@ -102,7 +102,7 @@ namespace zypp
   /// plain string values. Derived classes for well known entries tell
   ///
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogData
+  class ZYPP_API HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogData>;
@@ -196,7 +196,7 @@ namespace zypp
   /// \brief  A zypp history log line for an installed packaged.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataInstall : public HistoryLogData
+  class ZYPP_API HistoryLogDataInstall : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataInstall>;
@@ -236,7 +236,7 @@ namespace zypp
   /// \brief  A zypp history log line for an installed packaged.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogPatchStateChange : public HistoryLogData
+  class ZYPP_API HistoryLogPatchStateChange : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogPatchStateChange>;
@@ -280,7 +280,7 @@ namespace zypp
   /// \brief A zypp history log line for a removed packge.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataRemove : public HistoryLogData
+  class ZYPP_API HistoryLogDataRemove : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataRemove>;
@@ -315,7 +315,7 @@ namespace zypp
   /// \brief A zypp history log line for an added repository.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataRepoAdd : public HistoryLogData
+  class ZYPP_API HistoryLogDataRepoAdd : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataRepoAdd>;
@@ -346,7 +346,7 @@ namespace zypp
   /// \brief A zypp history log line for a removed repository.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataRepoRemove : public HistoryLogData
+  class ZYPP_API HistoryLogDataRepoRemove : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataRepoRemove>;
@@ -375,7 +375,7 @@ namespace zypp
   /// \brief A zypp history log line for a repo alias change.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataRepoAliasChange : public HistoryLogData
+  class ZYPP_API HistoryLogDataRepoAliasChange : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataRepoAliasChange>;
@@ -438,7 +438,7 @@ namespace zypp
   /// triggered the following commit.
   /// \ingroup g_ZyppHistory
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogDataStampCommand : public HistoryLogData
+  class ZYPP_API HistoryLogDataStampCommand : public HistoryLogData
   {
   public:
     using Ptr = shared_ptr<HistoryLogDataStampCommand>;

--- a/zypp/IdString.h
+++ b/zypp/IdString.h
@@ -18,6 +18,7 @@
 
 #include <boost/utility/string_ref_fwd.hpp>
 
+#include <zypp-core/Globals.h>
 #include <zypp/sat/detail/PoolMember.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -39,7 +40,7 @@ namespace zypp
    * While comparison differs between \ref IdString::Null and \ref IdString::Empty
    * ( \c NULL and \c "" ), both are represented by an empty string \c "".
    */
-  class IdString : protected sat::detail::PoolMember
+  class ZYPP_API IdString : protected sat::detail::PoolMember
   {
     public:
       using IdType = sat::detail::IdType;
@@ -138,10 +139,10 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates IdString Stream output */
-  std::ostream & operator<<( std::ostream & str, const IdString & obj );
+  std::ostream & operator<<( std::ostream & str, const IdString & obj ) ZYPP_API;
 
   /** \relates IdString Stream output */
-  std::ostream & dumpOn( std::ostream & str, const IdString & obj );
+  std::ostream & dumpOn( std::ostream & str, const IdString & obj ) ZYPP_API;
 
   /** \relates IdString Equal */
   inline bool operator==( const IdString & lhs, const IdString & rhs )

--- a/zypp/IdStringType.h
+++ b/zypp/IdStringType.h
@@ -160,7 +160,7 @@ namespace zypp
       int compare( const char * rhs )         const { return compare( idStr(), rhs ); }
 
     private:
-      static int _doCompare( const char * lhs,  const char * rhs )
+      static inline int _doCompare( const char * lhs,  const char * rhs ) ZYPP_API
       {
         if ( ! lhs ) return rhs ? -1 : 0;
         return rhs ? ::strcmp( lhs, rhs ) : 1;

--- a/zypp/InstanceId.h
+++ b/zypp/InstanceId.h
@@ -44,7 +44,7 @@ namespace zypp
    *   }
    * \endcode
    */
-  class InstanceId
+  class ZYPP_API InstanceId
   {
     public:
       /** Default ctor empty empty namespace */

--- a/zypp/KeyRing.h
+++ b/zypp/KeyRing.h
@@ -41,7 +41,7 @@ namespace zypp
    * \endcode
    * \see \ref KeyRing
   */
-  struct KeyRingReport : public callback::ReportBase
+  struct ZYPP_API KeyRingReport : public callback::ReportBase
   {
     /**
      * User reply options for the askUserToTrustKey callback.
@@ -149,7 +149,7 @@ namespace zypp
      constexpr static const char *REPORT_AUTO_IMPORT_KEY = "KeyRingReport/reportAutoImportKey";
   };
 
-  struct KeyRingSignals : public callback::ReportBase
+  struct ZYPP_API KeyRingSignals : public callback::ReportBase
   {
     virtual void trustedKeyAdded( const PublicKey &/*key*/ )
     {}
@@ -157,7 +157,7 @@ namespace zypp
     {}
   };
 
-  class KeyRingException : public Exception
+  class ZYPP_API KeyRingException : public Exception
    {
      public:
        /** Ctor taking message.
@@ -183,7 +183,7 @@ namespace zypp
   /** Gpg key handling.
    *
   */
-  class KeyRing : public base::ReferenceCounted, private base::NonCopyable
+  class ZYPP_API KeyRing : public base::ReferenceCounted, private base::NonCopyable
   {
     friend std::ostream & operator<<( std::ostream & str, const KeyRing & obj );
 
@@ -306,9 +306,9 @@ namespace zypp
      * \param file Path of the file to be verified
      * \param signature Signature to verify the file against
      */
-    bool verifyFileSignature( const Pathname &file, const Pathname &signature );
+    bool verifyFileSignature( const Pathname &file, const Pathname &signature ) ZYPP_API;
 
-    bool verifyFileTrustedSignature( const Pathname &file, const Pathname &signature );
+    bool verifyFileTrustedSignature( const Pathname &file, const Pathname &signature ) ZYPP_API;
 
     /** Dtor */
     ~KeyRing() override;

--- a/zypp/KeyRingContexts.h
+++ b/zypp/KeyRingContexts.h
@@ -26,7 +26,7 @@ namespace zypp::keyring
   ///////////////////////////////////////////////////////////////////
   /// I/O context for KeyRing::verifyFileSignatureWorkflow.
   ///////////////////////////////////////////////////////////////////
-  class VerifyFileContext
+  class ZYPP_API VerifyFileContext
   {
   public:
     /** Ctor. */

--- a/zypp/LanguageCode.h
+++ b/zypp/LanguageCode.h
@@ -27,7 +27,7 @@ namespace zypp
   /// In fact the class will not prevent to use a non iso language code.
   /// Just a warning will appear in the log.
   ///////////////////////////////////////////////////////////////////
-  class LanguageCode : public IdStringType<LanguageCode>
+  class ZYPP_API LanguageCode : public IdStringType<LanguageCode>
   {
   public:
     /** Default Ctor: \ref noCode */

--- a/zypp/Locale.h
+++ b/zypp/Locale.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include <zypp/base/Hash.h>
+#include <zypp/Globals.h>
 
 #include <zypp/IdStringType.h>
 #include <zypp/LanguageCode.h>
@@ -46,7 +47,7 @@ namespace zypp
   ///   l.fallback().fallback().fallback() == Locale::noCode == "";
   /// \endcode
   ///////////////////////////////////////////////////////////////////
-  class Locale : public IdStringType<Locale>
+  class ZYPP_API Locale : public IdStringType<Locale>
   {
   public:
     /** Default Ctor: \ref noCode */

--- a/zypp/Locks.h
+++ b/zypp/Locks.h
@@ -15,7 +15,7 @@ namespace zypp
    * for user information about locksfile and its format see
    * <a>http://en.opensuse.org/Libzypp/Locksfile</a>
    */
-  class Locks
+  class ZYPP_API Locks
   {
   public:
     using LockList = std::list<PoolQuery>;

--- a/zypp/MediaSetAccess.h
+++ b/zypp/MediaSetAccess.h
@@ -77,7 +77,7 @@ namespace zypp
      *
      * \endcode
      */
-    class MediaSetAccess : public base::ReferenceCounted, private base::NonCopyable
+    class ZYPP_API MediaSetAccess : public base::ReferenceCounted, private base::NonCopyable
     {
       friend std::ostream & operator<<( std::ostream & str, const MediaSetAccess & obj );
 

--- a/zypp/Package.h
+++ b/zypp/Package.h
@@ -12,6 +12,7 @@
 #ifndef ZYPP_PACKAGE_H
 #define ZYPP_PACKAGE_H
 
+#include <zypp/Globals.h>
 #include <zypp/ResObject.h>
 #include <zypp/PackageKeyword.h>
 #include <zypp/Changelog.h>
@@ -29,7 +30,7 @@ namespace zypp
   //
   /** Package interface.
   */
-  class Package : public ResObject
+  class ZYPP_API Package : public ResObject
   {
   public:
     using Self = Package;

--- a/zypp/Patch.h
+++ b/zypp/Patch.h
@@ -34,7 +34,7 @@ namespace zypp
    * Patches can be marked for installation but their
    * installation is a no-op.
    */
-  class Patch : public ResObject
+  class ZYPP_API Patch : public ResObject
   {
     public:
       using Self = Patch;
@@ -238,13 +238,13 @@ namespace zypp
   ZYPP_DECLARE_OPERATORS_FOR_FLAGS(Patch::SeverityFlags);
 
   /** \relates Patch::Category string representation.*/
-  std::string asString( const Patch::Category & obj );
+  std::string asString( const Patch::Category & obj ) ZYPP_API;
 
   /** \relates Patch::InteractiveFlag string representation.*/
-  std::string asString( const Patch::InteractiveFlag & obj );
+  std::string asString( const Patch::InteractiveFlag & obj ) ZYPP_API;
 
   /** \relates Patch::SeverityFlag string representation.*/
-  std::string asString( const Patch::SeverityFlag & obj );
+  std::string asString( const Patch::SeverityFlag & obj ) ZYPP_API;
 
   /**
    * Query class for Patch issue references

--- a/zypp/Pattern.h
+++ b/zypp/Pattern.h
@@ -28,7 +28,7 @@ namespace zypp
   //
   /** Pattern interface.
   */
-  class Pattern : public ResObject
+  class ZYPP_API Pattern : public ResObject
   {
     public:
       using Self = Pattern;

--- a/zypp/PluginExecutor.h
+++ b/zypp/PluginExecutor.h
@@ -38,7 +38,7 @@ namespace zypp
   /// \see PluginScript
   /// \ingroup g_RAII
   ///////////////////////////////////////////////////////////////////
-  class PluginExecutor
+  class ZYPP_API PluginExecutor
   {
     friend std::ostream & operator<<( std::ostream & str, const PluginExecutor & obj );
     friend bool operator==( const PluginExecutor & lhs, const PluginExecutor & rhs );

--- a/zypp/PluginFrame.h
+++ b/zypp/PluginFrame.h
@@ -37,7 +37,7 @@ namespace zypp
    *
    * \see PluginScript
    */
-  class PluginFrame
+  class ZYPP_TESTS PluginFrame
   {
     friend std::ostream & operator<<( std::ostream & str, const PluginFrame & obj );
     friend bool operator==( const PluginFrame & lhs, const PluginFrame & rhs );
@@ -254,7 +254,7 @@ namespace zypp
   };
 
   /** \relates PluginFrame Stream output for logging */
-  std::ostream & operator<<( std::ostream & str, const PluginFrame & obj );
+  std::ostream & operator<<( std::ostream & str, const PluginFrame & obj ) ZYPP_TESTS;
 
   /** \relates PluginFrame Stream output writing all data for logging (no throw) */
   inline std::ostream & dumpOn( std::ostream & str, const PluginFrame & obj )
@@ -265,7 +265,7 @@ namespace zypp
   { return PluginFrame::readFrom( str, obj ); }
 
   /** \relates PluginFrame Comparison based on content. */
-  bool operator==( const PluginFrame & lhs, const PluginFrame & rhs );
+  bool operator==( const PluginFrame & lhs, const PluginFrame & rhs ) ZYPP_TESTS;
 
   /** \relates PluginFrame Comparison based on content. */
   inline bool operator!=( const PluginFrame & lhs, const PluginFrame & rhs )

--- a/zypp/PluginFrameException.h
+++ b/zypp/PluginFrameException.h
@@ -26,7 +26,7 @@ namespace zypp
   //	CLASS NAME : PluginFrameException
   //
   /** Base class for \ref PluginFrame \ref Exception. */
-  class PluginFrameException : public Exception
+  class ZYPP_API PluginFrameException : public Exception
   {
     public:
       PluginFrameException();

--- a/zypp/PluginScript.h
+++ b/zypp/PluginScript.h
@@ -59,7 +59,7 @@ namespace zypp
    *
    * \see http://stomp.codehaus.org/
    */
-  class PluginScript
+  class ZYPP_API PluginScript
   {
     friend std::ostream & operator<<( std::ostream & str, const PluginScript & obj );
 

--- a/zypp/PluginScriptException.h
+++ b/zypp/PluginScriptException.h
@@ -22,7 +22,7 @@ namespace zypp
 { /////////////////////////////////////////////////////////////////
 
   /** Base class for \ref PluginScript \ref Exception. */
-  class PluginScriptException : public Exception
+  class ZYPP_API PluginScriptException : public Exception
   {
     public:
       PluginScriptException();
@@ -33,7 +33,7 @@ namespace zypp
 
   /** Convenience macro to declare more specific PluginScriptExceptions. */
 #define declException( EXCP, BASE )								\
-  class EXCP : public BASE {									\
+  class ZYPP_API EXCP : public BASE {							\
     public:											\
       EXCP() : BASE( #EXCP ) {}									\
       EXCP( const std::string & msg_r ) : BASE( msg_r ) {}					\

--- a/zypp/PoolItem.h
+++ b/zypp/PoolItem.h
@@ -47,7 +47,7 @@ namespace zypp
   /// \c const, i.e. you can't change the refered PoolItem. The PoolItem
   /// (i.e. the status) is always mutable.
   ///////////////////////////////////////////////////////////////////
-  class PoolItem : public sat::SolvableType<PoolItem>
+  class ZYPP_API PoolItem : public sat::SolvableType<PoolItem>
   {
     friend std::ostream & operator<<( std::ostream & str, const PoolItem & obj );
     public:
@@ -169,8 +169,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates PoolItem Stream output */
-  std::ostream & operator<<( std::ostream & str, const PoolItem & obj );
-
+  std::ostream & operator<<( std::ostream & str, const PoolItem & obj ) ZYPP_API;
 
   /** \relates PoolItem Required to disambiguate vs. (PoolItem,ResObject::constPtr) due to implicit PoolItem::operator ResObject::constPtr  */
   inline bool operator==( const PoolItem & lhs, const PoolItem & rhs )

--- a/zypp/PoolItemBest.h
+++ b/zypp/PoolItemBest.h
@@ -60,7 +60,7 @@ namespace zypp
    *
    * \todo Support arbitrary Predicates.
    */
-  class PoolItemBest
+  class ZYPP_API PoolItemBest
   {
       using Container = std::unordered_map<IdString, PoolItem>;
     public:

--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -87,7 +87,7 @@ namespace zypp
    * \see tests/zypp/PoolQuery_test.cc for more examples
    * \see sat::SolvIterMixin
    */
-  class PoolQuery : public sat::SolvIterMixin<PoolQuery, detail::PoolQueryIterator>
+  class ZYPP_API PoolQuery : public sat::SolvIterMixin<PoolQuery, detail::PoolQueryIterator>
   {
   public:
     using Kinds = std::set<ResKind>;
@@ -494,10 +494,10 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates PoolQuery Stream output. */
-  std::ostream & operator<<( std::ostream & str, const PoolQuery & obj );
+  std::ostream & operator<<( std::ostream & str, const PoolQuery & obj ) ZYPP_API;
 
   /** \relates PoolQuery Detailed stream output. */
-  std::ostream & dumpOn( std::ostream & str, const PoolQuery & obj );
+  std::ostream & dumpOn( std::ostream & str, const PoolQuery & obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
   namespace detail
@@ -516,7 +516,7 @@ namespace zypp
    * But it also provides an iterator by itself, to allow a detailed inspection of
    * the individual attribute matches within the current Solvable.
    */
-  class PoolQueryIterator : public boost::iterator_adaptor<
+  class ZYPP_API PoolQueryIterator : public boost::iterator_adaptor<
     PoolQueryIterator                  // Derived
     , sat::LookupAttr::iterator        // Base
     , const sat::Solvable              // Value
@@ -615,7 +615,7 @@ namespace zypp
   { return str << obj.base(); }
 
   /** \relates PoolQueryIterator Detailed stream output. */
-  std::ostream & dumpOn( std::ostream & str, const PoolQueryIterator & obj );
+  std::ostream & dumpOn( std::ostream & str, const PoolQueryIterator & obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
   } //namespace detail

--- a/zypp/ProblemSolution.h
+++ b/zypp/ProblemSolution.h
@@ -37,7 +37,7 @@ namespace zypp
   ///    - Ignore: Inject artificial "provides" for a missing requirement
   ///	(pretend that requirement is satisfied)
   /////////////////////////////////////////////////////////////////////////
-  class ProblemSolution : public base::ReferenceCounted
+  class ZYPP_API ProblemSolution : public base::ReferenceCounted
   {
   public:
     using SolutionAction_Ptr = solver::detail::SolutionAction_Ptr;
@@ -108,10 +108,10 @@ namespace zypp
   };
 
   /** \relates ProblemSolution Stream output */
-  std::ostream& operator<<(std::ostream&, const ProblemSolution & obj );
+  std::ostream& operator<<(std::ostream&, const ProblemSolution & obj ) ZYPP_API;
 
   /** \relates ProblemSolution Stream output */
-  std::ostream& operator<<(std::ostream&, const ProblemSolutionList & obj );
+  std::ostream& operator<<(std::ostream&, const ProblemSolutionList & obj ) ZYPP_API;
 
 } // namespace zypp
 /////////////////////////////////////////////////////////////////////////

--- a/zypp/Product.h
+++ b/zypp/Product.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <string>
 
+#include <zypp/Globals.h>
 #include <zypp/ResObject.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -29,7 +30,7 @@ namespace zypp
   //
   /** Product interface.
   */
-  class Product : public ResObject
+  class ZYPP_API Product : public ResObject
   {
   public:
     using Self = Product;

--- a/zypp/PublicKey.h
+++ b/zypp/PublicKey.h
@@ -46,7 +46,7 @@ namespace zypp
   /// \class BadKeyException
   /// \brief Exception thrown when the supplied key is not a valid gpg key
   ///////////////////////////////////////////////////////////////////
-  class BadKeyException : public Exception
+  class ZYPP_API BadKeyException : public Exception
   {
     public:
       /** Ctor taking message.
@@ -77,7 +77,7 @@ namespace zypp
   /// \brief Class representing a GPG Public Keys subkeys.
   /// \see \ref PublicKeyData.
   ///////////////////////////////////////////////////////////////////
-  class PublicSubkeyData
+  class ZYPP_API PublicSubkeyData
   {
   public:
     /** Default constructed: empty data. */
@@ -204,7 +204,7 @@ namespace zypp
   /// armored version of the key placed in a tempfile. In this
   /// case use \ref PublicKey.
   ///////////////////////////////////////////////////////////////////
-  class PublicKeyData
+  class ZYPP_API PublicKeyData
   {
   public:
     /** Default constructed: empty data. */
@@ -341,7 +341,7 @@ namespace zypp
   { return str << obj.asString(); }
 
   /** \relates PublicKeyData Detailed stream output */
-  std::ostream & dumpOn( std::ostream & str, const PublicKeyData & obj );
+  std::ostream & dumpOn( std::ostream & str, const PublicKeyData & obj ) ZYPP_API;
 
   /** \relates PublicKeyData Equal based on  fingerprint anf creation date. */
   bool operator==( const PublicKeyData & lhs, const PublicKeyData & rhs );
@@ -361,7 +361,7 @@ namespace zypp
   /// keys, the \b last keys data are made available via the API. The
   /// additional keys data are made available via \ref hiddenKeys.
   ///////////////////////////////////////////////////////////////////
-  class PublicKey
+  class ZYPP_API PublicKey
   {
   public:
     /** Implementation  */
@@ -476,7 +476,7 @@ namespace zypp
   { return str << obj.asString(); }
 
   /** \relates PublicKey Detailed stream output */
-  std::ostream & dumpOn( std::ostream & str, const PublicKey & obj );
+  std::ostream & dumpOn( std::ostream & str, const PublicKey & obj ) ZYPP_API;
 
  /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/PurgeKernels.h
+++ b/zypp/PurgeKernels.h
@@ -10,6 +10,7 @@
  *
 */
 
+#include <zypp/Globals.h>
 #include <zypp/PoolItem.h>
 #include <zypp/base/PtrTypes.h>
 
@@ -23,7 +24,7 @@ namespace zypp {
    * Implements the logic of the "purge-kernels" command.
    *
    */
-  class PurgeKernels
+  class ZYPP_API PurgeKernels
   {
   public:
     PurgeKernels();

--- a/zypp/Rel.h
+++ b/zypp/Rel.h
@@ -15,6 +15,8 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 { /////////////////////////////////////////////////////////////////
@@ -40,7 +42,7 @@ namespace zypp
    *
    * \ingroup g_EnumerationClass
   */
-  struct Rel
+  struct ZYPP_API Rel
   {
     /** \name Relational operators
      * These are the \em real relational operator contants to

--- a/zypp/RepoInfo.h
+++ b/zypp/RepoInfo.h
@@ -68,7 +68,7 @@ namespace zypp
    * \note Name, baseUrls and mirrorUrl are subject to repo variable replacement
    * (\see \ref RepoVariablesStringReplacer).
    */
-  class RepoInfo : public repo::RepoInfoBase
+  class ZYPP_API RepoInfo : public repo::RepoInfoBase
   {
     friend std::ostream & operator<<( std::ostream & str, const RepoInfo & obj );
 
@@ -574,10 +574,10 @@ namespace zypp
   using RepoInfoList = std::list<RepoInfo>;
 
   /** \relates RepoInfo Stream output */
-  std::ostream & operator<<( std::ostream & str, const RepoInfo & obj );
+  std::ostream & operator<<( std::ostream & str, const RepoInfo & obj ) ZYPP_API;
 
   /** \relates RepoInfo::GpgCheck Stream output */
-  std::ostream & operator<<( std::ostream & str, const RepoInfo::GpgCheck & obj );
+  std::ostream & operator<<( std::ostream & str, const RepoInfo::GpgCheck & obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/RepoManager.h
+++ b/zypp/RepoManager.h
@@ -48,13 +48,13 @@ namespace zypp
     * \throws ParseException If the file parsing fails
     * \throws Exception On other errors.
     */
-   std::list<RepoInfo> readRepoFile(const Url & repo_file);
+   std::list<RepoInfo> readRepoFile(const Url & repo_file) ZYPP_API;
 
   /**
    * \short creates and provides information about known sources.
    *
    */
-  class RepoManager
+  class ZYPP_API RepoManager
   {
     friend std::ostream & operator<<( std::ostream & str, const RepoManager & obj );
 
@@ -659,7 +659,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates RepoManager Stream output */
-  std::ostream & operator<<( std::ostream & str, const RepoManager & obj );
+  std::ostream & operator<<( std::ostream & str, const RepoManager & obj ) ZYPP_API;
 
   /** Iterate the known repositories. */
   inline Iterable<RepoManager::RepoConstIterator> RepoManager::repos() const

--- a/zypp/RepoManagerOptions.h
+++ b/zypp/RepoManagerOptions.h
@@ -13,6 +13,7 @@
 #define ZYPP_REPOMANAGER_OPTIONS_H
 
 #include <zypp/Pathname.h>
+#include <zypp/Globals.h>
 #include <ostream>
 
 namespace zypp
@@ -21,7 +22,7 @@ namespace zypp
    * Repo manager settings.
    * Settings default to ZYpp global settings.
    */
-  struct RepoManagerOptions
+  struct ZYPP_API RepoManagerOptions
   {
     /** Default ctor following \ref ZConfig global settings.
      * If an optional \c root_r directory is given, all paths  will

--- a/zypp/RepoStatus.h
+++ b/zypp/RepoStatus.h
@@ -37,7 +37,7 @@ namespace zypp
   /// use outside this class. \ref operator== tells if the checksums
   /// of two rRepoStatus are the same.
   ///////////////////////////////////////////////////////////////////
-  class RepoStatus
+  class ZYPP_API RepoStatus
   {
     friend std::ostream & operator<<( std::ostream & str, const RepoStatus & obj );
     friend RepoStatus operator&&( const RepoStatus & lhs, const RepoStatus & rhs );
@@ -109,13 +109,13 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates RepoStatus Stream output */
-  std::ostream & operator<<( std::ostream & str, const RepoStatus & obj );
+  std::ostream & operator<<( std::ostream & str, const RepoStatus & obj ) ZYPP_API;
 
   /** \relates RepoStatus Combine two RepoStatus (combined checksum and newest timestamp) */
-  RepoStatus operator&&( const RepoStatus & lhs, const RepoStatus & rhs );
+  RepoStatus operator&&( const RepoStatus & lhs, const RepoStatus & rhs ) ZYPP_API;
 
   /** \relates RepoStatus Whether 2 RepoStatus refer to the same content checksum */
-  bool operator==( const RepoStatus & lhs, const RepoStatus & rhs );
+  bool operator==( const RepoStatus & lhs, const RepoStatus & rhs ) ZYPP_API;
 
   /** \relates RepoStatus Whether 2 RepoStatus refer to different content checksums */
   inline bool operator!=( const RepoStatus & lhs, const RepoStatus & rhs )

--- a/zypp/Repository.h
+++ b/zypp/Repository.h
@@ -36,7 +36,7 @@ namespace zypp
     //	CLASS NAME : Repository
     //
     /** */
-    class Repository : protected sat::detail::PoolMember
+    class ZYPP_API Repository : protected sat::detail::PoolMember
     {
     public:
         using SolvableIterator = filter_iterator<detail::ByRepository, sat::detail::SolvableIterator>;
@@ -336,10 +336,10 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates Repository Stream output */
-    std::ostream & operator<<( std::ostream & str, const Repository & obj );
+    std::ostream & operator<<( std::ostream & str, const Repository & obj ) ZYPP_API;
 
     /** \relates Repository XML output */
-    std::ostream & dumpAsXmlOn( std::ostream & str, const Repository & obj );
+    std::ostream & dumpAsXmlOn( std::ostream & str, const Repository & obj ) ZYPP_API;
 
     /** \relates Repository */
     inline bool operator==( const Repository & lhs, const Repository & rhs )
@@ -455,7 +455,7 @@ namespace zypp
       //	CLASS NAME : RepositoryIterator
       //
       /** */
-      class RepositoryIterator : public boost::iterator_adaptor<
+      class ZYPP_API RepositoryIterator : public boost::iterator_adaptor<
             RepositoryIterator                            // Derived
                            , sat::detail::CRepo **        // Base
                            , Repository                   // Value

--- a/zypp/ResKind.h
+++ b/zypp/ResKind.h
@@ -29,7 +29,7 @@ namespace zypp
   /// A \b lowercased string and used as identification. Comparison
   /// against string values is always case insensitive.
   ///////////////////////////////////////////////////////////////////
-  class ResKind : public IdStringType<ResKind>
+  class ZYPP_API ResKind : public IdStringType<ResKind>
   {
     public:
       /** \name Some builtin ResKind constants. */

--- a/zypp/ResObject.h
+++ b/zypp/ResObject.h
@@ -34,7 +34,7 @@ namespace zypp
   /// \see \ref makeResObject for how to construct ResObjects.
   /// \todo Merge with Resolvable
   ///////////////////////////////////////////////////////////////////
-  class ResObject : public Resolvable
+  class ZYPP_API ResObject : public Resolvable
   {
   public:
     using Self = ResObject;
@@ -99,7 +99,7 @@ namespace zypp
    * Package::Ptr   pkg( make<Package>( s ) );
    * \endcode
   */
-  ResObject::Ptr makeResObject( const sat::Solvable & solvable_r );
+  ResObject::Ptr makeResObject( const sat::Solvable & solvable_r ) ZYPP_API;
 
   /** Directly create a certain kind of ResObject from \ref sat::Solvable.
    *

--- a/zypp/ResPool.h
+++ b/zypp/ResPool.h
@@ -58,7 +58,7 @@ namespace zypp
    *
    * \include n_ResPool_nomorenameiter
   */
-  class ResPool
+  class ZYPP_API ResPool
   {
     friend std::ostream & operator<<( std::ostream & str, const ResPool & obj );
 
@@ -472,7 +472,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates ResPool Stream output */
-  std::ostream & operator<<( std::ostream & str, const ResPool & obj );
+  std::ostream & operator<<( std::ostream & str, const ResPool & obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/ResPoolProxy.h
+++ b/zypp/ResPoolProxy.h
@@ -32,7 +32,7 @@ namespace zypp
   /** ResPool::instance().proxy();
    * \todo integrate it into ResPool
   */
-  class ResPoolProxy
+  class ZYPP_API ResPoolProxy
   {
     friend std::ostream & operator<<( std::ostream & str, const ResPoolProxy & obj );
     friend std::ostream & dumpOn( std::ostream & str, const ResPoolProxy & obj );

--- a/zypp/ResStatus.h
+++ b/zypp/ResStatus.h
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 #include <iosfwd>
 #include <zypp/Bit.h>
+#include <zypp/Globals.h>
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
@@ -50,7 +51,7 @@ namespace zypp
    *        a to be installed/deleted solvable.
    *
   */
-  class ResStatus
+  class ZYPP_API ResStatus
   {
     friend std::ostream & operator<<( std::ostream & str, const ResStatus & obj );
     friend bool operator==( const ResStatus & lhs, const ResStatus & rhs );
@@ -706,13 +707,13 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates ResStatus Stream output */
-  std::ostream & operator<<( std::ostream & str, const ResStatus & obj );
+  std::ostream & operator<<( std::ostream & str, const ResStatus & obj ) ZYPP_API;
 
   /** \relates ResStatus Stream output */
-  std::ostream & operator<<( std::ostream & str, ResStatus::TransactValue obj );
+  std::ostream & operator<<( std::ostream & str, ResStatus::TransactValue obj ) ZYPP_API;
 
   /** \relates ResStatus Stream output */
-  std::ostream & operator<<( std::ostream & str, ResStatus::TransactByValue obj );
+  std::ostream & operator<<( std::ostream & str, ResStatus::TransactByValue obj ) ZYPP_API;
 
   /** \relates ResStatus */
   inline bool operator==( const ResStatus & lhs, const ResStatus & rhs )

--- a/zypp/ResTraits.h
+++ b/zypp/ResTraits.h
@@ -82,7 +82,7 @@ namespace zypp
       using PtrType = intrusive_ptr<TRes>;
       using constPtrType = intrusive_ptr<const TRes>;
 
-      static const ResKind              kind;	///< Defined in ResKind.cc
+      static const ResKind              kind ZYPP_API;	///< Defined in ResKind.cc
 
       /** Those are denoted to be installed, if the
        *  solver verifies them as being satisfied. */
@@ -90,12 +90,12 @@ namespace zypp
     };
 
     // Defined in ResKind.cc
-    template<> const ResKind ResTraits<Package>::kind;
-    template<> const ResKind ResTraits<Patch>::kind;
-    template<> const ResKind ResTraits<Pattern>::kind;
-    template<> const ResKind ResTraits<Product>::kind;
-    template<> const ResKind ResTraits<SrcPackage>::kind;
-    template<> const ResKind ResTraits<Application>::kind;
+    template<> const ResKind ResTraits<Package>::kind ZYPP_API;
+    template<> const ResKind ResTraits<Patch>::kind ZYPP_API;
+    template<> const ResKind ResTraits<Pattern>::kind ZYPP_API;
+    template<> const ResKind ResTraits<Product>::kind ZYPP_API;
+    template<> const ResKind ResTraits<SrcPackage>::kind ZYPP_API;
+    template<> const ResKind ResTraits<Application>::kind ZYPP_API;
 
   /** ResTraits specialisation for Resolvable.
    * Resolvable is common base and has no Kind value.

--- a/zypp/Resolvable.h
+++ b/zypp/Resolvable.h
@@ -46,7 +46,7 @@ namespace zypp
   /// \todo Merge with ResObject
   /// \todo Get rid of refcout/smart_prt bloat, as this type is actually IdBased (i.e. sizeof(unsigned))
   ///////////////////////////////////////////////////////////////////
-  class Resolvable : public sat::SolvableType<Resolvable>,
+  class ZYPP_API Resolvable : public sat::SolvableType<Resolvable>,
                      public base::ReferenceCounted, private base::NonCopyable
   {
     friend std::ostream & operator<<( std::ostream & str, const Resolvable & obj );

--- a/zypp/Resolver.h
+++ b/zypp/Resolver.h
@@ -41,7 +41,7 @@ namespace zypp
    * the changes directly on the \ref PoolItem status objects,
    * call the \ref resolvePool() method.
    */
-  class Resolver : public base::ReferenceCounted, private base::NonCopyable
+  class ZYPP_API Resolver : public base::ReferenceCounted, private base::NonCopyable
   {
   public:
 

--- a/zypp/ResolverFocus.h
+++ b/zypp/ResolverFocus.h
@@ -14,6 +14,8 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 {
@@ -27,12 +29,12 @@ namespace zypp
   };
 
   /** \relates ResolverFocus Conversion to string (enumerator name) */
-  std::string asString( const ResolverFocus & val_r );
+  std::string asString( const ResolverFocus & val_r ) ZYPP_API;
 
   /** \relates ResolverFocus Conversion from string (enumerator name, case insensitive, empty string is Default)
    * \returns \c false if \a val_r is not recognized
    */
-  bool fromString( const std::string & val_r, ResolverFocus & ret_r );
+  bool fromString( const std::string & val_r, ResolverFocus & ret_r ) ZYPP_API;
 
   /** \relates ResolverFocus Conversion from string (convenience)
    * \returns \ref ResolverFocus::Default if \a val_r is not recognized

--- a/zypp/ResolverProblem.h
+++ b/zypp/ResolverProblem.h
@@ -23,7 +23,7 @@ namespace zypp
   /// \class ResolverProblem
   /// \brief Describe a solver problem and offer solutions.
   ///////////////////////////////////////////////////////////////////////
-  class ResolverProblem : public base::ReferenceCounted
+  class ZYPP_API ResolverProblem : public base::ReferenceCounted
   {
   public:
     /** Constructor. */

--- a/zypp/ServiceInfo.h
+++ b/zypp/ServiceInfo.h
@@ -33,7 +33,7 @@ namespace zypp
   /// \note Name and Url are subject to repo variable replacement
   /// (\see \ref RepoVariablesStringReplacer).
   ///
-  class ServiceInfo : public repo::RepoInfoBase
+  class ZYPP_API ServiceInfo : public repo::RepoInfoBase
   {
   public:
     /** Default ctor creates \ref noService.*/
@@ -58,7 +58,7 @@ namespace zypp
 
   public:
     /** Represents an empty service. */
-    static const ServiceInfo noService;
+    static const ServiceInfo noService ZYPP_API;
 
   public:
 
@@ -223,7 +223,7 @@ namespace zypp
   using ServiceInfoList = std::list<ServiceInfo>;
 
   /** \relates ServiceInfo Stream output */
-  std::ostream & operator<<( std::ostream & str, const ServiceInfo & obj );
+  std::ostream & operator<<( std::ostream & str, const ServiceInfo & obj ) ZYPP_API;
 
 
     /////////////////////////////////////////////////////////////////

--- a/zypp/SrcPackage.h
+++ b/zypp/SrcPackage.h
@@ -26,7 +26,7 @@ namespace zypp
   //
   /** SrcPackage interface.
   */
-  class SrcPackage : public ResObject
+  class ZYPP_API SrcPackage : public ResObject
   {
 
   public:

--- a/zypp/SysContent.h
+++ b/zypp/SysContent.h
@@ -61,7 +61,7 @@ namespace zypp
      * \endcode
      * \see Reader
     */
-    class Writer
+    class ZYPP_API Writer
     {
       using StorageT = std::set<ResObject::constPtr>;
     public:
@@ -168,7 +168,7 @@ namespace zypp
     /** Retrieve \ref ResObject data serialized by \ref Writer.
      * \see Writer
     */
-    class Reader
+    class ZYPP_API Reader
     {
     public:
       /** Restored \ref ResObject data. */
@@ -240,7 +240,7 @@ namespace zypp
     //	CLASS NAME : Reader::Entry
     //
     /** Restored \ref ResObject data. */
-    class Reader::Entry
+    class ZYPP_API Reader::Entry
     {
     public:
       Entry();

--- a/zypp/Target.h
+++ b/zypp/Target.h
@@ -47,7 +47,7 @@ namespace zypp
   //
   /**
   */
-  class Target : public base::ReferenceCounted, public base::NonCopyable
+  class ZYPP_API Target : public base::ReferenceCounted, public base::NonCopyable
   {
   public:
     using Impl = target::TargetImpl;

--- a/zypp/VendorAttr.h
+++ b/zypp/VendorAttr.h
@@ -57,7 +57,7 @@ namespace zypp {
  *
  * \see \ref pg_zypp-solv-vendorchange
 */
-class VendorAttr
+class ZYPP_API VendorAttr
 {
     friend std::ostream & operator<<( std::ostream & str, const VendorAttr & obj );
 
@@ -176,7 +176,7 @@ class VendorAttr
 };
 
 /** \relates VendorAttr Stream output */
-std::ostream & operator<<( std::ostream & str, const VendorAttr & obj );
+std::ostream & operator<<( std::ostream & str, const VendorAttr & obj ) ZYPP_API;
 
 ///////////////////////////////////////////////////////////////////
 }; // namespace zypp

--- a/zypp/VendorSupportOptions.h
+++ b/zypp/VendorSupportOptions.h
@@ -85,7 +85,7 @@ namespace zypp
      * Note the description is based in the way Novell defines the support
      * levels, and the semantics may be different for other vendors.
      */
-    std::string asUserString( VendorSupportOption );
+    std::string asUserString( VendorSupportOption ) ZYPP_API;
 
     /**
      * converts the support option to a description intended to be printed
@@ -94,7 +94,7 @@ namespace zypp
      * Note the description is based in the way Novell defines the support
      * levels, and the semantics may be different for other vendors.
      */
-    std::string asUserStringDescription( VendorSupportOption );
+    std::string asUserStringDescription( VendorSupportOption ) ZYPP_API;
 
 }
 

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -60,7 +60,7 @@ namespace zypp
    * \ingroup ZyppConfig
    * \ingroup Singleton
   */
-  class ZConfig : private base::NonCopyable
+  class ZYPP_API ZConfig : private base::NonCopyable
   {
     public:
 

--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -54,7 +54,7 @@ namespace zypp
    * \todo define Exceptions
    * ZYpp API main interface
    */
-  class ZYpp : private base::NonCopyable
+  class ZYPP_API ZYpp : private base::NonCopyable
   {
     friend std::ostream & operator<<( std::ostream & str, const ZYpp & obj );
 

--- a/zypp/ZYppCallbacks.h
+++ b/zypp/ZYppCallbacks.h
@@ -37,7 +37,7 @@ namespace zypp
   } // namespace sat
   ///////////////////////////////////////////////////////////////////
 
-  struct ProgressReport : public callback::ReportBase
+  struct ZYPP_API ProgressReport : public callback::ReportBase
   {
     virtual void start( const ProgressData &/*task*/ )
     {}
@@ -100,7 +100,7 @@ namespace zypp
   namespace repo
   {
     // progress for downloading a resolvable
-    struct DownloadResolvableReport : public callback::ReportBase
+    struct ZYPP_API DownloadResolvableReport : public callback::ReportBase
     {
       enum Action {
         ABORT,  // abort and return error
@@ -196,7 +196,7 @@ namespace zypp
     };
 
     // progress for probing a source
-    struct ProbeRepoReport : public callback::ReportBase
+    struct ZYPP_API ProbeRepoReport : public callback::ReportBase
     {
       enum Action {
         ABORT,  // abort and return error
@@ -222,7 +222,7 @@ namespace zypp
       virtual Action problem( const Url &/*url*/, Error /*error*/, const std::string &/*description*/ ) { return ABORT; }
     };
 
-    struct RepoCreateReport : public callback::ReportBase
+    struct ZYPP_API RepoCreateReport : public callback::ReportBase
     {
       enum Action {
         ABORT,  // abort and return error
@@ -256,7 +256,7 @@ namespace zypp
       {}
     };
 
-    struct RepoReport : public callback::ReportBase
+    struct ZYPP_API RepoReport : public callback::ReportBase
     {
       enum Action {
         ABORT,  // abort and return error
@@ -298,7 +298,7 @@ namespace zypp
   namespace media
   {
     // media change request callback
-    struct MediaChangeReport : public callback::ReportBase
+    struct ZYPP_API MediaChangeReport : public callback::ReportBase
     {
       enum Action {
         ABORT,  // abort and return error
@@ -347,7 +347,7 @@ namespace zypp
     /// \brief Temporarily disable MediaChangeReport
     /// Sometimes helpful to suppress interactive messages connected to
     /// MediaChangeReport while fallback URLs are avaialble.
-    struct ScopedDisableMediaChangeReport
+    struct ZYPP_API ScopedDisableMediaChangeReport
     {
       /** Disbale MediaChangeReport if \a condition_r is \c true.*/
       ScopedDisableMediaChangeReport( bool condition_r = true );
@@ -356,7 +356,7 @@ namespace zypp
     };
 
     // progress for downloading a file
-    struct DownloadProgressReport : public callback::ReportBase
+    struct ZYPP_API DownloadProgressReport : public callback::ReportBase
     {
         enum Action {
           ABORT,  // abort and return error
@@ -401,7 +401,7 @@ namespace zypp
     };
 
     // authentication issues report
-    struct AuthenticationReport : public callback::ReportBase
+    struct ZYPP_API AuthenticationReport : public callback::ReportBase
     {
       /**
        * Prompt for authentication data.
@@ -433,7 +433,7 @@ namespace zypp
   namespace target
   {
     /** Request to display the pre commit message of a patch. */
-    struct PatchMessageReport : public callback::ReportBase
+    struct ZYPP_API PatchMessageReport : public callback::ReportBase
     {
       /** Display \c patch->message().
        * Return \c true to continue, \c false to abort commit.
@@ -446,7 +446,7 @@ namespace zypp
      * \c %post script shipped by a package and to be executed
      * after the package was installed.
     */
-    struct PatchScriptReport : public callback::ReportBase
+    struct ZYPP_API PatchScriptReport : public callback::ReportBase
     {
       enum Notify { OUTPUT, PING };
       enum Action {
@@ -485,7 +485,7 @@ namespace zypp
     /// \a noFilelist_r. This usually happens if download mode 'as-needed'
     /// is used.
     ///////////////////////////////////////////////////////////////////
-    struct FindFileConflictstReport : public callback::ReportBase
+    struct ZYPP_API FindFileConflictstReport : public callback::ReportBase
     {
       /**
        * \param progress_r	Progress counter for packages to check.
@@ -518,7 +518,7 @@ namespace zypp
     {
 
       // progress for installing a resolvable
-      struct InstallResolvableReport : public callback::ReportBase
+      struct ZYPP_API InstallResolvableReport : public callback::ReportBase
       {
         enum Action {
           ABORT,  // abort and return error
@@ -568,11 +568,11 @@ namespace zypp
          * line     : std::reference_wrapper<const std::string>
          * lineno   : unsigned
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
       // progress for removing a resolvable
-      struct RemoveResolvableReport : public callback::ReportBase
+      struct ZYPP_API RemoveResolvableReport : public callback::ReportBase
       {
         enum Action {
           ABORT,  // abort and return error
@@ -609,11 +609,11 @@ namespace zypp
         /** "rpmout/removepkg": Additional rpm output (sent immediately).
          * For data \see \ref InstallResolvableReport::contentRpmout
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
       // progress for rebuilding the database
-      struct RebuildDBReport : public callback::ReportBase
+      struct ZYPP_API RebuildDBReport : public callback::ReportBase
       {
         enum Action {
           ABORT,  // abort and return error
@@ -682,14 +682,14 @@ namespace zypp
       /// \todo maybe include the sub-task reports here as well, so it
       /// becomes the only report needed to follow the transaction.
       ///////////////////////////////////////////////////////////////////
-      struct SingleTransReport : public callback::ReportBase
+      struct ZYPP_API SingleTransReport : public callback::ReportBase
       {
         /** \c "zypp-rpm/logline" report a line suitable to be written to the screen.
          * UserData:
          * \c "line"  : std::reference_wrapper<const std::string>; the line to show
          * \c "level" : enum class loglevel; rendering hint
          */
-        static const UserData::ContentType contentLogline;
+        static const UserData::ContentType contentLogline ZYPP_API;
         /** Rendering hint for log-lines to show. */
         enum class loglevel { dbg, msg, war, err, crt };
         /** Suggested prefix for log-lines to show. */
@@ -708,7 +708,7 @@ namespace zypp
 
       // Generic transaction reports, this is used for verifying and preparing tasks, the name param
       // for the start function defines which report we are looking at
-      struct TransactionReportSA : public callback::ReportBase
+      struct ZYPP_API TransactionReportSA : public callback::ReportBase
       {
         enum Error {
           NO_ERROR, // everything went perfectly fine
@@ -735,12 +735,12 @@ namespace zypp
        * Data:
        * line     : std::reference_wrapper<const std::string>
        */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
 
       // progress for installing a resolvable in single transaction mode
-      struct InstallResolvableReportSA : public callback::ReportBase
+      struct ZYPP_API InstallResolvableReportSA : public callback::ReportBase
       {
         enum Error {
           NO_ERROR,
@@ -771,11 +771,11 @@ namespace zypp
          * solvable : satSolvable processed
          * line     : std::reference_wrapper<const std::string>
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
       // progress for removing a resolvable in single transaction mode
-      struct RemoveResolvableReportSA : public callback::ReportBase
+      struct ZYPP_API RemoveResolvableReportSA : public callback::ReportBase
       {
         enum Error {
           NO_ERROR,
@@ -804,11 +804,11 @@ namespace zypp
         /** "zypp-rpm/removepkgsa": Additional rpm output (sent immediately).
          * For data \see \ref InstallResolvableReportSA::contentRpmout
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
       // progress for cleaning up the old version of a package after it was upgraded to a new version
-      struct CleanupPackageReportSA : public callback::ReportBase
+      struct ZYPP_API CleanupPackageReportSA : public callback::ReportBase
       {
         enum Error {
           NO_ERROR
@@ -832,13 +832,13 @@ namespace zypp
         /** "zypp-rpm/cleanupkgsa": Additional rpm output (sent immediately).
          * For data \see \ref InstallResolvableReportSA::contentRpmout
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
 
       // progress for script thats executed during a commit transaction
       // the resolvable can be null, for things like posttrans scripts
-      struct CommitScriptReportSA : public callback::ReportBase
+      struct ZYPP_API CommitScriptReportSA : public callback::ReportBase
       {
         enum Error {
           NO_ERROR,
@@ -870,7 +870,7 @@ namespace zypp
          * solvable : satSolvable processed ( can be empty )
          * line     : std::reference_wrapper<const std::string>
          */
-        static const UserData::ContentType contentRpmout;
+        static const UserData::ContentType contentRpmout ZYPP_API;
       };
 
       /////////////////////////////////////////////////////////////////
@@ -889,7 +889,7 @@ namespace zypp
    * Callback for cleaning locks which doesn't lock anything in pool.
    */
 
-  struct CleanEmptyLocksReport : public callback::ReportBase
+  struct ZYPP_API CleanEmptyLocksReport : public callback::ReportBase
   {
     /**
      * action performed by cleaning api to specific lock
@@ -941,7 +941,7 @@ namespace zypp
   /**
    * this callback handles merging old locks with newly added or removed
    */
-  struct SavingLocksReport : public callback::ReportBase
+  struct ZYPP_API SavingLocksReport : public callback::ReportBase
   {
     /**
      * action for old lock which is in conflict
@@ -996,7 +996,7 @@ namespace zypp
   /// \class JobReport
   /// \brief Generic report for sending messages.
   ///////////////////////////////////////////////////////////////////
-  struct JobReport : public callback::ReportBase
+  struct ZYPP_API JobReport : public callback::ReportBase
   {
   public:
     /** message type (use like 'enum class \ref MsgType') */
@@ -1049,7 +1049,7 @@ namespace zypp
   /// \class UserDataJobReport
   /// \brief \ref JobReport convenience sending this instance of \ref UserData with each message.
   ///////////////////////////////////////////////////////////////////
-  struct UserDataJobReport : public JobReport::UserData
+  struct ZYPP_API UserDataJobReport : public JobReport::UserData
   {
     using JobReport::UserData::UserData;
 

--- a/zypp/ZYppCommitPolicy.h
+++ b/zypp/ZYppCommitPolicy.h
@@ -30,7 +30,7 @@ namespace zypp
   /** Options and policies for ZYpp::commit.
    * \see \ref ZYpp::commit
    */
-  class ZYppCommitPolicy
+  class ZYPP_API ZYppCommitPolicy
   {
     public:
 
@@ -108,7 +108,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates ZYppCommitPolicy Stream output. */
-  std::ostream & operator<<( std::ostream & str, const ZYppCommitPolicy & obj );
+  std::ostream & operator<<( std::ostream & str, const ZYppCommitPolicy & obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/ZYppCommitResult.h
+++ b/zypp/ZYppCommitResult.h
@@ -60,7 +60,7 @@ namespace zypp
    *
    * \see \ref ZYpp::commit
    */
-  class ZYppCommitResult
+  class ZYPP_API ZYppCommitResult
   {
     public:
       using TransactionStepList = std::vector<sat::Transaction::Step>;
@@ -192,7 +192,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates ZYppCommitResult Stream output. */
-  std::ostream & operator<<( std::ostream & str, const ZYppCommitResult & obj );
+  std::ostream & operator<<( std::ostream & str, const ZYppCommitResult & obj ) ZYPP_API;
 
   /////////////////////////////////////////////////////////////////
 } // namespace zypp

--- a/zypp/ZYppFactory.cc
+++ b/zypp/ZYppFactory.cc
@@ -82,7 +82,7 @@ namespace zypp
 
     static bool active = getenv("ZYPP_READONLY_HACK");
 
-    void IWantIt()	// see zypp/zypp_detail/ZYppReadOnlyHack.h
+    ZYPP_API void IWantIt()	// see zypp/zypp_detail/ZYppReadOnlyHack.h
     {
       active = true;
       MIL << "ZYPP_READONLY promised." <<  endl;

--- a/zypp/ZYppFactory.h
+++ b/zypp/ZYppFactory.h
@@ -21,7 +21,7 @@
 namespace zypp
 { /////////////////////////////////////////////////////////////////
 
-  class ZYppFactoryException : public Exception
+  class ZYPP_API ZYppFactoryException : public Exception
   {
   public:
     ZYppFactoryException( std::string msg_r, pid_t lockerPid_r, std::string lockerName_r );
@@ -40,7 +40,7 @@ namespace zypp
   //
   /** ZYpp factory class (Singleton)
   */
-  class ZYppFactory
+  class ZYPP_API ZYppFactory
   {
     friend std::ostream & operator<<( std::ostream & str, const ZYppFactory & obj );
 

--- a/zypp/base/Backtrace.h
+++ b/zypp/base/Backtrace.h
@@ -14,6 +14,8 @@
 #include <iosfwd>
 #include <string>
 
+#include <zypp/Globals.h>
+
 ///////////////////////////////////////////////////////////////////
 namespace zypp
 {
@@ -29,7 +31,7 @@ namespace zypp
    * std::string trace( str::Str() << zypp::dumpBacktrace );
    * \endcode
    */
-  std::ostream & dumpBacktrace( std::ostream & stream_r );
+  std::ostream & dumpBacktrace( std::ostream & stream_r ) ZYPP_API;
 
 } // namespace zypp
 ///////////////////////////////////////////////////////////////////

--- a/zypp/base/DrunkenBishop.h
+++ b/zypp/base/DrunkenBishop.h
@@ -58,7 +58,7 @@ namespace zypp
     /// and heatmap.
     /// See also http://dirk-loss.de/sshvis/drunken_bishop.pdf.
     ///////////////////////////////////////////////////////////////////
-    class DrunkenBishop
+    class ZYPP_API DrunkenBishop
     {
       friend std::ostream & operator<<( std::ostream & str, const DrunkenBishop & obj );
 

--- a/zypp/base/Measure.h
+++ b/zypp/base/Measure.h
@@ -65,7 +65,7 @@ namespace zypp
      * // MEASURE(Parse)  0 (u 0.17 s 0.02 c 0.00) [ 0 (u 0.00 s 0.00 c 0.00)]
      * \endcode
     */
-    class Measure
+    class ZYPP_API Measure
     {
     public:
       /** Default Ctor does nothing. */

--- a/zypp/base/SetRelationMixin.h
+++ b/zypp/base/SetRelationMixin.h
@@ -34,7 +34,7 @@ namespace zypp
       disjoint		= (1<<3),	///< "{ }"
     };
     /** String representantion */
-    static const std::string & asString( Enum val_r );
+    static const std::string & asString( Enum val_r ) ZYPP_API;
   };
   /** \relates ESetCompareDef typedef 'enum class SetCompare' */
   using SetCompare = base::EnumClass<ESetCompareDef>;
@@ -65,7 +65,7 @@ namespace zypp
       superset		= properSuperset|equal,		///< "{>=}"
     };
     /** String representantion */
-    static const std::string & asString( Enum val_r );
+    static const std::string & asString( Enum val_r ) ZYPP_API;
   };
   /** \relates ESetRelationDef typedef 'enum class SetRelation' */
   using SetRelation = base::EnumClass<ESetRelationDef>;

--- a/zypp/base/StrMatcher.h
+++ b/zypp/base/StrMatcher.h
@@ -29,7 +29,7 @@ namespace zypp
   /// Match mode( Match::GLOB | Match::NOCASE );
   /// \endcode
   ///////////////////////////////////////////////////////////////////
-  class Match
+  class ZYPP_API Match
   {
   private:
     static const int _modemask;
@@ -235,16 +235,16 @@ namespace zypp
   { return Match(lhs) -= rhs; }
 
   /** \relates Match::Mode Stream output */
-  std::ostream & operator<<( std::ostream & str, Match::Mode obj );
+  std::ostream & operator<<( std::ostream & str, Match::Mode obj ) ZYPP_API;
 
   /** \relates Match Stream output */
-  std::ostream & operator<<( std::ostream & str, const Match & obj );
+  std::ostream & operator<<( std::ostream & str, const Match & obj ) ZYPP_API;
 
   ///////////////////////////////////////////////////////////////////
   /// \class MatchException
   /// \brief Exceptions thrown from attribute matching.
   ///////////////////////////////////////////////////////////////////
-  struct MatchException : public Exception
+  struct ZYPP_API MatchException : public Exception
   {
     /** Supplied message. */
     explicit MatchException( const std::string & msg_r ) : Exception( msg_r ) {}
@@ -254,7 +254,7 @@ namespace zypp
   /// \class MatchUnknownModeException
   /// \brief Unknown match mode.
   ///////////////////////////////////////////////////////////////////
-  struct MatchUnknownModeException : public MatchException
+  struct ZYPP_API MatchUnknownModeException : public MatchException
   {
     /** Supplied message. */
     explicit MatchUnknownModeException( const std::string & msg_r ) : MatchException( msg_r ) {}
@@ -267,7 +267,7 @@ namespace zypp
   /// \class MatchInvalidRegexException
   /// \brief Invalid regular expression (failed ::regcomp).
   ///////////////////////////////////////////////////////////////////
-  struct MatchInvalidRegexException : public MatchException
+  struct ZYPP_API MatchInvalidRegexException : public MatchException
   {
     /** Supplied message. */
     explicit MatchInvalidRegexException( const std::string & msg_r ) : MatchException( msg_r ) {}
@@ -294,7 +294,7 @@ namespace zypp
   ///
   /// \Note Those flags are always set: <tt>REG_EXTENDED | REG_NOSUB | REG_NEWLINE</tt>
   ///////////////////////////////////////////////////////////////////
-  class StrMatcher
+  class ZYPP_TESTS StrMatcher
   {
     friend std::ostream & operator<<( std::ostream & str, const StrMatcher & obj );
 
@@ -393,7 +393,7 @@ namespace zypp
   };
 
   /** \relates StrMatcher Stream output */
-  std::ostream & operator<<( std::ostream & str, const StrMatcher & obj );
+  std::ostream & operator<<( std::ostream & str, const StrMatcher & obj ) ZYPP_TESTS;
 
   /** \relates StrMatcher */
   bool operator==( const StrMatcher & lhs, const StrMatcher & rhs );

--- a/zypp/media/MediaHandler.h
+++ b/zypp/media/MediaHandler.h
@@ -48,7 +48,7 @@ namespace zypp {
  * logging. For the real action they call virtual methods overloaded by the
  * concrete handler.
  **/
-class MediaHandler {
+class ZYPP_TESTS MediaHandler {
     friend std::ostream & operator<<( std::ostream & str, const MediaHandler & obj );
 
     public:

--- a/zypp/media/MediaManager.h
+++ b/zypp/media/MediaManager.h
@@ -44,7 +44,7 @@ namespace zypp::media
   /**
    * Interface to implement a media verifier.
    */
-  class MediaVerifierBase //: private zypp::NonCopyable
+  class ZYPP_TESTS MediaVerifierBase //: private zypp::NonCopyable
   {
   public:
     MediaVerifierBase()
@@ -450,7 +450,7 @@ namespace zypp::media
    *   - \c script<->libzypp communication:
    *     - \TODO to be documented.
    */
-  class MediaManager: private zypp::base::NonCopyable
+  class ZYPP_API MediaManager: private zypp::base::NonCopyable
   {
   public:
     /**
@@ -818,7 +818,7 @@ namespace zypp::media
      * FIXME: see MediaAccess class.
      */
     bool doesFileExist(MediaAccessId  accessId,
-                       const Pathname & filename ) const;
+                       const Pathname & filename ) const ZYPP_TESTS;
 
     /**
      * Fill in a vector of detected ejectable devices and the index of the

--- a/zypp/misc/CheckAccessDeleted.h
+++ b/zypp/misc/CheckAccessDeleted.h
@@ -15,6 +15,7 @@
 #include <iosfwd>
 #include <vector>
 #include <string>
+#include <zypp/Globals.h>
 #include <zypp/Pathname.h>
 #include <zypp/base/PtrTypes.h>
 
@@ -38,7 +39,7 @@ namespace zypp
    * enabled by \ref setDebugOutputFile.\n
    * This data file can be used as datasource when passed to \ref check(const Pathname &, bool).
    */
-  class CheckAccessDeleted
+  class ZYPP_API CheckAccessDeleted
   {
 
     public:

--- a/zypp/misc/LoadTestcase.h
+++ b/zypp/misc/LoadTestcase.h
@@ -14,6 +14,7 @@
 
 #include <zypp/Pathname.h>
 #include <zypp/Url.h>
+#include <zypp/Globals.h>
 #include <zypp/base/PtrTypes.h>
 #include <zypp/base/NonCopyable.h>
 #include <zypp/misc/TestcaseSetup.h>
@@ -23,7 +24,7 @@
 
 namespace zypp::misc::testcase {
 
-  struct TestcaseTrial
+  struct ZYPP_TESTS TestcaseTrial
   {
     struct Node {
       struct Impl;
@@ -55,7 +56,7 @@ namespace zypp::misc::testcase {
     RWCOW_pointer<Impl> _pimpl;
   };
 
-  class LoadTestcase : private zypp::base::NonCopyable
+  class ZYPP_API LoadTestcase : private zypp::base::NonCopyable
   {
   public:
     struct Impl;

--- a/zypp/misc/TestcaseSetup.h
+++ b/zypp/misc/TestcaseSetup.h
@@ -14,6 +14,7 @@
 #define ZYPP_MISC_TESTCASESETUP_H
 
 #include <zypp/Arch.h>
+#include <zypp/Globals.h>
 #include <zypp/Locale.h>
 #include <zypp/Pathname.h>
 #include <zypp/ResolverFocus.h>
@@ -74,7 +75,7 @@ namespace zypp::misc::testcase
     RWCOW_pointer<ForceInstallImpl> _pimpl;
   };
 
-  class TestcaseSetup
+  class ZYPP_API TestcaseSetup
   {
   public:
 

--- a/zypp/ng/repo/downloader.h
+++ b/zypp/ng/repo/downloader.h
@@ -32,7 +32,7 @@ namespace zyppng {
 
 namespace zyppng::repo {
   template <class ContextRefType>
-  class DownloadContext : public CacheProviderContext<ContextRefType>
+  class ZYPP_TESTS DownloadContext : public CacheProviderContext<ContextRefType>
   {
   public:
 

--- a/zypp/ng/repo/workflows/rpmmd.h
+++ b/zypp/ng/repo/workflows/rpmmd.h
@@ -33,8 +33,8 @@ namespace zyppng {
     AsyncOpRef<expected<zypp::RepoStatus>> repoStatus( repo::AsyncDownloadContextRef dl, ProvideMediaHandle mediaHandle );
     expected<zypp::RepoStatus> repoStatus(repo::SyncDownloadContextRef dl, SyncMediaHandle mediaHandle );
 
-    AsyncOpRef<expected<repo::AsyncDownloadContextRef>> download ( repo::AsyncDownloadContextRef dl, ProvideMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr );
-    expected<repo::SyncDownloadContextRef> download ( repo::SyncDownloadContextRef dl, SyncMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr );
+    AsyncOpRef<expected<repo::AsyncDownloadContextRef>> download ( repo::AsyncDownloadContextRef dl, ProvideMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr ) ZYPP_TESTS;
+    expected<repo::SyncDownloadContextRef> download ( repo::SyncDownloadContextRef dl, SyncMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr ) ZYPP_TESTS;
   }
 }
 

--- a/zypp/ng/repo/workflows/susetags.h
+++ b/zypp/ng/repo/workflows/susetags.h
@@ -39,8 +39,8 @@ namespace zyppng {
     /*!
      * Download metadata to a local directory
      */
-    AsyncOpRef<expected<repo::AsyncDownloadContextRef>> download ( repo::AsyncDownloadContextRef dl, ProvideMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr );
-    expected<repo::SyncDownloadContextRef> download ( repo::SyncDownloadContextRef dl, SyncMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr );
+    AsyncOpRef<expected<repo::AsyncDownloadContextRef>> download ( repo::AsyncDownloadContextRef dl, ProvideMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr ) ZYPP_TESTS;
+    expected<repo::SyncDownloadContextRef> download ( repo::SyncDownloadContextRef dl, SyncMediaHandle mediaHandle, ProgressObserverRef progressObserver = nullptr ) ZYPP_TESTS;
   }
 }
 

--- a/zypp/ng/workflows/contextfacade.h
+++ b/zypp/ng/workflows/contextfacade.h
@@ -24,7 +24,7 @@ namespace zyppng {
   using KeyRing    = zypp::KeyRing;
   using KeyRingRef = zypp::KeyRing_Ptr;
 
-  class SyncContext {
+  class ZYPP_API SyncContext {
 
     ZYPP_ADD_CREATE_FUNC(SyncContext)
 

--- a/zypp/ng/workflows/keyringwf.h
+++ b/zypp/ng/workflows/keyringwf.h
@@ -73,11 +73,11 @@ namespace zyppng {
      *
      * \see \ref zypp::KeyRingReport
      */
-    std::pair<bool,zypp::keyring::VerifyFileContext> verifyFileSignature( SyncContextRef zyppContext, zypp::keyring::VerifyFileContext && context_r );
-    AsyncOpRef<std::pair<bool,zypp::keyring::VerifyFileContext>> verifyFileSignature( ContextRef zyppContext, zypp::keyring::VerifyFileContext && context_r );
+    std::pair<bool,zypp::keyring::VerifyFileContext> verifyFileSignature( SyncContextRef zyppContext, zypp::keyring::VerifyFileContext && context_r ) ZYPP_TESTS;
+    AsyncOpRef<std::pair<bool,zypp::keyring::VerifyFileContext>> verifyFileSignature( ContextRef zyppContext, zypp::keyring::VerifyFileContext && context_r ) ZYPP_TESTS;
 
-    std::pair<bool,zypp::keyring::VerifyFileContext> verifyFileSignature( SyncContextRef zyppContext, zypp::KeyRing_Ptr keyRing, zypp::keyring::VerifyFileContext &&context_r );
-    AsyncOpRef<std::pair<bool,zypp::keyring::VerifyFileContext>> verifyFileSignature( ContextRef zyppContext, zypp::KeyRing_Ptr keyRing, zypp::keyring::VerifyFileContext &&context_r );
+    std::pair<bool,zypp::keyring::VerifyFileContext> verifyFileSignature( SyncContextRef zyppContext, zypp::KeyRing_Ptr keyRing, zypp::keyring::VerifyFileContext &&context_r ) ZYPP_TESTS;
+    AsyncOpRef<std::pair<bool,zypp::keyring::VerifyFileContext>> verifyFileSignature( ContextRef zyppContext, zypp::KeyRing_Ptr keyRing, zypp::keyring::VerifyFileContext &&context_r ) ZYPP_TESTS;
   }
 }
 

--- a/zypp/ng/workflows/mediafacade.h
+++ b/zypp/ng/workflows/mediafacade.h
@@ -44,7 +44,7 @@ namespace zyppng {
    * class just in a sync way. Meaning every operation will finish immediately
    * instead of returns a \ref AsyncOp.
    */
-  class MediaSyncFacade : public Base
+  class ZYPP_API MediaSyncFacade : public Base
   {
     ZYPP_ADD_CREATE_FUNC(MediaSyncFacade);
   public:

--- a/zypp/parser/HistoryLogReader.h
+++ b/zypp/parser/HistoryLogReader.h
@@ -63,7 +63,7 @@ namespace zypp
   /// \see \ref HistoryLogData for how to access the individual data fields.
   ///
   ///////////////////////////////////////////////////////////////////
-  class HistoryLogReader
+  class ZYPP_API HistoryLogReader
   {
   public:
 

--- a/zypp/parser/ProductFileReader.h
+++ b/zypp/parser/ProductFileReader.h
@@ -38,7 +38,7 @@ namespace zypp
     /** Data returned by \ref ProductFileReader
      * \see \ref ProductFileReader
     */
-    class ProductFileData
+    class ZYPP_API ProductFileData
     {
       public:
         struct Impl;
@@ -99,10 +99,10 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates  ProductFileData Stream output */
-    std::ostream & operator<<( std::ostream & str, const ProductFileData & obj );
+    std::ostream & operator<<( std::ostream & str, const ProductFileData & obj ) ZYPP_API;
 
     /** \relates  ProductFileData::Upgrade Stream output */
-    std::ostream & operator<<( std::ostream & str, const ProductFileData::Upgrade & obj );
+    std::ostream & operator<<( std::ostream & str, const ProductFileData::Upgrade & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
     //
@@ -118,7 +118,7 @@ namespace zypp
      *                             "/etc/products.d" );
      * \endcode
      */
-    class ProductFileReader
+    class ZYPP_API ProductFileReader
     {
     public:
       /** Callback being invoked for each \ref ProductFileData parsed.

--- a/zypp/parser/RepoFileReader.h
+++ b/zypp/parser/RepoFileReader.h
@@ -48,7 +48,7 @@ namespace zypp
      * Repeating the \c baseurl= tag on each line is also accepted, but when the
      * file has to be written, the preferred style is used.
      */
-    class RepoFileReader
+    class ZYPP_TESTS RepoFileReader
     {
       friend std::ostream & operator<<( std::ostream & str, const RepoFileReader & obj );
     public:

--- a/zypp/parser/RepoindexFileReader.h
+++ b/zypp/parser/RepoindexFileReader.h
@@ -41,7 +41,7 @@ namespace zypp
    *                  bind( &SomeClass::callbackfunc, &SomeClassInstance, _1) );
    * \endcode
    */
-  class RepoindexFileReader : private base::NonCopyable
+  class ZYPP_API RepoindexFileReader : private base::NonCopyable
   {
   public:
    /**

--- a/zypp/parser/xml/Reader.h
+++ b/zypp/parser/xml/Reader.h
@@ -92,7 +92,7 @@ namespace zypp
      * }
      * \endcode
      **/
-    class Reader : private zypp::base::NonCopyable
+    class ZYPP_API Reader : private zypp::base::NonCopyable
     {
     public:
       /** Ctor. Setup xmlTextReader and advance to the 1st Node. */

--- a/zypp/parser/xml/XmlString.h
+++ b/zypp/parser/xml/XmlString.h
@@ -37,7 +37,7 @@ namespace zypp
      * be freed. If the wraped <tt>xmlChar *</tt> needs to be freed by
      * calling \c xmlFree, pass \c FREE as 2nd argument to the ctor.
      **/
-    class XmlString
+    class ZYPP_API XmlString
     {
       /** shared_ptr custom deleter calling \c xmlFree. */
       struct Deleter
@@ -107,7 +107,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates XmlString Stream output. */
-    std::ostream & operator<<( std::ostream & str, const XmlString & obj );
+    std::ostream & operator<<( std::ostream & str, const XmlString & obj ) ZYPP_API;
 
     /////////////////////////////////////////////////////////////////
   } // namespace xml

--- a/zypp/parser/yum/RepomdFileReader.h
+++ b/zypp/parser/yum/RepomdFileReader.h
@@ -35,7 +35,7 @@ namespace zypp
    * After each file entry is read, an \ref OnMediaLocation and the resource type
    * string are prepared and passed to the \ref _callback.
    */
-  class RepomdFileReader : private base::NonCopyable
+  class ZYPP_TESTS RepomdFileReader : private base::NonCopyable
   {
   public:
     /** Callback taking \ref OnMediaLocation and the resource type string */

--- a/zypp/pool/PoolStats.h
+++ b/zypp/pool/PoolStats.h
@@ -56,7 +56,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates PoolStats Stream output */
-    std::ostream & operator<<( std::ostream & str, const PoolStats & obj );
+    std::ostream & operator<<( std::ostream & str, const PoolStats & obj ) ZYPP_API;
 
     /////////////////////////////////////////////////////////////////
   } // namespace pool

--- a/zypp/repo/DeltaCandidates.h
+++ b/zypp/repo/DeltaCandidates.h
@@ -33,7 +33,7 @@ namespace zypp
      * gets all patches and deltas from them for a given
      * package.
      */
-    class DeltaCandidates
+    class ZYPP_API DeltaCandidates
     {
       friend std::ostream & operator<<( std::ostream & str, const DeltaCandidates & obj );
 
@@ -65,7 +65,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates DeltaCandidates Stream output */
-    std::ostream & operator<<( std::ostream & str, const DeltaCandidates & obj );
+    std::ostream & operator<<( std::ostream & str, const DeltaCandidates & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/repo/PackageProvider.h
+++ b/zypp/repo/PackageProvider.h
@@ -31,7 +31,7 @@ namespace zypp
     /// \class PackageProviderPolicy
     /// \brief Policies and options for \ref PackageProvider
     ///////////////////////////////////////////////////////////////////
-    class PackageProviderPolicy
+    class ZYPP_API PackageProviderPolicy
     {
     public:
       /** Get installed Editions callback signature. */
@@ -57,7 +57,7 @@ namespace zypp
     ///
     /// Use available deltarpm if apropriate.
     ///////////////////////////////////////////////////////////////////
-    class PackageProvider
+    class ZYPP_API PackageProvider
     {
     public:
       /** Ctor taking the package to provide.

--- a/zypp/repo/PluginRepoverification.h
+++ b/zypp/repo/PluginRepoverification.h
@@ -29,7 +29,7 @@ namespace zypp_private
     /// \class PluginRepoverificationCheckException
     /// \brief Exceptiontype thrown if a plugins verification fails.
     ///////////////////////////////////////////////////////////////////
-    class PluginRepoverificationCheckException : public FileCheckException
+    class ZYPP_API PluginRepoverificationCheckException : public FileCheckException
     {
     public:
       PluginRepoverificationCheckException( const std::string &msg )

--- a/zypp/repo/PluginServices.h
+++ b/zypp/repo/PluginServices.h
@@ -25,7 +25,7 @@ namespace zypp
   namespace repo
   { /////////////////////////////////////////////////////////////////
 
-    class PluginServices
+    class ZYPP_TESTS PluginServices
     {
       friend std::ostream & operator<<( std::ostream & str, const PluginServices& obj );
     public:

--- a/zypp/repo/RepoException.h
+++ b/zypp/repo/RepoException.h
@@ -34,7 +34,7 @@ namespace zypp
     /**
      * \short Exception for repository handling.
      */
-    class RepoException : public Exception
+    class ZYPP_API RepoException : public Exception
     {
       public:
         RepoException();
@@ -62,7 +62,7 @@ namespace zypp
      * so you can't create the repostories from
      * the cache.
      */
-    class RepoNotCachedException : public RepoException
+    class ZYPP_API RepoNotCachedException : public RepoException
     {
       public:
         RepoNotCachedException();
@@ -75,7 +75,7 @@ namespace zypp
      * thrown when it was impossible to
      * determine one url for this repo.
      */
-    class RepoNoUrlException : public RepoException
+    class ZYPP_API RepoNoUrlException : public RepoException
     {
       public:
         RepoNoUrlException();
@@ -88,7 +88,7 @@ namespace zypp
      * thrown when it was impossible to
      * determine an alias for this repo.
      */
-    class RepoNoAliasException : public RepoException
+    class ZYPP_API RepoNoAliasException : public RepoException
     {
       public:
         RepoNoAliasException();
@@ -100,7 +100,7 @@ namespace zypp
     /**
      * Thrown when the repo alias is found to be invalid.
      */
-    class RepoInvalidAliasException : public RepoException
+    class ZYPP_API RepoInvalidAliasException : public RepoException
     {
     public:
       RepoInvalidAliasException();
@@ -113,7 +113,7 @@ namespace zypp
      * thrown when it was impossible to
      * match a repository
      */
-    class RepoNotFoundException : public RepoException
+    class ZYPP_API RepoNotFoundException : public RepoException
     {
       public:
         RepoNotFoundException();
@@ -126,7 +126,7 @@ namespace zypp
      * Repository already exists and some unique
      * attribute can't be duplicated.
      */
-    class RepoAlreadyExistsException : public RepoException
+    class ZYPP_API RepoAlreadyExistsException : public RepoException
     {
       public:
         RepoAlreadyExistsException();
@@ -139,7 +139,7 @@ namespace zypp
      * thrown when it was impossible to
      * determine this repo type.
      */
-    class RepoUnknownTypeException : public RepoException
+    class ZYPP_API RepoUnknownTypeException : public RepoException
     {
       public:
         RepoUnknownTypeException();
@@ -152,7 +152,7 @@ namespace zypp
      * thrown when it was impossible to
      * use the raw metadata for this repo.
      */
-    class RepoMetadataException : public RepoException
+    class ZYPP_API RepoMetadataException : public RepoException
     {
       public:
         RepoMetadataException();
@@ -172,7 +172,7 @@ namespace zypp
 
     /** Base Exception for service handling.
      */
-    class ServiceException : public Exception
+    class ZYPP_API ServiceException : public Exception
     {
       public:
         ServiceException();
@@ -197,7 +197,7 @@ namespace zypp
 
     /** Service without alias was used in an operation.
      */
-    class ServiceNoAliasException : public ServiceException
+    class ZYPP_API ServiceNoAliasException : public ServiceException
     {
       public:
         ServiceNoAliasException();
@@ -209,7 +209,7 @@ namespace zypp
     /**
      * Thrown when the repo alias is found to be invalid.
      */
-    class ServiceInvalidAliasException : public ServiceException
+    class ZYPP_API ServiceInvalidAliasException : public ServiceException
     {
     public:
       ServiceInvalidAliasException();
@@ -220,7 +220,7 @@ namespace zypp
 
     /** Service already exists and some unique attribute can't be duplicated.
      */
-    class ServiceAlreadyExistsException : public ServiceException
+    class ZYPP_API ServiceAlreadyExistsException : public ServiceException
     {
       public:
         ServiceAlreadyExistsException();
@@ -231,7 +231,7 @@ namespace zypp
 
     /** Service has no or invalid url defined.
      */
-    class ServiceNoUrlException : public ServiceException
+    class ZYPP_API ServiceNoUrlException : public ServiceException
     {
       public:
         ServiceNoUrlException();
@@ -248,7 +248,7 @@ namespace zypp
 
     /** PLUGIN Service related exceptions
      */
-    class ServicePluginException : public ServiceException
+    class ZYPP_API ServicePluginException : public ServiceException
     {
       public:
         ServicePluginException();
@@ -259,7 +259,7 @@ namespace zypp
 
     /** Service plugin has trouble providing the metadata but this should not be treated as error.
      */
-    class ServicePluginInformalException : public ServicePluginException
+    class ZYPP_API ServicePluginInformalException : public ServicePluginException
     {
       public:
         ServicePluginInformalException();
@@ -270,7 +270,7 @@ namespace zypp
 
     /** Service plugin is immutable.
      */
-    class ServicePluginImmutableException : public ServicePluginException
+    class ZYPP_API ServicePluginImmutableException : public ServicePluginException
     {
       public:
         ServicePluginImmutableException();

--- a/zypp/repo/RepoInfoBase.h
+++ b/zypp/repo/RepoInfoBase.h
@@ -36,7 +36,7 @@ namespace zypp
      * \note Name is subject to repo variable replacement
      * (\see \ref RepoVariablesStringReplacer).
      */
-    class RepoInfoBase
+    class ZYPP_API RepoInfoBase
     {
       friend std::ostream & operator<<( std::ostream & str, const RepoInfoBase & obj );
 

--- a/zypp/repo/RepoProvideFile.h
+++ b/zypp/repo/RepoProvideFile.h
@@ -58,7 +58,7 @@ namespace zypp
      * files from different repositories in different order
      * without opening and closing medias all the time
      */
-    class RepoMediaAccess
+    class ZYPP_API RepoMediaAccess
     {
     public:
       /** Ctor taking the default \ref ProvideFilePolicy. */

--- a/zypp/repo/RepoType.h
+++ b/zypp/repo/RepoType.h
@@ -12,6 +12,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <zypp/Globals.h>
 
 namespace zypp
 {
@@ -24,7 +25,7 @@ namespace zypp
    * Repositories can be from varous types
    * ...
    */
-  struct RepoType
+  struct ZYPP_API RepoType
   {
     static const RepoType RPMMD;
     static const RepoType YAST2;

--- a/zypp/repo/RepoVariables.h
+++ b/zypp/repo/RepoVariables.h
@@ -54,7 +54,7 @@ namespace zypp
     /// If variable is unset or empty nothing is substituted.
     /// Otherwise, the expansion of \c word is substituted.</li>
     /// </ul>
-    struct RepoVarExpand
+    struct ZYPP_API RepoVarExpand
     {
       /** Function taking a variable name and returning a pointer to the variable value or \c nullptr if unset. */
       using VarRetriever = function<const std::string *(const std::string &)>;
@@ -102,7 +102,7 @@ namespace zypp
      *
      * \see \ref RepoVarExpand for supported variable syntax.
      */
-    struct RepoVariablesStringReplacer
+    struct ZYPP_TESTS RepoVariablesStringReplacer
     {
       std::string operator()( const std::string & value_r ) const;
 
@@ -116,7 +116,7 @@ namespace zypp
      * Replaces repository variables in the URL (except for user/pass inside authority)
      * \see RepoVariablesStringReplacer
      */
-    struct RepoVariablesUrlReplacer
+    struct ZYPP_API RepoVariablesUrlReplacer
     {
       Url operator()( const Url & url_r ) const;
     };

--- a/zypp/repo/ServiceType.h
+++ b/zypp/repo/ServiceType.h
@@ -23,15 +23,15 @@ namespace zypp
    *
    * Currently we have only RIS service, but more can come later.
    */
-  struct ServiceType
+  struct ZYPP_API ServiceType
   {
     /**
      * Repository Index Service (RIS)
      * (formerly known as 'Novell Update' (NU) service)
      */
-    static const ServiceType RIS;
+    static const ServiceType RIS ZYPP_API;
     /** No service set. */
-    static const ServiceType NONE;
+    static const ServiceType NONE ZYPP_API;
     /**
      * Plugin services are scripts installed on
      * your system that provide the package manager with
@@ -40,7 +40,7 @@ namespace zypp
      * The mechanism used to create this repository list
      * is completely up to the script
      */
-    static const ServiceType PLUGIN;
+    static const ServiceType PLUGIN ZYPP_API;
 
     enum Type
     {

--- a/zypp/repo/SrcPackageProvider.h
+++ b/zypp/repo/SrcPackageProvider.h
@@ -35,7 +35,7 @@ namespace zypp
     //	CLASS NAME : SrcPackageProvider
     //
     /** */
-    class SrcPackageProvider : private base::NonCopyable
+    class ZYPP_API SrcPackageProvider : private base::NonCopyable
     {
     public:
       /** Ctor */

--- a/zypp/sat/FileConflicts.h
+++ b/zypp/sat/FileConflicts.h
@@ -27,7 +27,7 @@ namespace zypp
     /// \class FileConflicts
     /// \brief Libsolv queue representing file conflicts.
     ///////////////////////////////////////////////////////////////////
-    class FileConflicts : private Queue
+    class ZYPP_API FileConflicts : private Queue
     {
       friend bool operator==( const FileConflicts & lhs, const FileConflicts & rhs );
       static constexpr size_type queueBlockSize = 6;
@@ -70,16 +70,16 @@ namespace zypp
     };
 
     /** \relates FileConflicts Stream output */
-    std::ostream & operator<<( std::ostream & str, const FileConflicts & obj );
+    std::ostream & operator<<( std::ostream & str, const FileConflicts & obj ) ZYPP_API;
 
     /** \relates FileConflicts::Conflict Stream output */
-    std::ostream & operator<<( std::ostream & str, const FileConflicts::Conflict & obj );
+    std::ostream & operator<<( std::ostream & str, const FileConflicts::Conflict & obj ) ZYPP_API;
 
     /** \relates FileConflicts XML output */
-    std::ostream & dumpAsXmlOn( std::ostream & str, const FileConflicts & obj );
+    std::ostream & dumpAsXmlOn( std::ostream & str, const FileConflicts & obj ) ZYPP_API;
 
     /** \relates FileConflicts::Conflict XML output */
-    std::ostream & dumpAsXmlOn( std::ostream & str, const FileConflicts::Conflict & obj );
+    std::ostream & dumpAsXmlOn( std::ostream & str, const FileConflicts::Conflict & obj ) ZYPP_API;
 
     /** \relates FileConflicts */
     inline bool operator==( const FileConflicts & lhs, const FileConflicts & rhs )

--- a/zypp/sat/LookupAttr.h
+++ b/zypp/sat/LookupAttr.h
@@ -17,6 +17,7 @@
 
 #include <zypp/base/PtrTypes.h>
 #include <zypp-core/base/DefaultIntegral>
+#include <zypp-core/Globals.h>
 
 #include <zypp/sat/detail/PoolMember.h>
 #include <zypp/sat/SolvAttr.h>
@@ -105,7 +106,7 @@ namespace zypp
      *  }
      * \endcode
      */
-    class LookupAttr
+    class ZYPP_API LookupAttr
     {
       public:
         using Exception = MatchException;
@@ -235,10 +236,10 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates LookupAttr Stream output. */
-    std::ostream & operator<<( std::ostream & str, const LookupAttr & obj );
+    std::ostream & operator<<( std::ostream & str, const LookupAttr & obj ) ZYPP_API;
 
     /** \relates LookupAttr Verbose stream output including the query result. */
-    std::ostream & dumpOn( std::ostream & str, const LookupAttr & obj );
+    std::ostream & dumpOn( std::ostream & str, const LookupAttr & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
     //
@@ -579,7 +580,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates LookupAttr::iterator Stream output. */
-    std::ostream & operator<<( std::ostream & str, const LookupAttr::iterator & obj );
+    std::ostream & operator<<( std::ostream & str, const LookupAttr::iterator & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/sat/Map.h
+++ b/zypp/sat/Map.h
@@ -30,7 +30,7 @@ namespace zypp
     /// \Note Requested sizes are filled up to the next multiple of eight.
     /// Libsolv bitmaps are not shrinkable.
     ///////////////////////////////////////////////////////////////////
-    class Map
+    class ZYPP_API Map
     {
     public:
       using size_type = unsigned long;
@@ -117,7 +117,7 @@ namespace zypp
     { return str << obj.asString(); }
 
     /** \relates Map */
-    bool operator==( const Map & lhs, const Map & rhs );
+    bool operator==( const Map & lhs, const Map & rhs ) ZYPP_API;
 
     /** \relates Map */
     inline bool operator!=( const Map & lhs, const Map & rhs )

--- a/zypp/sat/Pool.h
+++ b/zypp/sat/Pool.h
@@ -43,7 +43,7 @@ namespace zypp
      *
      * Explicitly shared singleton \ref Pool::instance.
      */
-    class Pool : protected detail::PoolMember
+    class ZYPP_API Pool : protected detail::PoolMember
     {
       public:
         using SolvableIterator = detail::SolvableIterator;
@@ -288,7 +288,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates Pool Stream output */
-    std::ostream & operator<<( std::ostream & str, const Pool & obj );
+    std::ostream & operator<<( std::ostream & str, const Pool & obj ) ZYPP_API;
 
     /** \relates Pool */
     inline bool operator==( const Pool & lhs, const Pool & rhs )

--- a/zypp/sat/Queue.h
+++ b/zypp/sat/Queue.h
@@ -13,6 +13,7 @@
 
 #include <iosfwd>
 
+#include <zypp/Globals.h>
 #include <zypp/base/PtrTypes.h>
 #include <zypp/sat/detail/PoolMember.h>
 
@@ -31,7 +32,7 @@ namespace zypp
     /// \brief Libsolv Id queue wrapper.
     /// \todo template value_type to work with IString and other Id based types
     ///////////////////////////////////////////////////////////////////
-    class Queue
+    class ZYPP_API Queue
     {
       public:
         using size_type = unsigned int;
@@ -115,13 +116,13 @@ namespace zypp
     };
 
     /** \relates Queue Stream output */
-    std::ostream & operator<<( std::ostream & str, const Queue & obj );
+    std::ostream & operator<<( std::ostream & str, const Queue & obj ) ZYPP_API;
 
     /** \relates Queue Stream output assuming a Solvable queue. */
-    std::ostream & dumpOn( std::ostream & str, const Queue & obj );
+    std::ostream & dumpOn( std::ostream & str, const Queue & obj ) ZYPP_API;
 
     /** \relates Queue */
-    bool operator==( const Queue & lhs, const Queue & rhs );
+    bool operator==( const Queue & lhs, const Queue & rhs ) ZYPP_API;
 
     /** \relates Queue */
     inline bool operator!=( const Queue & lhs, const Queue & rhs )

--- a/zypp/sat/SolvAttr.h
+++ b/zypp/sat/SolvAttr.h
@@ -37,7 +37,7 @@ namespace sat
    *
    * \see \ref LookupAttr
    */
-  class SolvAttr : public IdStringType<SolvAttr>
+  class ZYPP_API SolvAttr : public IdStringType<SolvAttr>
   {
     public:
       /** \name Some builtin SolvAttr constants. */

--- a/zypp/sat/SolvIterMixin.h
+++ b/zypp/sat/SolvIterMixin.h
@@ -40,7 +40,7 @@ namespace zypp
        * used in \ref SolvIterMixin when mapping a  Solvable iterator
        * to a Selectable iterator.
       */
-      struct UnifyByIdent
+      struct ZYPP_API UnifyByIdent
       {
         bool operator()( const Solvable & solv_r ) const;
 

--- a/zypp/sat/Solvable.h
+++ b/zypp/sat/Solvable.h
@@ -50,7 +50,7 @@ namespace zypp
     /// packages as an own kind of solvable and map their arch to
     /// \ref Arch_noarch.
     ///////////////////////////////////////////////////////////////////
-    class Solvable : protected detail::PoolMember
+    class ZYPP_API Solvable : protected detail::PoolMember
     {
     public:
       using IdType = sat::detail::SolvableIdType;
@@ -438,13 +438,13 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates Solvable Stream output */
-    std::ostream & operator<<( std::ostream & str, const Solvable & obj );
+    std::ostream & operator<<( std::ostream & str, const Solvable & obj ) ZYPP_API;
 
     /** \relates Solvable More verbose stream output including dependencies */
-    std::ostream & dumpOn( std::ostream & str, const Solvable & obj );
+    std::ostream & dumpOn( std::ostream & str, const Solvable & obj ) ZYPP_API;
 
     /** \relates Solvable XML output */
-    std::ostream & dumpAsXmlOn( std::ostream & str, const Solvable & obj );
+    std::ostream & dumpAsXmlOn( std::ostream & str, const Solvable & obj ) ZYPP_API;
 
     /** \relates Solvable */
     inline bool operator==( const Solvable & lhs, const Solvable & rhs )
@@ -563,7 +563,7 @@ namespace zypp
      * \relates Solvable
      * \relates sat::SolvIterMixin
      */
-    struct asSolvable
+    struct ZYPP_TESTS asSolvable
     {
       using result_type = Solvable;
 

--- a/zypp/sat/SolvableSet.h
+++ b/zypp/sat/SolvableSet.h
@@ -109,7 +109,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates SolvableSet Stream output */
-    std::ostream & operator<<( std::ostream & str, const SolvableSet & obj );
+    std::ostream & operator<<( std::ostream & str, const SolvableSet & obj ) ZYPP_API;
 
     /////////////////////////////////////////////////////////////////
   } // namespace sat

--- a/zypp/sat/SolvableSpec.h
+++ b/zypp/sat/SolvableSpec.h
@@ -41,7 +41,7 @@ namespace zypp
     ///
     /// \note \ref contains does not match srcpackage: per default.
     ///////////////////////////////////////////////////////////////////
-    class SolvableSpec
+    class ZYPP_TESTS SolvableSpec
     {
     public:
       /** Default ctor */

--- a/zypp/sat/Transaction.h
+++ b/zypp/sat/Transaction.h
@@ -48,7 +48,7 @@ namespace zypp
      *       do not cause/require any specific action. To skip those informal steps
      *       when iterating, use the \ref actionBegin /\ref actionEnd methods.
      */
-    class Transaction : public SolvIterMixin<Transaction, detail::Transaction_const_iterator>
+    class ZYPP_API Transaction : public SolvIterMixin<Transaction, detail::Transaction_const_iterator>
     {
       friend std::ostream & operator<<( std::ostream & str, const Transaction & obj );
       friend std::ostream & dumpOn( std::ostream & str, const Transaction & obj );

--- a/zypp/sat/WhatObsoletes.cc
+++ b/zypp/sat/WhatObsoletes.cc
@@ -29,9 +29,9 @@ namespace zypp
     // Obsoletes may either match against provides, or names.
     // Configuration depends on the behaviour of rpm.
 #ifdef _RPM_5
-    bool obsoleteUsesProvides = true;
+    ZYPP_TESTS bool obsoleteUsesProvides = true;
 #else
-    bool obsoleteUsesProvides = false;
+    ZYPP_TESTS bool obsoleteUsesProvides = false;
 #endif
 
     ///////////////////////////////////////////////////////////////////

--- a/zypp/sat/WhatObsoletes.h
+++ b/zypp/sat/WhatObsoletes.h
@@ -33,7 +33,7 @@ namespace zypp
      *
      * \todo Publish obsoleteUsesProvides config option.
      */
-    class WhatObsoletes : public SolvIterMixin<WhatObsoletes,detail::WhatProvidesIterator>,
+    class ZYPP_TESTS WhatObsoletes : public SolvIterMixin<WhatObsoletes,detail::WhatProvidesIterator>,
                           protected detail::PoolMember
     {
       public:

--- a/zypp/sat/WhatProvides.h
+++ b/zypp/sat/WhatProvides.h
@@ -84,7 +84,7 @@ namespace zypp
      * }
      * \endcode
      */
-    class WhatProvides : public SolvIterMixin<WhatProvides,detail::WhatProvidesIterator>,
+    class ZYPP_API WhatProvides : public SolvIterMixin<WhatProvides,detail::WhatProvidesIterator>,
                          protected detail::PoolMember
     {
       public:
@@ -134,7 +134,7 @@ namespace zypp
 
     ///////////////////////////////////////////////////////////////////
     /// \brief Container of packages providing `ptf()`
-    class AllPTFs : public WhatProvides
+    class ZYPP_API AllPTFs : public WhatProvides
     {
     public:
       AllPTFs() : WhatProvides( Capability(Solvable::ptfMasterToken.id()) ) {};

--- a/zypp/target/CommitPackageCache.h
+++ b/zypp/target/CommitPackageCache.h
@@ -35,7 +35,7 @@ namespace zypp
     /// \p pool_r \ref ResPool used to get candidates
     /// \p pi item to be commited
     ///////////////////////////////////////////////////////////////////
-    class RepoProvidePackage
+    class ZYPP_API RepoProvidePackage
     {
     public:
       RepoProvidePackage();
@@ -55,7 +55,7 @@ namespace zypp
     //
     /** Target::commit helper optimizing package provision.
     */
-    class CommitPackageCache
+    class ZYPP_API CommitPackageCache
     {
       friend std::ostream & operator<<( std::ostream & str, const CommitPackageCache & obj );
 

--- a/zypp/target/TargetException.h
+++ b/zypp/target/TargetException.h
@@ -29,7 +29,7 @@ namespace zypp
     /** Just inherits Exception to separate target exceptions
      *
      **/
-    class TargetException : public Exception
+    class ZYPP_API TargetException : public Exception
     {
     public:
       /** Ctor taking message.
@@ -48,7 +48,7 @@ namespace zypp
       ~TargetException() throw() override {};
     };
 
-    class TargetAbortedException : public TargetException
+    class ZYPP_API TargetAbortedException : public TargetException
     {
     public:
       TargetAbortedException( );

--- a/zypp/target/rpm/RpmDb.h
+++ b/zypp/target/rpm/RpmDb.h
@@ -46,7 +46,7 @@ namespace rpm
 /**
  * @short Interface to the rpm program
  **/
-class RpmDb : public base::ReferenceCounted, private base::NonCopyable
+class ZYPP_API RpmDb : public base::ReferenceCounted, private base::NonCopyable
 {
 public:
 
@@ -500,10 +500,10 @@ protected:
 };
 
 /** \relates RpmDb::CheckPackageResult Stream output */
-std::ostream & operator<<( std::ostream & str, RpmDb::CheckPackageResult obj );
+std::ostream & operator<<( std::ostream & str, RpmDb::CheckPackageResult obj ) ZYPP_API;
 
 /** \relates RpmDb::checkPackageDetail Stream output */
-std::ostream & operator<<( std::ostream & str, const RpmDb::CheckPackageDetail & obj );
+std::ostream & operator<<( std::ostream & str, const RpmDb::CheckPackageDetail & obj ) ZYPP_API;
 
 } // namespace rpm
 } // namespace target

--- a/zypp/target/rpm/RpmException.h
+++ b/zypp/target/rpm/RpmException.h
@@ -35,7 +35,7 @@ namespace rpm
 /** Just inherits Exception to separate media exceptions
  *
  **/
-class RpmException : public Exception
+class ZYPP_API RpmException : public Exception
 {
 public:
   /** Ctor taking message.
@@ -55,7 +55,7 @@ public:
   {};
 };
 
-class GlobalRpmInitException : public RpmException
+class ZYPP_API GlobalRpmInitException : public RpmException
 {
 public:
   /** Ctor taking message.
@@ -70,7 +70,7 @@ public:
 private:
 };
 
-class RpmInvalidRootException : public RpmException
+class ZYPP_API RpmInvalidRootException : public RpmException
 {
 public:
   /** Ctor taking message.
@@ -100,7 +100,7 @@ private:
   std::string _dbpath;
 };
 
-class RpmAccessBlockedException : public RpmException
+class ZYPP_API RpmAccessBlockedException : public RpmException
 {
 public:
   RpmAccessBlockedException( const Pathname & root_r,
@@ -126,7 +126,7 @@ private:
   std::string _dbpath;
 };
 
-class RpmSubprocessException : public RpmException
+class ZYPP_API RpmSubprocessException : public RpmException
 {
 public:
   RpmSubprocessException(std::string  errmsg_r)
@@ -141,7 +141,7 @@ private:
   std::string _errmsg;
 };
 
-class RpmInitException : public RpmException
+class ZYPP_API RpmInitException : public RpmException
 {
 public:
   RpmInitException(const Pathname & root_r,
@@ -159,7 +159,7 @@ private:
   std::string _dbpath;
 };
 
-class RpmDbOpenException : public RpmException
+class ZYPP_API RpmDbOpenException : public RpmException
 {
 public:
   RpmDbOpenException(const Pathname & root_r,
@@ -177,7 +177,7 @@ private:
   std::string _dbpath;
 };
 
-class RpmDbAlreadyOpenException : public RpmException
+class ZYPP_API RpmDbAlreadyOpenException : public RpmException
 {
 public:
   RpmDbAlreadyOpenException(const Pathname & old_root_r,
@@ -201,7 +201,7 @@ private:
   std::string _new_dbpath;
 };
 
-class RpmDbNotOpenException : public RpmException
+class ZYPP_API RpmDbNotOpenException : public RpmException
 {
 public:
   RpmDbNotOpenException()
@@ -214,7 +214,7 @@ protected:
 private:
 };
 
-class RpmDbConvertException : public RpmException
+class ZYPP_API RpmDbConvertException : public RpmException
 {
 public:
   RpmDbConvertException()
@@ -227,7 +227,7 @@ protected:
 private:
 };
 
-class RpmNullDatabaseException : public RpmException
+class ZYPP_API RpmNullDatabaseException : public RpmException
 {
 public:
   RpmNullDatabaseException()
@@ -240,7 +240,7 @@ protected:
 private:
 };
 
-class RpmTransactionFailedException : public RpmException
+class ZYPP_API RpmTransactionFailedException : public RpmException
 {
 public:
   RpmTransactionFailedException(std::string  errmsg_r)

--- a/zypp/target/rpm/RpmHeader.h
+++ b/zypp/target/rpm/RpmHeader.h
@@ -58,7 +58,7 @@ struct FileInfo
  *
  * <B>NEVER create <code>RpmHeader</code> from a NULL <code>Header</code>! </B>
  **/
-class RpmHeader : public BinHeader
+class ZYPP_API RpmHeader : public BinHeader
 {
 public:
   using Ptr = intrusive_ptr<RpmHeader>;

--- a/zypp/target/rpm/librpmDb.h
+++ b/zypp/target/rpm/librpmDb.h
@@ -84,7 +84,7 @@ private:
   /**
    * Whether access is blocked (no _defaultDb will be available).
    **/
-  static bool _dbBlocked;
+  static bool _dbBlocked ZYPP_API;
 
   /**
    * For internal use. Pointer returned should immediately be
@@ -199,7 +199,7 @@ public:
    * @return The number of outstandig references to the database, 0 if
    * if database was physically closed.
    **/
-  static unsigned dbRelease( bool force_r = false );
+  static unsigned dbRelease( bool force_r = false ) ZYPP_API;
 
   /**
    * Blocks further access to rpmdb. Basically the same as @ref dbRelease( true ),
@@ -208,7 +208,7 @@ public:
    * @return The number of outstandig references to the database, 0 if
    * if database was physically closed.
    **/
-  static unsigned blockAccess();
+  static unsigned blockAccess() ZYPP_API;
 
   /**
    * @overload Blocks access iff the database is located at root_r/dbPath_r.
@@ -228,12 +228,12 @@ public:
    * @return The number of outstandig references to the database, 0 if
    * if database was physically closed.
    **/
-  static void unblockAccess();
+  static void unblockAccess() ZYPP_API;
 
   /**
    * @return Whether database access is blocked.
    **/
-  static bool isBlocked()
+  static bool isBlocked() ZYPP_API
   {
     return _dbBlocked;
   }
@@ -340,7 +340,7 @@ public:
  *
  *
  **/
-class librpmDb::db_const_iterator
+class ZYPP_API librpmDb::db_const_iterator
 {
   db_const_iterator & operator=( const db_const_iterator & ); // NO ASSIGNMENT!
   db_const_iterator ( const db_const_iterator & );            // NO COPY!

--- a/zypp/ui/Selectable.h
+++ b/zypp/ui/Selectable.h
@@ -49,7 +49,7 @@ namespace zypp
      * Installed objects are sorted according the installation date, newer install
      * time first.
     */
-    class Selectable : public base::ReferenceCounted, private base::NonCopyable
+    class ZYPP_API Selectable : public base::ReferenceCounted, private base::NonCopyable
     {
       friend std::ostream & operator<<( std::ostream & str, const Selectable & obj );
       friend std::ostream & dumpOn( std::ostream & str, const Selectable & obj );
@@ -574,16 +574,16 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates Selectable Stream output */
-    std::ostream & operator<<( std::ostream & str, const Selectable & obj );
+    std::ostream & operator<<( std::ostream & str, const Selectable & obj ) ZYPP_API;
 
     /** \relates Selectable More verbose stream output */
-    std::ostream & dumpOn( std::ostream & str, const Selectable & obj );
+    std::ostream & dumpOn( std::ostream & str, const Selectable & obj ) ZYPP_API;
 
     /** Solvable to Selectable transform functor.
      * \relates Selectable
      * \relates sat::SolvIterMixin
      */
-    struct asSelectable
+    struct ZYPP_API asSelectable
     {
       using result_type = Selectable_Ptr;
 

--- a/zypp/ui/Status.h
+++ b/zypp/ui/Status.h
@@ -51,7 +51,7 @@ namespace zypp
     ///////////////////////////////////////////////////////////////////
 
     /** \relates Status Enum value as string. */
-    std::string asString( const Status & obj );
+    std::string asString( const Status & obj ) ZYPP_API;
 
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/ui/UserWantedPackages.h
+++ b/zypp/ui/UserWantedPackages.h
@@ -37,7 +37,7 @@ namespace zypp
          * - Pkg is part of a pattern that is required by a pattern the
          *   user wanted to transact
          **/
-        std::set<std::string> userWantedPackageNames();
+        std::set<std::string> userWantedPackageNames() ZYPP_API;
 
     } // namespace ui
 } // namespace zypp

--- a/zypp/zypp_detail/ZYppReadOnlyHack.h
+++ b/zypp/zypp_detail/ZYppReadOnlyHack.h
@@ -23,7 +23,7 @@ namespace zypp
   namespace zypp_readonly_hack
   { /////////////////////////////////////////////////////////////////
 
-    void IWantIt() ZYPP_DEPRECATED;
+    extern void IWantIt() ZYPP_DEPRECATED;
 
     /////////////////////////////////////////////////////////////////
   } // namespace zypp_readonly_hack


### PR DESCRIPTION
Together with a switch to O2 this reduces the resulting binary size by about 10%. The most simple approach has been taken so far by only declaring export visibility on classes instead of individual public functions where possible. Similarly ZYPP_TESTS is added as export declaration for things that are (seemingly) only used by tests.