### PR TITLE
fix rpmdb iterator usage

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -181,7 +181,7 @@ namespace zypp
     bool lsofNoOptKi()
     {
       using target::rpm::librpmDb;
-      librpmDb::db_const_iterator it;
+      librpmDb::db_const_iterator it( "/" );
       return( it.findPackage( "lsof" ) && it->tag_edition() < Edition("4.90") && !it->tag_provides().count( Capability("backported-option-Ki") ) );
     }
 

--- a/zypp/target/CommitPackageCache.cc
+++ b/zypp/target/CommitPackageCache.cc
@@ -37,12 +37,15 @@ namespace zypp
       ///////////////////////////////////////////////////////////////////
       /// \class QueryInstalledEditionHelper
       /// \short Helper for PackageProvider queries during download.
+      /// Queries the exact version of a currently installed package
+      /// in context(/) which may then be used by \ref applydeltarpm
+      /// to build a final rpm.
       ///////////////////////////////////////////////////////////////////
       struct QueryInstalledEditionHelper
       {
         bool operator()( const std::string & name_r, const Edition & ed_r, const Arch & arch_r ) const
         {
-          rpm::librpmDb::db_const_iterator it;
+          rpm::librpmDb::db_const_iterator it( "/" );
           for ( it.findByName( name_r ); *it; ++it )
           {
             if ( arch_r == it->tag_arch()

--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -165,7 +165,7 @@ namespace zypp
               _scripts = std::nullopt;
             }
 
-            rpm::librpmDb::db_const_iterator it;
+            rpm::RpmDb::db_const_iterator it { rpm_r.dbConstIterator() };
             recallFromDumpfile( _dumpfile->_dumpfile, [&]( const std::string& n_r, const std::string& v_r, const std::string& r_r, const std::string& a_r ) -> void {
               if ( it.findPackage( n_r, Edition( v_r, r_r ) ) && headerHasPosttrans( *it ) )
                 collectScriptFromHeader( *it );
@@ -240,7 +240,7 @@ namespace zypp
             str::Format fmtScriptFailedMsg { "warning: %%posttrans(%1%) scriptlet failed, exit status %2%\n" };
             str::Format fmtPosttrans { "%%posttrans(%1%)" };
 
-            rpm::librpmDb::db_const_iterator it;  // Open DB only once
+            rpm::RpmDb::db_const_iterator it { rpm_r.dbConstIterator() }; // Open DB only once
             while ( ! _scripts->empty() )
             {
               const auto &scriptPair = _scripts->front();

--- a/zypp/target/TargetImpl.cc
+++ b/zypp/target/TargetImpl.cc
@@ -1454,8 +1454,6 @@ namespace zypp
       // Remove/install packages.
       ///////////////////////////////////////////////////////////////////
 
-      bool singleTransMode = policy_r.singleTransModeEnabled();
-
       DBG << "commit log file is set to: " << HistoryLog::fname() << endl;
       if ( ! policy_r.dryRun() || policy_r.downloadMode() == DownloadOnly )
       {

--- a/zypp/target/rpm/librpmDb.cc
+++ b/zypp/target/rpm/librpmDb.cc
@@ -373,7 +373,7 @@ public:
 // Former ZYPP_API used this as default ctor (dbptr_r == nullptr).
 // (dbptr_r!=nullptr) is not possible because librpmDb is not in ZYPP_API.
 librpmDb::db_const_iterator::db_const_iterator( librpmDb::constPtr dbptr_r )
-: db_const_iterator()
+: db_const_iterator( "/" )
 {}
 #endif
 

--- a/zypp/target/rpm/librpmDb.h
+++ b/zypp/target/rpm/librpmDb.h
@@ -222,8 +222,11 @@ public:
 #endif
 
 public:
-  /** Open the default rpmdb below the host system (at /). */
-  db_const_iterator();
+  /** Open the default rpmdb below the host system (at /).
+   * \deprecated It's preferred to explicitly tell the root directory
+   * of the system whose database you want to query.
+   */
+  db_const_iterator() ZYPP_DEPRECATED;
 
   /** Open the default rpmdb below the system at \a root_r. */
   explicit db_const_iterator( const Pathname & root_r );


### PR DESCRIPTION
After deprecating the db_const_iterator default ctor, the fix is straight forward. 
Either we need / or we need to follow the current RpmDb.

The test however shows too any dbopen/close calls. I'll add a fix for this ASAP.