### PR TITLE
Revert eintrSafeCall behavior to setting errno to 0

### DIFF
--- a/zypp-core/fs/PathInfo.cc
+++ b/zypp-core/fs/PathInfo.cc
@@ -282,11 +282,15 @@ namespace zypp
     //
     ///////////////////////////////////////////////////////////////////
 
-#define logResult MIL << endl, doLogResult
+#define logResult( ... ) doLogResult( __FUNCTION__, __LINE__, __VA_ARGS__ )
     namespace {
       /**  Helper function to log return values. */
-      inline int doLogResult( const int res, const char * rclass = 0 /*errno*/ )
+      inline int doLogResult( const char *function, const int line, const int res, const char * rclass = 0 /*errno*/ )
       {
+        // calling code has started a logline via: `MIL << "Some text";` but did not flush it via endl yet.
+        // we need to do this here but pass the actual function and line to getStream, because the last call to it before
+        // flushing is setting the logging location ( function/line ).
+        zypp::base::logger::getStream( ZYPP_BASE_LOGGER_LOGGROUP, zypp::base::logger::E_MIL, L_BASEFILE, function, line ) << endl;
         if ( res )
         {
           if ( rclass )

--- a/zypp-core/zyppng/base/private/linuxhelpers_p.h
+++ b/zypp-core/zyppng/base/private/linuxhelpers_p.h
@@ -34,9 +34,8 @@ namespace zyppng {
   template<typename Fun, typename RestartCb, typename... Args >
   auto eintrSafeCallEx ( const Fun &function, const RestartCb &restartCb, Args&&... args ) {
     int res = 0;
-    int oerrno = errno;
     while ( true ) {
-      errno = oerrno;
+      errno = 0;
       res = std::invoke(function, args... );
       if ( res == -1 && errno == EINTR ) {
         std::invoke( restartCb );


### PR DESCRIPTION
We attempted to fix a issue with logging in PathInfo.cc via restoring the original errno after leaving eintrSafeCall. This turned out to break code relying on errno being cleared and code that relies on checking errno after eintrSafeCall for errors other than EINTR.

This commit fixes the logging and the problems with eintrSafeCall.