### PR TITLE
zypp-tui: Make sure translated texts use the correct textdomain

### DIFF
--- a/zypp-tui/Table.cc
+++ b/zypp-tui/Table.cc
@@ -14,6 +14,7 @@
 #include <zypp/base/LogTools.h>
 #include <zypp/base/String.h>
 #include <zypp/base/DtorReset.h>
+#include <zypp-core/base/Gettext.h>
 
 #include <zypp-tui/Application>
 #include <zypp-tui/utils/colors.h>
@@ -27,6 +28,8 @@
 #define ZYPP_BASE_LOGGER_LOGGROUP "zypper"
 
 namespace ztui {
+
+const char * asYesNo( bool val_r ) { return val_r ? _("Yes") : _("No"); }
 
 TableLineStyle Table::defaultStyle = Ascii;
 

--- a/zypp-tui/Table.h
+++ b/zypp-tui/Table.h
@@ -26,7 +26,6 @@
 
 #include <zypp/base/String.h>
 #include <zypp/base/Exception.h>
-#include <zypp-core/base/Gettext.h>
 #include <zypp/sat/Solvable.h>
 #include <zypp/ui/Selectable.h>
 
@@ -35,7 +34,7 @@
 
 namespace ztui {
 
-inline const char * asYesNo( bool val_r ) { return val_r ? _("Yes") : _("No"); }
+const char * asYesNo( bool val_r );  ///> _("Yes") or _("No")
 
 /** Custom sort index type for table rows representing solvables (like detailed search results). */
 using SolvableCSI = std::pair<zypp::sat::Solvable, zypp::ui::Selectable::picklist_size_type>;

--- a/zypp-tui/output/Out.cc
+++ b/zypp-tui/output/Out.cc
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <sstream>
 
-//#include <zypp/AutoDispose.h>
+#include <zypp-core/base/Gettext.h>
 
 #include "Out.h"
 #include <zypp-tui/Table.h>
@@ -20,6 +20,17 @@
 #include "Utf8.h"
 
 namespace ztui {
+
+  namespace text {
+    // translator: usually followed by a ' ' and some explanatory text
+    ColorString tagNote() { return HIGHLIGHTString(_("Note:") ); }
+    // translator: usually followed by a ' ' and some explanatory text
+    ColorString tagWarning() { return MSG_WARNINGString(_("Warning:") ); }
+    // translator: usually followed by a ' ' and some explanatory text
+    ColorString tagError() { return MSG_ERRORString(_("Error:") ); }
+
+    const char * qContinue() { return _("Continue?"); }
+  }
 
 ///////////////////////////////////////////////////////////////////
 namespace out

--- a/zypp-tui/output/Out.h
+++ b/zypp-tui/output/Out.h
@@ -26,7 +26,6 @@
 #include <utility>
 #include <zypp-core/base/DefaultIntegral>
 #include <zypp-core/base/DtorReset>
-#include <zypp-core/base/Gettext.h>
 #include <zypp-core/Url.h>
 #include <zypp-core/TriBool.h>
 #include <zypp-core/ui/ProgressData>
@@ -47,15 +46,10 @@ enum class ProgressEnd { done, attention, error };
 
 namespace text
 {
-  // translator: usually followed by a ' ' and some explanatory text
-  inline ColorString tagNote() { return HIGHLIGHTString(_("Note:") ); }
-  // translator: usually followed by a ' ' and some explanatory text
-  inline ColorString tagWarning() { return MSG_WARNINGString(_("Warning:") ); }
-  // translator: usually followed by a ' ' and some explanatory text
-  inline ColorString tagError() { return MSG_ERRORString(_("Error:") ); }
-
-  inline const char * qContinue() { return _("Continue?"); }
-
+  ColorString tagNote();    ///< translated "Note:" highlighted
+  ColorString tagWarning(); ///< translated "Warning:" warning color
+  ColorString tagError();   ///< translated "Error:" error color
+  const char * qContinue(); ///< translated "Continue?"
 
   /** Simple join of two string types */
   template <class Tltext, class Trtext>

--- a/zypp-tui/output/OutNormal.cc
+++ b/zypp-tui/output/OutNormal.cc
@@ -17,6 +17,7 @@
 #include <zypp-core/ByteCount.h> // for download progress reporting
 #include <zypp-core/base/Logger.h>
 #include <zypp-core/base/String.h> // for toUpper()
+#include <zypp-core/base/Gettext.h>
 
 #include <zypp-tui/utils/colors.h>
 #include <zypp-tui/output/AliveCursor.h>

--- a/zypp/CMakeLists.txt
+++ b/zypp/CMakeLists.txt
@@ -980,6 +980,10 @@ macro( ADDZYPPLIB LIBNAME )
   TARGET_LINK_LIBRARIES(${LIBNAME} zypp-core )
   TARGET_LINK_LIBRARIES(${LIBNAME} zypp-protobuf )
 
+  # CAUTION, link zypp-tui.a at last, to prevent undefined references
+  # in case tui functions are used in libzypp.
+  TARGET_LINK_LIBRARIES(${LIBNAME} zypp-tui )
+
   TARGET_LINK_LIBRARIES(${LIBNAME} ${UTIL_LIBRARY} )
   TARGET_LINK_LIBRARIES(${LIBNAME} ${RPM_LIBRARY} )
   TARGET_LINK_LIBRARIES(${LIBNAME} ${GETTEXT_LIBRARIES} )


### PR DESCRIPTION
Public header files must not expose zypp-core/base/Gettext.h! (any!, not just zypp-tui's)

Otherwise our gettext macros may accidentally overwrite the application's macros, or get overwritten by the application's. Both leads to text being looked up in the wrong textdomain.