### PR TITLE
Require CMake 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 PROJECT(LIBZYPP)
 SET( PACKAGE "libzypp" )

--- a/libzypp.spec.cmake
+++ b/libzypp.spec.cmake
@@ -90,7 +90,7 @@ Recommends:     logrotate
 # lsof is used for 'zypper ps':
 Recommends:     lsof
 %endif
-BuildRequires:  cmake >= 3.1
+BuildRequires:  cmake >= 3.5
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  pkgconfig(libudev)
 %if 0%{?suse_version} >= 1330


### PR DESCRIPTION
Newer versions of CMake warn that support for CMake < 3.5 is deprecated.