### PR TITLE
Fix glib install

### DIFF
--- a/zypp-glib/CMakeLists.txt
+++ b/zypp-glib/CMakeLists.txt
@@ -106,6 +106,8 @@ TARGET_LINK_LIBRARIES( zypp-glib zypp-allsym )
 target_link_libraries( zypp-glib ${LIBGOBJECT_LIBRARIES} )
 #target_link_libraries( zypp-glib ${LIBGIO_LIBRARIES} )
 
+INSTALL(TARGETS zypp-glib LIBRARY DESTINATION ${LIB_INSTALL_DIR} )
+
 INCLUDE(GenerateExportHeader)
 message("Exporting experimental libzypp-ng API")
 GENERATE_EXPORT_HEADER(


### PR DESCRIPTION
Without change the library is not installed as part of make install when glib is enabled.