### PR TITLE
Use std::shared_ptr and std::weak_ptr instead of their ancestors from Boost

### DIFF
--- a/tests/lib/FtpServer.cc
+++ b/tests/lib/FtpServer.cc
@@ -314,7 +314,7 @@ public:
 
     filesystem::TmpDir _workingDir;
     zypp::Pathname _docroot;
-    zypp::shared_ptr<std::thread> _thrd;
+    std::shared_ptr<std::thread> _thrd;
 
     unsigned int _port;
     int _wakeupPipe[2];

--- a/tests/lib/WebServer.cc
+++ b/tests/lib/WebServer.cc
@@ -24,6 +24,7 @@
 
 #include <thread>
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <condition_variable>
 #include <fastcgi/fcgiapp.h>
@@ -449,7 +450,7 @@ public:
 
     filesystem::TmpDir _workingDir;
     zypp::Pathname _docroot;
-    zypp::shared_ptr<std::thread> _thrd;
+    std::shared_ptr<std::thread> _thrd;
     std::map<std::string, WebServer::RequestHandler> _handlers;
     WebServer::RequestHandler _defaultHandler;
     unsigned int _port;

--- a/zypp-core/AutoDispose.h
+++ b/zypp-core/AutoDispose.h
@@ -14,6 +14,7 @@
 
 #include <iosfwd>
 #include <boost/call_traits.hpp>
+#include <memory>
 #include <utility>
 
 #include <zypp-core/base/NonCopyable.h>
@@ -196,7 +197,7 @@ namespace zypp
         Dispose    _dispose;
       };
 
-      shared_ptr<Impl> _pimpl;
+      std::shared_ptr<Impl> _pimpl;
     };
 
     template<>
@@ -261,7 +262,7 @@ namespace zypp
         }
         Dispose    _dispose;
       };
-      shared_ptr<Impl> _pimpl;
+      std::shared_ptr<Impl> _pimpl;
     };
 
   /*!

--- a/zypp-core/Digest.cc
+++ b/zypp-core/Digest.cc
@@ -23,6 +23,7 @@
 #include <openssl/provider.h>
 #endif
 
+#include <memory>
 #include <string>
 #include <string.h>
 
@@ -65,7 +66,7 @@ namespace zypp {
       P &operator=(P &&) = delete;
 
       public:
-        using EvpDataPtr = zypp::shared_ptr<EVP_MD_CTX>;
+        using EvpDataPtr = std::shared_ptr<EVP_MD_CTX>;
         P();
         ~P();
 

--- a/zypp-core/ShutdownLock.cc
+++ b/zypp-core/ShutdownLock.cc
@@ -3,6 +3,7 @@
 #include <zypp-core/base/LogTools.h>
 #include <zypp-core/ExternalProgram.h>
 #include <iostream>
+#include <memory>
 #include <signal.h>
 
 zypp::ShutdownLock::ShutdownLock(const std::string &who, const std::string &reason)
@@ -22,7 +23,7 @@ zypp::ShutdownLock::ShutdownLock(const std::string &who, const std::string &reas
       "/usr/bin/cat",
       NULL
     };
-    _prog = shared_ptr<ExternalProgramWithSeperatePgid>( new ExternalProgramWithSeperatePgid( argv, ExternalProgram::Discard_Stderr ) );
+    _prog = std::shared_ptr<ExternalProgramWithSeperatePgid>( new ExternalProgramWithSeperatePgid( argv, ExternalProgram::Discard_Stderr ) );
   } catch (...) {
   }
 }

--- a/zypp-core/ShutdownLock_p.h
+++ b/zypp-core/ShutdownLock_p.h
@@ -13,6 +13,7 @@
 #ifndef ZYPP_SHUTDOWNLOCK_P_H_INCLUDED
 #define ZYPP_SHUTDOWNLOCK_P_H_INCLUDED
 
+#include <memory>
 #include <string>
 
 #include <zypp-core/Globals.h>
@@ -35,7 +36,7 @@ public:
    ~ShutdownLock();
 
 private:
-   shared_ptr<ExternalProgramWithSeperatePgid> _prog;
+   std::shared_ptr<ExternalProgramWithSeperatePgid> _prog;
 
 };
 

--- a/zypp-core/UserData.h
+++ b/zypp-core/UserData.h
@@ -14,6 +14,7 @@
 #include <iosfwd>
 #include <string>
 #include <map>
+#include <memory>
 #include <boost/any.hpp>
 #include <ostream>
 
@@ -223,7 +224,7 @@ namespace zypp
 
     private:
       ContentType _type;
-      mutable shared_ptr<DataType> _dataP;
+      mutable std::shared_ptr<DataType> _dataP;
     };
 
     /** \relates UserData Stream output */

--- a/zypp-core/base/LogControl.cc
+++ b/zypp-core/base/LogControl.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <mutex>
 #include <map>
+#include <memory>
 
 #include <zypp-core/base/Logger.h>
 #include <zypp-core/base/LogControl.h>
@@ -607,14 +608,14 @@ namespace zypp
         }
 
         /** NULL _lineWriter indicates no loggin. */
-        void setLineWriter( const shared_ptr<LogControl::LineWriter> & writer_r )
+        void setLineWriter( const std::shared_ptr<LogControl::LineWriter> & writer_r )
         { LogThread::instance().setLineWriter( writer_r ); }
 
-        shared_ptr<LogControl::LineWriter> getLineWriter() const
+        std::shared_ptr<LogControl::LineWriter> getLineWriter() const
         { return LogThread::instance().getLineWriter(); }
 
         /** Assert \a _lineFormater is not NULL. */
-        void setLineFormater( const shared_ptr<LogControl::LineFormater> & format_r )
+        void setLineFormater( const std::shared_ptr<LogControl::LineFormater> & format_r )
         {
           if ( format_r )
             _lineFormater = format_r;
@@ -625,11 +626,11 @@ namespace zypp
         void logfile( const Pathname & logfile_r, mode_t mode_r = 0640 )
         {
           if ( logfile_r.empty() )
-            setLineWriter( shared_ptr<LogControl::LineWriter>() );
+            setLineWriter( std::shared_ptr<LogControl::LineWriter>() );
           else if ( logfile_r == Pathname( "-" ) )
-            setLineWriter( shared_ptr<LogControl::LineWriter>(new log::StderrLineWriter) );
+            setLineWriter( std::shared_ptr<LogControl::LineWriter>(new log::StderrLineWriter) );
           else
-            setLineWriter( shared_ptr<LogControl::LineWriter>(new log::FileLineWriter(logfile_r, mode_r)) );
+            setLineWriter( std::shared_ptr<LogControl::LineWriter>(new log::FileLineWriter(logfile_r, mode_r)) );
         }
 
       private:
@@ -639,7 +640,7 @@ namespace zypp
         bool         _logToPPIDMode = false; ///< Hint for formatter to use the PPID and always show the thread name
         mutable TriBool _hideThreadName = indeterminate;	///< Hint for Formater whether to hide the thread name.
 
-        shared_ptr<LogControl::LineFormater> _lineFormater;
+        std::shared_ptr<LogControl::LineFormater> _lineFormater;
 
       public:
         /** Provide the log stream to write (logger interface) */
@@ -685,7 +686,7 @@ namespace zypp
         }
 
       private:
-        using StreamPtr = shared_ptr<Loglinestream>;
+        using StreamPtr = std::shared_ptr<Loglinestream>;
         using StreamSet = std::map<LogLevel, StreamPtr>;
         using StreamTable = std::map<std::string, StreamSet>;
         /** one streambuffer per group and level */
@@ -700,7 +701,7 @@ namespace zypp
 
           if ( getenv("ZYPP_PROFILING") )
           {
-            shared_ptr<LogControl::LineFormater> formater(new ProfilingFormater);
+            std::shared_ptr<LogControl::LineFormater> formater(new ProfilingFormater);
             setLineFormater(formater);
           }
         }
@@ -875,7 +876,7 @@ namespace zypp
       impl->logfile( logfile_r, mode_r );
     }
 
-    shared_ptr<LogControl::LineWriter> LogControl::getLineWriter() const
+    std::shared_ptr<LogControl::LineWriter> LogControl::getLineWriter() const
     {
       auto impl = LogControlImpl::instance();
       if ( !impl )
@@ -884,7 +885,7 @@ namespace zypp
       return impl->getLineWriter();
     }
 
-    void LogControl::setLineWriter( const shared_ptr<LineWriter> & writer_r )
+    void LogControl::setLineWriter( const std::shared_ptr<LineWriter> & writer_r )
     {
       auto impl = LogControlImpl::instance();
       if ( !impl )
@@ -892,7 +893,7 @@ namespace zypp
       impl->setLineWriter( writer_r );
     }
 
-    void LogControl::setLineFormater( const shared_ptr<LineFormater> & formater_r )
+    void LogControl::setLineFormater( const std::shared_ptr<LineFormater> & formater_r )
     {
       auto impl = LogControlImpl::instance();
       if ( !impl )
@@ -910,7 +911,7 @@ namespace zypp
       auto impl = LogControlImpl::instance();
       if ( !impl )
         return;
-      impl->setLineWriter( shared_ptr<LineWriter>() );
+      impl->setLineWriter( std::shared_ptr<LineWriter>() );
     }
 
     void LogControl::logToStdErr()
@@ -918,7 +919,7 @@ namespace zypp
       auto impl = LogControlImpl::instance();
       if ( !impl )
         return;
-      impl->setLineWriter( shared_ptr<LineWriter>( new log::StderrLineWriter ) );
+      impl->setLineWriter( std::shared_ptr<LineWriter>( new log::StderrLineWriter ) );
     }
 
     void base::LogControl::emergencyShutdown()

--- a/zypp-core/base/LogControl.cc
+++ b/zypp-core/base/LogControl.cc
@@ -96,12 +96,12 @@ namespace zypp
       return t;
     }
 
-    void setLineWriter ( boost::shared_ptr<log::LineWriter> writer ) {
+    void setLineWriter ( std::shared_ptr<log::LineWriter> writer ) {
       std::lock_guard lk( _lineWriterLock );
       _lineWriter = std::move(writer);
     }
 
-    boost::shared_ptr<log::LineWriter> getLineWriter () {
+    std::shared_ptr<log::LineWriter> getLineWriter () {
       std::lock_guard lk( _lineWriterLock );
       auto lw = _lineWriter;
       return lw;
@@ -207,12 +207,12 @@ namespace zypp
     std::thread _thread;
     zyppng::Wakeup _stopSignal;
 
-    // since the public API uses boost::shared_ptr we can not use the atomic
+    // since the public API uses std::shared_ptr we can not use the atomic
     // functionalities provided in std.
     // this lock type can be used safely in signals
     SpinLock _lineWriterLock;
-    // boost shared_ptr has a lock free implementation of reference counting so it can be used from signal handlers as well
-    boost::shared_ptr<log::LineWriter> _lineWriter{ nullptr };
+    // std::shared_ptr has a lock free implementation of reference counting so it can be used from signal handlers as well
+    std::shared_ptr<log::LineWriter> _lineWriter{ nullptr };
   };
 
   class LogClient

--- a/zypp-core/base/LogControl.h
+++ b/zypp-core/base/LogControl.h
@@ -13,6 +13,7 @@
 #define ZYPP_BASE_LOGCONTROL_H
 
 #include <iosfwd>
+#include <memory>
 #include <ostream> //for std::endl
 
 #include <zypp-core/base/Logger.h>
@@ -73,7 +74,7 @@ namespace zypp
     {
       FileLineWriter( const Pathname & file_r, mode_t mode_r = 0 );
       protected:
-        shared_ptr<void> _outs;
+        std::shared_ptr<void> _outs;
     };
 
     /////////////////////////////////////////////////////////////////
@@ -127,7 +128,7 @@ namespace zypp
        * If you want to format loglines by yourself. NULL installs the
        * default formater.
       */
-      void setLineFormater( const shared_ptr<LineFormater> & formater_r );
+      void setLineFormater( const std::shared_ptr<LineFormater> & formater_r );
 
       /*!
        * Sets a special log mode that uses the ppid in the log output and always shows the
@@ -167,14 +168,14 @@ namespace zypp
 
     public:
       /** Get the current LineWriter */
-      shared_ptr<LineWriter> getLineWriter() const;
+      std::shared_ptr<LineWriter> getLineWriter() const;
 
       /** Assign a LineWriter.
        * If you want to log the (formated) loglines by yourself.
        * NULL turns off logging (same as logNothing)
        * \see \ref log::LineWriter
        */
-      void setLineWriter( const shared_ptr<LineWriter> & writer_r );
+      void setLineWriter( const std::shared_ptr<LineWriter> & writer_r );
 
     public:
       /** Turn on excessive logging for the lifetime of this object.*/
@@ -189,7 +190,7 @@ namespace zypp
       */
       struct ZYPP_API TmpLineWriter
       {
-        TmpLineWriter( const shared_ptr<LineWriter> & writer_r = shared_ptr<LineWriter>() )
+        TmpLineWriter( const std::shared_ptr<LineWriter> & writer_r = std::shared_ptr<LineWriter>() )
           : _writer( LogControl::instance().getLineWriter() )
         { LogControl::instance().setLineWriter( writer_r ); }
 
@@ -201,13 +202,13 @@ namespace zypp
         template<class TLineWriter>
         TmpLineWriter( TLineWriter * _allocated_r )
           : _writer( LogControl::instance().getLineWriter() )
-        { LogControl::instance().setLineWriter( shared_ptr<LineWriter>( _allocated_r ) ); }
+        { LogControl::instance().setLineWriter( std::shared_ptr<LineWriter>( _allocated_r ) ); }
 
         ~TmpLineWriter()
         { LogControl::instance().setLineWriter( _writer ); }
 
       private:
-        shared_ptr<LineWriter> _writer;
+        std::shared_ptr<LineWriter> _writer;
       };
 
     private:

--- a/zypp-core/base/PtrTypes.h
+++ b/zypp-core/base/PtrTypes.h
@@ -196,8 +196,8 @@ namespace zypp
       template<class D>
         struct Shared
         {
-          using PtrType = shared_ptr<D>;
-          using constPtrType = shared_ptr<const D>;
+          using PtrType = std::shared_ptr<D>;
+          using constPtrType = std::shared_ptr<const D>;
           /** Check whether pointer is not shared. */
           bool unique( const constPtrType & ptr_r )
           { return !ptr_r || ptr_r.unique(); }

--- a/zypp-core/base/PtrTypes.h
+++ b/zypp-core/base/PtrTypes.h
@@ -18,8 +18,6 @@
 
 #include <zypp/Globals.h>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 ///////////////////////////////////////////////////////////////////
@@ -89,12 +87,6 @@ namespace zypp
     /** \class scoped_ptr */
     using boost::scoped_ptr;
 
-    /** \class shared_ptr */
-    using boost::shared_ptr;
-
-    /** \class weak_ptr */
-    using boost::weak_ptr;
-
     /** \class intrusive_ptr */
     using boost::intrusive_ptr;
 
@@ -128,35 +120,6 @@ namespace std
   // Otherwise we had to define an output operator always in the same namespace
   // as the typedef (else g++ will just print the pointer value).
 
-  /** \relates zypp::shared_ptr Stream output. */
-  template<class D>
-  inline std::ostream & operator<<( std::ostream & str, const zypp::shared_ptr<D> & obj )
-  {
-    if ( obj )
-      return str << *obj;
-    return str << std::string("NULL");
-  }
-  /** \overload specialize for void */
-  template<>
-  inline std::ostream & operator<<( std::ostream & str, const zypp::shared_ptr<void> & obj )
-  {
-    if ( obj )
-      return str << zypp::str::form( "%p", static_cast<void*>(obj.get()) );
-    return str << std::string("NULL");
-  }
-
-  /** \relates zypp::shared_ptr Stream output. */
-  template<class D>
-  inline std::ostream & dumpOn( std::ostream & str, const zypp::shared_ptr<D> & obj )
-  {
-    if ( obj )
-      return dumpOn( str, *obj );
-    return str << std::string("NULL");
-  }
-  /** \overload specialize for void */
-  template<>
-  inline std::ostream & dumpOn( std::ostream & str, const zypp::shared_ptr<void> & obj )
-  { return str << obj; }
 
   /** \relates zypp::intrusive_ptr Stream output. */
   template<class D>

--- a/zypp-core/base/String.h
+++ b/zypp-core/base/String.h
@@ -15,6 +15,7 @@
 #include <cstring>
 
 #include <iosfwd>
+#include <memory>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -157,7 +158,7 @@ namespace zypp
         { return p->asString(); }
 
     template<class Tp>
-        inline std::string asString( const weak_ptr<Tp> &p )
+        inline std::string asString( const std::weak_ptr<Tp> &p )
         { return p->asString(); }
 
     template<>

--- a/zypp-core/base/dtorreset.h
+++ b/zypp-core/base/dtorreset.h
@@ -12,7 +12,7 @@
 #ifndef ZYPP_CORE_BASE_DTORRESET_H
 #define ZYPP_CORE_BASE_DTORRESET_H
 
-#include <zypp-core/base/PtrTypes.h>
+#include <memory>
 
 ///////////////////////////////////////////////////////////////////
 namespace zypp
@@ -75,7 +75,7 @@ namespace zypp
         TVar & _var;
         TVal   _val;
       };
-    shared_ptr<void> _pimpl;
+    std::shared_ptr<void> _pimpl;
   };
   ///////////////////////////////////////////////////////////////////
 

--- a/zypp-core/base/inputstream.cc
+++ b/zypp-core/base/inputstream.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <zypp-core/base/LogTools.h>
 
 #include "inputstream.h"
@@ -40,15 +41,15 @@ namespace zypp
       return -1;
     }
 
-    inline shared_ptr<std::istream> streamForFile ( const Pathname & file_r )
+    inline std::shared_ptr<std::istream> streamForFile ( const Pathname & file_r )
     {
 #ifdef ENABLE_ZCHUNK_COMPRESSION
       if ( const auto zType = filesystem::zipType( file_r ); zType == filesystem::ZT_ZCHNK )
-        return shared_ptr<std::istream>( new ifzckstream( file_r.asString().c_str() ) );
+        return std::shared_ptr<std::istream>( new ifzckstream( file_r.asString().c_str() ) );
 #endif
 
       //fall back to gzstream
-      return shared_ptr<std::istream>( new ifgzstream( file_r.asString().c_str() ) );
+      return std::shared_ptr<std::istream>( new ifgzstream( file_r.asString().c_str() ) );
     }
 
     /////////////////////////////////////////////////////////////////

--- a/zypp-core/base/inputstream.h
+++ b/zypp-core/base/inputstream.h
@@ -13,6 +13,7 @@
 #define ZYPP_CORE_BASE_INPUTSTREAM_H
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp-core/base/PtrTypes.h>
 #include <zypp-core/base/DefaultIntegral>
@@ -128,9 +129,9 @@ namespace zypp
     { _size = val_r; }
 
   private:
-    Pathname                 _path;
-    shared_ptr<std::istream> _stream;
-    std::string              _name;
+    Pathname                      _path;
+    std::shared_ptr<std::istream> _stream;
+    std::string                   _name;
     DefaultIntegral<std::streamoff,-1> _size;
   };
   ///////////////////////////////////////////////////////////////////

--- a/zypp-core/onmedialocation.cc
+++ b/zypp-core/onmedialocation.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 //#include <zypp/base/Logger.h>
 
 #include <utility>
@@ -53,8 +54,8 @@ namespace zypp
 
   public:
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl()
-    { static shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
+    static std::shared_ptr<Impl> nullimpl()
+    { static std::shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
     /** clone for RWCOW_pointer */

--- a/zypp-core/rpc/PluginFrame.cc
+++ b/zypp-core/rpc/PluginFrame.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <zypp-core/base/LogTools.h>
 #include <zypp-core/rpc/PluginFrame.h>
@@ -249,9 +250,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
     private:

--- a/zypp-curl/auth/curlauthdata.h
+++ b/zypp-curl/auth/curlauthdata.h
@@ -12,6 +12,8 @@
 #ifndef ZYPP_CURL_AUTH_CURLAUTHDATA_H_INCLUDED
 #define ZYPP_CURL_AUTH_CURLAUTHDATA_H_INCLUDED
 
+#include <memory>
+
 #include <zypp-media/auth/AuthData>
 
 namespace zypp {
@@ -99,7 +101,7 @@ namespace zypp {
       long _auth_type;
     };
 
-    using CurlAuthData_Ptr = shared_ptr<CurlAuthData>;
+    using CurlAuthData_Ptr = std::shared_ptr<CurlAuthData>;
     std::ostream & operator << (std::ostream & str, const CurlAuthData & auth_data);
   }
 }

--- a/zypp-curl/proxyinfo.cc
+++ b/zypp-curl/proxyinfo.cc
@@ -12,6 +12,7 @@
 
 #include "proxyinfo.h"
 #include <iostream>
+#include <memory>
 #include <utility>
 
 #include <zypp/base/Logger.h>
@@ -24,7 +25,7 @@ using namespace zypp::base;
 namespace zypp {
   namespace media {
 
-    shared_ptr<ProxyInfo::Impl> ProxyInfo::Impl::_nullimpl;
+    std::shared_ptr<ProxyInfo::Impl> ProxyInfo::Impl::_nullimpl;
 
     ProxyInfo::ProxyInfo()
 #ifdef WITH_LIBPROXY_SUPPORT

--- a/zypp-curl/proxyinfo.h
+++ b/zypp-curl/proxyinfo.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <list>
+#include <memory>
 
 #include <zypp-core/base/PtrTypes.h>
 
@@ -36,7 +37,7 @@ namespace zypp {
 
       /** Implementation */
       struct Impl;
-      using ImplPtr = shared_ptr<Impl>;
+      using ImplPtr = std::shared_ptr<Impl>;
 
       /** Default Ctor: guess the best available implementation. */
       ProxyInfo();

--- a/zypp-curl/proxyinfo/proxyinfoimpl.h
+++ b/zypp-curl/proxyinfo/proxyinfoimpl.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <list>
+#include <memory>
 
 #include <zypp-core/Url.h>
 #include <zypp-core/base/String.h>
@@ -72,7 +73,7 @@ namespace zypp {
 
     public:
       /** Default Impl: empty sets. */
-      static shared_ptr<Impl> _nullimpl;
+      static std::shared_ptr<Impl> _nullimpl;
     };
 
 

--- a/zypp-curl/transfersettings.cc
+++ b/zypp-curl/transfersettings.cc
@@ -12,6 +12,7 @@
 
 #include "transfersettings.h"
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include <zypp-core/base/String.h>
@@ -55,9 +56,9 @@ namespace zypp
       virtual ~Impl() {}
 
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
 

--- a/zypp-media/auth/authdata.h
+++ b/zypp-media/auth/authdata.h
@@ -15,6 +15,7 @@
 #include <zypp-core/Url.h>
 #include <zypp-core/base/PtrTypes.h>
 
+#include <memory>
 #include <utility>
 
 namespace zypp {
@@ -78,7 +79,7 @@ private:
   std::map<std::string, std::string> _extraValues;
 };
 
-using AuthData_Ptr = shared_ptr<AuthData>;
+using AuthData_Ptr = std::shared_ptr<AuthData>;
 std::ostream & operator << (std::ostream & str, const AuthData & auth_data);
 
 ///////////////////////////////////////////////////////////////////

--- a/zypp-media/ng/providespec.cc
+++ b/zypp-media/ng/providespec.cc
@@ -11,6 +11,7 @@
 */
 
 #include <iostream>
+#include <memory>
 #include <utility>
 #include "providespec.h"
 
@@ -49,8 +50,8 @@ namespace zyppng
 
   public:
     /** Offer default Impl. */
-    static zypp::shared_ptr<Impl> nullimpl()
-    { static zypp::shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
+    static std::shared_ptr<Impl> nullimpl()
+    { static std::shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
 
   private:
     friend ProvideMediaSpec::Impl * zypp::rwcowClone<ProvideMediaSpec::Impl>( const ProvideMediaSpec::Impl * rhs );
@@ -82,8 +83,8 @@ namespace zyppng
 
   public:
     /** Offer default Impl. */
-    static zypp::shared_ptr<Impl> nullimpl()
-    { static zypp::shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
+    static std::shared_ptr<Impl> nullimpl()
+    { static std::shared_ptr<Impl> _nullimpl( new Impl ); return _nullimpl; }
 
   private:
     friend ProvideFileSpec::Impl * zypp::rwcowClone<ProvideFileSpec::Impl>( const ProvideFileSpec::Impl * rhs );

--- a/zypp/Fetcher.cc
+++ b/zypp/Fetcher.cc
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <list>
 #include <map>
+#include <memory>
 
 #include <zypp/base/Easy.h>
 #include <zypp/base/LogControl.h>
@@ -51,7 +52,7 @@ namespace zypp
     DefaultIntegral<bool,false> read;
   };
 
-  using FetcherIndex_Ptr = shared_ptr<FetcherIndex>;
+  using FetcherIndex_Ptr = std::shared_ptr<FetcherIndex>;
 
   /** std::set ordering (less semantic) */
   struct SameFetcherIndex
@@ -111,7 +112,7 @@ namespace zypp
   };
 
   ZYPP_DECLARE_OPERATORS_FOR_FLAGS(FetcherJob::Flags);
-  using FetcherJob_Ptr = shared_ptr<FetcherJob>;
+  using FetcherJob_Ptr = std::shared_ptr<FetcherJob>;
 
   std::ostream & operator<<( std::ostream & str, const FetcherJob_Ptr & obj )
   {
@@ -157,9 +158,9 @@ namespace zypp
                 const ProgressData::ReceiverFnc & progress_receiver );
 
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl()
+    static std::shared_ptr<Impl> nullimpl()
     {
-      static shared_ptr<Impl> _nullimpl( new Impl );
+      static std::shared_ptr<Impl> _nullimpl( new Impl );
       return _nullimpl;
     }
   private:

--- a/zypp/HistoryLogData.h
+++ b/zypp/HistoryLogData.h
@@ -14,6 +14,7 @@
 #define ZYPP_HISTORYLOGDATA_H_
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp-core/Globals.h>
 #include <zypp/Date.h>
@@ -105,8 +106,8 @@ namespace zypp
   class ZYPP_API HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogData>;
-    using constPtr = shared_ptr<const HistoryLogData>;
+    using Ptr = std::shared_ptr<HistoryLogData>;
+    using constPtr = std::shared_ptr<const HistoryLogData>;
 
     using FieldVector = std::vector<std::string>;
     using size_type = FieldVector::size_type;
@@ -199,8 +200,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataInstall : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataInstall>;
-    using constPtr = shared_ptr<const HistoryLogDataInstall>;
+    using Ptr = std::shared_ptr<HistoryLogDataInstall>;
+    using constPtr = std::shared_ptr<const HistoryLogDataInstall>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -239,8 +240,8 @@ namespace zypp
   class ZYPP_API HistoryLogPatchStateChange : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogPatchStateChange>;
-    using constPtr = shared_ptr<const HistoryLogPatchStateChange>;
+    using Ptr = std::shared_ptr<HistoryLogPatchStateChange>;
+    using constPtr = std::shared_ptr<const HistoryLogPatchStateChange>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -283,8 +284,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataRemove : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataRemove>;
-    using constPtr = shared_ptr<const HistoryLogDataRemove>;
+    using Ptr = std::shared_ptr<HistoryLogDataRemove>;
+    using constPtr = std::shared_ptr<const HistoryLogDataRemove>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -318,8 +319,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataRepoAdd : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataRepoAdd>;
-    using constPtr = shared_ptr<const HistoryLogDataRepoAdd>;
+    using Ptr = std::shared_ptr<HistoryLogDataRepoAdd>;
+    using constPtr = std::shared_ptr<const HistoryLogDataRepoAdd>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -349,8 +350,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataRepoRemove : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataRepoRemove>;
-    using constPtr = shared_ptr<const HistoryLogDataRepoRemove>;
+    using Ptr = std::shared_ptr<HistoryLogDataRepoRemove>;
+    using constPtr = std::shared_ptr<const HistoryLogDataRepoRemove>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -378,8 +379,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataRepoAliasChange : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataRepoAliasChange>;
-    using constPtr = shared_ptr<const HistoryLogDataRepoAliasChange>;
+    using Ptr = std::shared_ptr<HistoryLogDataRepoAliasChange>;
+    using constPtr = std::shared_ptr<const HistoryLogDataRepoAliasChange>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -409,8 +410,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataRepoUrlChange : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataRepoUrlChange>;
-    using constPtr = shared_ptr<const HistoryLogDataRepoUrlChange>;
+    using Ptr = std::shared_ptr<HistoryLogDataRepoUrlChange>;
+    using constPtr = std::shared_ptr<const HistoryLogDataRepoUrlChange>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */
@@ -441,8 +442,8 @@ namespace zypp
   class ZYPP_API HistoryLogDataStampCommand : public HistoryLogData
   {
   public:
-    using Ptr = shared_ptr<HistoryLogDataStampCommand>;
-    using constPtr = shared_ptr<const HistoryLogDataStampCommand>;
+    using Ptr = std::shared_ptr<HistoryLogDataStampCommand>;
+    using constPtr = std::shared_ptr<const HistoryLogDataStampCommand>;
     /** Ctor \b moving \a FieldVector (via swap).
      * \throws ParseException if \a fields_r has the wrong \ref HistoryActionID or number of fields.
      */

--- a/zypp/PoolItem.cc
+++ b/zypp/PoolItem.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <zypp/base/Logger.h>
 #include <utility>
 #include <zypp-core/base/DefaultIntegral>
@@ -142,9 +143,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
   };

--- a/zypp/PoolItemBest.h
+++ b/zypp/PoolItemBest.h
@@ -13,6 +13,7 @@
 #define ZYPP_POOLITEMBEST_H
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp/base/PtrTypes.h>
 #include <zypp/base/Function.h>
@@ -150,7 +151,7 @@ namespace zypp
       /** Pointer to implementation */
       const RWCOW_pointer<Impl> & pimpl() const { return *(reinterpret_cast<RWCOW_pointer<Impl>*>( _dont_use_this_use_pimpl.get() )); }
       /** Avoid need to include Impl definition when inlined ctors (due to tepmlate) are provided. */
-      shared_ptr<void> _dont_use_this_use_pimpl;
+      std::shared_ptr<void> _dont_use_this_use_pimpl;
   };
   ///////////////////////////////////////////////////////////////////
 

--- a/zypp/PoolQuery.cc
+++ b/zypp/PoolQuery.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <utility>
 
@@ -1619,7 +1620,7 @@ namespace zypp
         /** Ctor stores the \ref PoolQuery settings.
          * \throw MatchException Any of the exceptions thrown by \ref PoolQuery::Impl::compile.
          */
-        PoolQueryMatcher( const shared_ptr<const PoolQuery::Impl> & query_r )
+        PoolQueryMatcher( const std::shared_ptr<const PoolQuery::Impl> & query_r )
         {
           query_r->compile();
 
@@ -1854,7 +1855,7 @@ namespace zypp
 
   detail::PoolQueryIterator PoolQuery::begin() const
   {
-    return shared_ptr<detail::PoolQueryMatcher>( new detail::PoolQueryMatcher( _pimpl.getPtr() ) );
+    return std::shared_ptr<detail::PoolQueryMatcher>( new detail::PoolQueryMatcher( _pimpl.getPtr() ) );
   }
 
   /////////////////////////////////////////////////////////////////

--- a/zypp/PoolQuery.h
+++ b/zypp/PoolQuery.h
@@ -15,6 +15,7 @@
 #include <iosfwd>
 #include <set>
 #include <map>
+#include <memory>
 
 #include <zypp/base/Regex.h>
 #include <zypp/base/PtrTypes.h>
@@ -531,7 +532,7 @@ namespace zypp
       {}
 
       /** \Ref PoolQuery ctor. */
-      PoolQueryIterator( const shared_ptr<PoolQueryMatcher> & matcher_r )
+      PoolQueryIterator( const std::shared_ptr<PoolQueryMatcher> & matcher_r )
       : _matcher( matcher_r )
       { increment(); }
 
@@ -602,8 +603,8 @@ namespace zypp
       const Matches & matches() const;
 
     private:
-      shared_ptr<PoolQueryMatcher> _matcher;
-      mutable shared_ptr<Matches>  _matches;
+      std::shared_ptr<PoolQueryMatcher> _matcher;
+      mutable std::shared_ptr<Matches>  _matches;
   };
   ///////////////////////////////////////////////////////////////////
 

--- a/zypp/PublicKey.cc
+++ b/zypp/PublicKey.cc
@@ -12,6 +12,7 @@
 #include <climits>
 
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -137,7 +138,7 @@ namespace zypp
 
   public:
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl();
+    static std::shared_ptr<Impl> nullimpl();
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -145,9 +146,9 @@ namespace zypp
     Impl * clone() const;
   };
 
-  shared_ptr<zypp::PublicSubkeyData::Impl> PublicSubkeyData::Impl::nullimpl()
+  std::shared_ptr<zypp::PublicSubkeyData::Impl> PublicSubkeyData::Impl::nullimpl()
   {
-    static shared_ptr<Impl> _nullimpl( new Impl );
+    static std::shared_ptr<Impl> _nullimpl( new Impl );
     return _nullimpl;
   }
 
@@ -212,7 +213,7 @@ namespace zypp
 
   public:
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl();
+    static std::shared_ptr<Impl> nullimpl();
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -220,9 +221,9 @@ namespace zypp
     Impl * clone() const;
   };
 
-  shared_ptr<zypp::PublicKeySignatureData::Impl> PublicKeySignatureData::Impl::nullimpl()
+  std::shared_ptr<zypp::PublicKeySignatureData::Impl> PublicKeySignatureData::Impl::nullimpl()
   {
-    static shared_ptr<Impl> _nullimpl( new Impl );
+    static std::shared_ptr<Impl> _nullimpl( new Impl );
     return _nullimpl;
   }
 
@@ -315,8 +316,8 @@ namespace zypp
 
   public:
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl();
-    static shared_ptr<Impl> fromGpgmeKey(gpgme_key_t rawData);
+    static std::shared_ptr<Impl> nullimpl();
+    static std::shared_ptr<Impl> fromGpgmeKey(gpgme_key_t rawData);
 
   private:
     friend Impl * rwcowClone<Impl>( const Impl * rhs );
@@ -336,20 +337,20 @@ namespace zypp
     return ret;
   }
 
-  shared_ptr<PublicKeyData::Impl> PublicKeyData::Impl::nullimpl()
+  std::shared_ptr<PublicKeyData::Impl> PublicKeyData::Impl::nullimpl()
   {
-    static shared_ptr<Impl> _nullimpl( new Impl );
+    static std::shared_ptr<Impl> _nullimpl( new Impl );
     return _nullimpl;
   }
 
-  shared_ptr<PublicKeyData::Impl> PublicKeyData::Impl::fromGpgmeKey(gpgme_key_t rawData)
+  std::shared_ptr<PublicKeyData::Impl> PublicKeyData::Impl::fromGpgmeKey(gpgme_key_t rawData)
   {
     //gpgme stores almost nothing in the top level key
     //the information we look for is stored in the subkey, where subkey[0]
     //is always the primary key
     gpgme_subkey_t sKey = rawData->subkeys;
     if (sKey) {
-      shared_ptr<PublicKeyData::Impl> data(new Impl);
+      std::shared_ptr<PublicKeyData::Impl> data(new Impl);
       //libzypp expects the date of the latest signature on the first uid
       if ( rawData->uids && rawData->uids->signatures ) {
         data->_created = zypp::Date(rawData->uids->signatures->timestamp);
@@ -402,7 +403,7 @@ namespace zypp
     : _pimpl( Impl::nullimpl() )
   {}
 
-  PublicKeyData::PublicKeyData(shared_ptr<Impl> data)
+  PublicKeyData::PublicKeyData(std::shared_ptr<Impl> data)
     : _pimpl( std::move(data) )
   {}
 
@@ -591,15 +592,15 @@ namespace zypp
       }
 
     private:
-      shared_ptr<filesystem::TmpFile> _dontUseThisPtrDirectly; // shared_ptr ok because TmpFile itself is a refernce type (no COW)
+      std::shared_ptr<filesystem::TmpFile> _dontUseThisPtrDirectly; // shared_ptr ok because TmpFile itself is a reference type (no COW)
       PublicKeyData		_keyData;
       std::list<PublicKeyData>  _hiddenKeys;
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
 

--- a/zypp/PublicKey.h
+++ b/zypp/PublicKey.h
@@ -331,7 +331,7 @@ namespace zypp
     friend class KeyManagerCtx;
     static PublicKeyData fromGpgmeKey(_gpgme_key *data);
 
-    PublicKeyData(shared_ptr<Impl> data);
+    PublicKeyData(std::shared_ptr<Impl> data);
     friend std::ostream & dumpOn( std::ostream & str, const PublicKeyData & obj );
   };
   ///////////////////////////////////////////////////////////////////

--- a/zypp/RepoInfo.h
+++ b/zypp/RepoInfo.h
@@ -13,6 +13,7 @@
 #define ZYPP2_REPOSITORYINFO_H
 
 #include <list>
+#include <memory>
 #include <set>
 
 #include <zypp/base/Iterator.h>
@@ -570,9 +571,9 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates RepoInfo */
-  using RepoInfo_Ptr = shared_ptr<RepoInfo>;
+  using RepoInfo_Ptr = std::shared_ptr<RepoInfo>;
   /** \relates RepoInfo */
-  using RepoInfo_constPtr = shared_ptr<const RepoInfo>;
+  using RepoInfo_constPtr = std::shared_ptr<const RepoInfo>;
   /** \relates RepoInfo */
   using RepoInfoList = std::list<RepoInfo>;
 

--- a/zypp/ResPool.h
+++ b/zypp/ResPool.h
@@ -13,6 +13,7 @@
 #define ZYPP_RESPOOL_H
 
 #include <iosfwd>
+#include <memory>
 #include <utility>
 
 #include <zypp-core/Globals.h>
@@ -325,7 +326,7 @@ namespace zypp
       private:
         friend class pool::PoolImpl;
         /** Factory: \ref ResPool::establishedStates */
-        EstablishedStates( shared_ptr<Impl> pimpl_r )
+        EstablishedStates( std::shared_ptr<Impl> pimpl_r )
         : _pimpl { std::move(pimpl_r) }
         {}
       };

--- a/zypp/ResPoolProxy.cc
+++ b/zypp/ResPoolProxy.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <zypp/base/LogTools.h>
 
@@ -202,9 +203,9 @@ namespace zypp
 
   public:
     /** Offer default Impl. */
-    static shared_ptr<Impl> nullimpl()
+    static std::shared_ptr<Impl> nullimpl()
     {
-      static shared_ptr<Impl> _nullimpl( new Impl );
+      static std::shared_ptr<Impl> _nullimpl( new Impl );
       return _nullimpl;
     }
   };

--- a/zypp/ServiceInfo.h
+++ b/zypp/ServiceInfo.h
@@ -12,6 +12,7 @@
 #ifndef ZYPP_SERVICE_H
 #define ZYPP_SERVICE_H
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -216,9 +217,9 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
 
   /** \relates ServiceInfo */
-  using ServiceInfo_Ptr = shared_ptr<ServiceInfo>;
+  using ServiceInfo_Ptr = std::shared_ptr<ServiceInfo>;
   /** \relates ServiceInfo */
-  using ServiceInfo_constPtr = shared_ptr<const ServiceInfo>;
+  using ServiceInfo_constPtr = std::shared_ptr<const ServiceInfo>;
   /** \relates ServiceInfo */
   using ServiceInfoList = std::list<ServiceInfo>;
 

--- a/zypp/SysContent.cc
+++ b/zypp/SysContent.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <zypp/base/Logger.h>
 
 #include <zypp/SysContent.h>
@@ -71,9 +72,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
 
@@ -212,7 +213,7 @@ namespace zypp
     : _pimpl( new Impl )
     {}
 
-    Reader::Entry::Entry( const shared_ptr<Impl> & pimpl_r )
+    Reader::Entry::Entry( const std::shared_ptr<Impl> & pimpl_r )
     : _pimpl( pimpl_r )
     {}
 
@@ -251,9 +252,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
 
@@ -350,7 +351,7 @@ namespace zypp
 
         void start( const Node & node_r ) override
         {
-          shared_ptr<Reader::Entry::Impl> centry( new Reader::Entry::Impl );
+          std::shared_ptr<Reader::Entry::Impl> centry( new Reader::Entry::Impl );
 
           centry->_kind = node_r.getAttribute("kind").asString();
           centry->_name = node_r.getAttribute("name").asString();

--- a/zypp/SysContent.h
+++ b/zypp/SysContent.h
@@ -14,6 +14,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <memory>
 #include <set>
 
 #include <zypp/base/PtrTypes.h>
@@ -250,7 +251,7 @@ namespace zypp
       const Arch & arch() const;
     public:
       class Impl;
-      Entry( const shared_ptr<Impl> & pimpl_r );
+      Entry( const std::shared_ptr<Impl> & pimpl_r );
     private:
       RW_pointer<Impl> _pimpl;
     };

--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -164,6 +164,7 @@ namespace zypp
   private:
     /** Deleted via shared_ptr */
     friend void ::boost::checked_delete<ZYpp>(ZYpp*) BOOST_NOEXCEPT;	// template<class T> inline void checked_delete(T * x)
+  public:
     /** Dtor */
     ~ZYpp();
   private:

--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -12,6 +12,7 @@
 #ifndef ZYPP_ZYPP_H
 #define ZYPP_ZYPP_H
 #include <iosfwd>
+#include <memory>
 
 #include <zypp/base/NonCopyable.h>
 #include <zypp/base/PtrTypes.h>
@@ -157,7 +158,7 @@ namespace zypp
     /** Factory */
     friend class ZYppFactory;
     using Impl = zypp_detail::ZYppImpl;
-    using Impl_Ptr = shared_ptr<Impl>;
+    using Impl_Ptr = std::shared_ptr<Impl>;
     /** Factory ctor */
     explicit ZYpp( const Impl_Ptr & impl_r );
   private:

--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -59,9 +59,8 @@ namespace zypp
     friend std::ostream & operator<<( std::ostream & str, const ZYpp & obj );
 
   public:
-    // can't get swig working if shared_ptr is without namespace here
-    using Ptr = ::boost::shared_ptr<ZYpp>;
-    using constPtr = ::boost::shared_ptr<const ZYpp>;
+    using Ptr = std::shared_ptr<ZYpp>;
+    using constPtr = std::shared_ptr<const ZYpp>;
 
   public:
 

--- a/zypp/ZYppCallbacks.h
+++ b/zypp/ZYppCallbacks.h
@@ -12,6 +12,8 @@
 #ifndef ZYPP_ZYPPCALLBACKS_H
 #define ZYPP_ZYPPCALLBACKS_H
 
+#include <memory>
+
 #include <zypp/base/EnumClass.h>
 #include <zypp/Callback.h>
 #include <zypp-core/UserData.h>
@@ -352,7 +354,7 @@ namespace zypp
       /** Disbale MediaChangeReport if \a condition_r is \c true.*/
       ScopedDisableMediaChangeReport( bool condition_r = true );
     private:
-      shared_ptr<callback::TempConnect<media::MediaChangeReport> > _guard;
+      std::shared_ptr<callback::TempConnect<media::MediaChangeReport> > _guard;
     };
 
     // progress for downloading a file

--- a/zypp/ZYppFactory.cc
+++ b/zypp/ZYppFactory.cc
@@ -310,7 +310,7 @@ namespace zypp
   ///////////////////////////////////////////////////////////////////
   namespace
   {
-    static weak_ptr<ZYpp>		_theZYppInstance;
+    static std::weak_ptr<ZYpp>		_theZYppInstance;
     static scoped_ptr<ZYppGlobalLock>	_theGlobalLock;		// on/off in sync with _theZYppInstance
 
     ZYppGlobalLock & globalLock()

--- a/zypp/ZYppFactory.cc
+++ b/zypp/ZYppFactory.cc
@@ -15,6 +15,7 @@ extern "C"
 }
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <signal.h>
 
 #include <zypp/base/Logger.h>
@@ -153,7 +154,7 @@ namespace zypp
     bool	_cleanLock;
 
   private:
-    using ScopedGuard = shared_ptr<void>;
+    using ScopedGuard = std::shared_ptr<void>;
 
     /** Exception safe access to the lockfile.
      * \code

--- a/zypp/base/DrunkenBishop.cc
+++ b/zypp/base/DrunkenBishop.cc
@@ -356,9 +356,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
     };

--- a/zypp/media/MediaHandler.h
+++ b/zypp/media/MediaHandler.h
@@ -14,6 +14,7 @@
 #define ZYPP_MEDIA_MEDIAHANDLERL_H
 
 #include <iosfwd>
+#include <memory>
 #include <string>
 #include <list>
 
@@ -52,8 +53,8 @@ class MediaHandler {
     friend std::ostream & operator<<( std::ostream & str, const MediaHandler & obj );
 
     public:
-        using Ptr = shared_ptr<MediaHandler>;
-        using constPtr = shared_ptr<const MediaHandler>;
+        using Ptr = std::shared_ptr<MediaHandler>;
+        using constPtr = std::shared_ptr<const MediaHandler>;
 
         static bool setAttachPrefix(const Pathname &attach_prefix);
 

--- a/zypp/parser/ParserProgress.h
+++ b/zypp/parser/ParserProgress.h
@@ -10,8 +10,8 @@
 #ifndef ZYPP_ParserProgress_H
 #define ZYPP_ParserProgress_H
 
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
+#include <memory>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////
@@ -23,7 +23,7 @@ namespace parser
   class ParserProgress
   {
     public:
-      using Ptr = boost::shared_ptr<ParserProgress>;
+      using Ptr = std::shared_ptr<ParserProgress>;
 
       /**
        * initializes a progress objetc, with a callback functor

--- a/zypp/parser/xml/ParseDef.cc
+++ b/zypp/parser/xml/ParseDef.cc
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <string>
 #include <map>
+#include <memory>
 
 #include <zypp/base/Logger.h>
 #include <zypp/base/String.h>
@@ -96,13 +97,13 @@ namespace zypp
     {
       friend std::ostream & operator<<( std::ostream & str, const ParseDef::Impl & obj );
     public:
-      using ImplPtr = shared_ptr<Impl>;
+      using ImplPtr = std::shared_ptr<Impl>;
       using SubNodes = std::map<std::string, ImplPtr>;
 
     public:
       Impl(std::string &&name_r, Mode mode_r,
-           shared_ptr<ParseDefConsume> &&target_r =
-          shared_ptr<ParseDefConsume>())
+           std::shared_ptr<ParseDefConsume> &&target_r =
+           std::shared_ptr<ParseDefConsume>())
         : _name(std::move(name_r)), _mode(mode_r), _parent(NULL) {
         if ( target_r )
           _callback.setRedirect( std::move(target_r) );
@@ -375,11 +376,11 @@ namespace zypp
     : _pimpl( new Impl( std::move(name_r), mode_r ) )
     {}
 
-    ParseDef::ParseDef( std::string name_r, Mode mode_r, shared_ptr<ParseDefConsume> target_r )
+    ParseDef::ParseDef( std::string name_r, Mode mode_r, std::shared_ptr<ParseDefConsume> target_r )
     : _pimpl( new Impl( std::move(name_r), mode_r, std::move(target_r) ) )
     {}
 
-    ParseDef::ParseDef( const shared_ptr<Impl> & pimpl_r )
+    ParseDef::ParseDef( const std::shared_ptr<Impl> & pimpl_r )
     : _pimpl( pimpl_r )
     {}
 
@@ -417,7 +418,7 @@ namespace zypp
 
     ParseDef ParseDef::operator[]( const std::string & name_r )
     {
-      shared_ptr<Impl> retimpl( _pimpl->getNode( name_r ) );
+      std::shared_ptr<Impl> retimpl( _pimpl->getNode( name_r ) );
       if ( ! retimpl )
         {
           ZYPP_THROW( ParseDefBuildException( "No subnode "+name_r ) );
@@ -425,7 +426,7 @@ namespace zypp
       return retimpl;
     }
 
-    void ParseDef::setConsumer( const shared_ptr<ParseDefConsume> & target_r )
+    void ParseDef::setConsumer( const std::shared_ptr<ParseDefConsume> & target_r )
     { _pimpl->_callback.setRedirect( target_r ); }
 
     void ParseDef::setConsumer( ParseDefConsume * allocatedTarget_r )
@@ -437,7 +438,7 @@ namespace zypp
     void ParseDef::cancelConsumer()
     { _pimpl->_callback.cancelRedirect(); }
 
-    shared_ptr<ParseDefConsume> ParseDef::getConsumer() const
+    std::shared_ptr<ParseDefConsume> ParseDef::getConsumer() const
     { return _pimpl->_callback.getRedirect(); }
 
 

--- a/zypp/parser/xml/ParseDef.h
+++ b/zypp/parser/xml/ParseDef.h
@@ -13,6 +13,7 @@
 #define ZYPP_PARSER_XML_PARSEDEF_H
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp/base/PtrTypes.h>
 #include <zypp/parser/xml/ParseDefTraits.h>
@@ -140,7 +141,7 @@ namespace zypp
 
     public:
       ParseDef( std::string name_r, Mode mode_r );
-      ParseDef( std::string name_r, Mode mode_r, shared_ptr<ParseDefConsume> target_r );
+      ParseDef( std::string name_r, Mode mode_r, std::shared_ptr<ParseDefConsume> target_r );
 
       virtual ~ParseDef();
 
@@ -167,7 +168,7 @@ namespace zypp
       ParseDef & addNode( const std::string & name_r, Mode mode_r )
       { ParseDef tmp( name_r, mode_r ); return addNode( tmp ); }
 
-      ParseDef & addNode( const std::string & name_r, Mode mode_r, const shared_ptr<ParseDefConsume> & target_r )
+      ParseDef & addNode( const std::string & name_r, Mode mode_r, const std::shared_ptr<ParseDefConsume> & target_r )
       { ParseDef tmp( name_r, mode_r, target_r ); return addNode( tmp ); }
 
       /** Add subnode definition.
@@ -179,7 +180,7 @@ namespace zypp
       ParseDef & operator()( const std::string & name_r, Mode mode_r )
       { return addNode( name_r, mode_r ); }
 
-      ParseDef & operator()( const std::string & name_r, Mode mode_r, const shared_ptr<ParseDefConsume> & target_r )
+      ParseDef & operator()( const std::string & name_r, Mode mode_r, const std::shared_ptr<ParseDefConsume> & target_r )
       { return addNode( name_r, mode_r, target_r ); }
 
       /** Get subnode by name.
@@ -189,10 +190,10 @@ namespace zypp
 
     public:
       /** Set data consumer. */
-      void setConsumer( const shared_ptr<ParseDefConsume> & target_r );
+      void setConsumer( const std::shared_ptr<ParseDefConsume> & target_r );
       /** Set data consumer.
-       * \note \a allocatedTarget_r is immediately wraped into a
-       *       shared_ptr.
+       * \note \a allocatedTarget_r is immediately wrapped into a
+       *       \c std::shared_ptr.
       */
       void setConsumer( ParseDefConsume * allocatedTarget_r );
       /** Set data consumer. */
@@ -201,7 +202,7 @@ namespace zypp
       void cancelConsumer();
 
       /** Get data consumer. */
-      shared_ptr<ParseDefConsume> getConsumer() const;
+      std::shared_ptr<ParseDefConsume> getConsumer() const;
 
       /** Parse the node.
        * This parses the node and all defined subnodes. Unknown
@@ -221,7 +222,7 @@ namespace zypp
       /** Pointer to implementation (shared!) */
       RW_pointer<Impl> _pimpl;
 
-      ParseDef( const shared_ptr<Impl> & pimpl_r );
+      ParseDef( const std::shared_ptr<Impl> & pimpl_r );
       friend std::ostream & operator<<( std::ostream & str, const ParseDef & obj );
       friend std::ostream & operator<<( std::ostream & str, const ParseDef::Impl & obj );
 

--- a/zypp/parser/xml/ParseDefConsume.cc
+++ b/zypp/parser/xml/ParseDefConsume.cc
@@ -9,6 +9,8 @@
 /** \file	zypp/parser/xml/ParseDefConsume.cc
  *
 */
+#include <memory>
+
 #include <zypp/parser/xml/ParseDefConsume.h>
 
 ///////////////////////////////////////////////////////////////////
@@ -54,7 +56,7 @@ namespace zypp
     ParseDefConsumeRedirect::ParseDefConsumeRedirect()
     {}
 
-    ParseDefConsumeRedirect::ParseDefConsumeRedirect( shared_ptr<ParseDefConsume> target_r )
+    ParseDefConsumeRedirect::ParseDefConsumeRedirect( std::shared_ptr<ParseDefConsume> target_r )
     : _target( std::move(target_r) )
     {}
 
@@ -69,7 +71,7 @@ namespace zypp
     ParseDefConsumeRedirect::~ParseDefConsumeRedirect()
     {}
 
-    void ParseDefConsumeRedirect::setRedirect( shared_ptr<ParseDefConsume> target_r )
+    void ParseDefConsumeRedirect::setRedirect( std::shared_ptr<ParseDefConsume> target_r )
     { _target = std::move(target_r); }
 
     void ParseDefConsumeRedirect::setRedirect( ParseDefConsume * allocatedTarget_r )
@@ -81,7 +83,7 @@ namespace zypp
     void ParseDefConsumeRedirect::cancelRedirect()
     { _target.reset(); }
 
-    shared_ptr<ParseDefConsume> ParseDefConsumeRedirect::getRedirect() const
+    std::shared_ptr<ParseDefConsume> ParseDefConsumeRedirect::getRedirect() const
     { return _target; }
 
     void ParseDefConsumeRedirect::start( const Node & _node )

--- a/zypp/parser/xml/ParseDefConsume.h
+++ b/zypp/parser/xml/ParseDefConsume.h
@@ -16,6 +16,7 @@
 #include <zypp/base/Function.h>
 #include <zypp/base/Hash.h>
 #include <zypp/base/String.h>
+#include <memory>
 #include <utility>
 #include <zypp-core/base/DefaultIntegral>
 
@@ -56,25 +57,25 @@ namespace zypp
     //
     /** ParseDef consumer redirecting all events to another consumer.
      * \note Allocated <tt>ParseDefConsume *</tt> passed are
-     *       immediately wraped into a shared_ptr.
+     *       immediately wrapped into a \c std::shared_ptr.
     */
     class ParseDefConsumeRedirect : public ParseDefConsume
     {
     public:
       ParseDefConsumeRedirect();
-      ParseDefConsumeRedirect( shared_ptr<ParseDefConsume> target_r );
+      ParseDefConsumeRedirect( std::shared_ptr<ParseDefConsume> target_r );
       ParseDefConsumeRedirect( ParseDefConsume * allocatedTarget_r );
       ParseDefConsumeRedirect( ParseDefConsume & target_r );
 
       ~ParseDefConsumeRedirect() override;
 
     public:
-      void setRedirect( shared_ptr<ParseDefConsume> target_r );
+      void setRedirect( std::shared_ptr<ParseDefConsume> target_r );
       void setRedirect( ParseDefConsume * allocatedTarget_r );
       void setRedirect( ParseDefConsume & target_r );
       void cancelRedirect();
 
-      shared_ptr<ParseDefConsume> getRedirect() const;
+      std::shared_ptr<ParseDefConsume> getRedirect() const;
 
     public:
       void start( const Node & _node ) override;
@@ -85,7 +86,7 @@ namespace zypp
       void doneSubnode ( const Node & _node ) override;
 
     private:
-      shared_ptr<ParseDefConsume> _target;
+      std::shared_ptr<ParseDefConsume> _target;
     };
     ///////////////////////////////////////////////////////////////////
 
@@ -128,7 +129,7 @@ namespace zypp
     { /////////////////////////////////////////////////////////////////
       template <class Tp> struct Assigner;
 
-      using AssignerRef = shared_ptr<Assigner<void>>;
+      using AssignerRef = std::shared_ptr<Assigner<void>>;
 
       /** Common interface to all Assigner types. */
       template <>
@@ -270,7 +271,7 @@ namespace zypp
        *
        * The class constructs the consumer, allows to extend it via
        * \ref operator(), and provides a conversion to
-       * \c shared_ptr<ParseDefConsume>, so it can be passed as a
+       * \c std::shared_ptr<ParseDefConsume>, so it can be passed as a
        * node consumer to \ref ParseDef.
        *
        * You may also set a <tt>void( const Node & )</tt> notification
@@ -316,11 +317,11 @@ namespace zypp
         { _ptr->postnotify( std::move(done_r) ); return *this; }
 
         /** Type conversion so this can be passed as node consumer to \ref ParseDef. */
-        operator shared_ptr<ParseDefConsume> () const
+        operator std::shared_ptr<ParseDefConsume> () const
         { return _ptr; }
 
         private:
-          shared_ptr<Consumer> _ptr;
+          std::shared_ptr<Consumer> _ptr;
       };
       /////////////////////////////////////////////////////////////////
     } // namespace parse_def_assign

--- a/zypp/parser/xml/XmlString.h
+++ b/zypp/parser/xml/XmlString.h
@@ -102,7 +102,7 @@ namespace zypp
     private:
       /** Wraps the <tt>xmlChar *</tt>.
        * The appropriate custom deleter is set by the ctor. */
-      shared_ptr<const xmlChar> _xmlstr;
+      std::shared_ptr<const xmlChar> _xmlstr;
     };
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/pool/PoolImpl.h
+++ b/zypp/pool/PoolImpl.h
@@ -13,6 +13,7 @@
 #define ZYPP_POOL_POOLIMPL_H
 
 #include <iosfwd>
+#include <memory>
 #include <utility>
 
 #include <zypp/base/Easy.h>
@@ -480,8 +481,8 @@ namespace zypp
         mutable DefaultIntegral<bool,true>    _id2itemDirty;
 
       private:
-        mutable shared_ptr<ResPoolProxy>      _poolProxy;
-        mutable shared_ptr<EstablishedStatesImpl> _establishedStates;
+        mutable std::shared_ptr<ResPoolProxy>      _poolProxy;
+        mutable std::shared_ptr<EstablishedStatesImpl> _establishedStates;
 
       private:
         /** Set of queries that define hardlocks. */

--- a/zypp/pool/PoolTraits.h
+++ b/zypp/pool/PoolTraits.h
@@ -14,6 +14,7 @@
 
 #include <set>
 #include <map>
+#include <memory>
 #include <list>
 #include <vector>
 
@@ -86,8 +87,8 @@ namespace zypp
       using hardLockQueries_iterator = HardLockQueries::const_iterator;
 
       using Impl = PoolImpl;
-      using Impl_Ptr = shared_ptr<PoolImpl>;
-      using Impl_constPtr = shared_ptr<const PoolImpl>;
+      using Impl_Ptr = std::shared_ptr<PoolImpl>;
+      using Impl_constPtr = std::shared_ptr<const PoolImpl>;
     };
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/repo/PackageProvider.cc
+++ b/zypp/repo/PackageProvider.cc
@@ -12,6 +12,7 @@
 #include "zypp/ng/workflows/contextfacade.h"
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <zypp/repo/PackageDelta.h>
 #include <zypp/base/Logger.h>
@@ -353,7 +354,7 @@ namespace zypp
       RepoMediaAccess &		_access;
 
     private:
-      using ScopedGuard = shared_ptr<void>;
+      using ScopedGuard = std::shared_ptr<void>;
 
       ScopedGuard newReport() const
       {
@@ -361,14 +362,14 @@ namespace zypp
         // Use a custom deleter calling _report.reset() when guard goes out of
         // scope (cast required as reset is overloaded). We want report to end
         // when leaving providePackage and not wait for *this going out of scope.
-        return shared_ptr<void>( static_cast<void*>(0),
-                                 std::bind( std::mem_fn(static_cast<void (shared_ptr<Report>::*)()>(&shared_ptr<Report>::reset)),
-                                            std::ref(_report) ) );
+        return std::shared_ptr<void>( static_cast<void*>(0),
+                                      std::bind( std::mem_fn(static_cast<void (std::shared_ptr<Report>::*)()>(&std::shared_ptr<Report>::reset)),
+                                                 std::ref(_report) ) );
       }
 
-      mutable bool               _retry;
-      mutable shared_ptr<Report> _report;
-      mutable Target_Ptr         _target;
+      mutable bool                    _retry;
+      mutable std::shared_ptr<Report> _report;
+      mutable Target_Ptr              _target;
     };
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/repo/RepoInfoBase.h
+++ b/zypp/repo/RepoInfoBase.h
@@ -13,6 +13,7 @@
 #define REPOINFOBASE_H_
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp/base/PtrTypes.h>
 #include <zypp-core/Globals.h>
@@ -184,9 +185,9 @@ namespace zypp
     std::ostream & operator<<( std::ostream & str, const RepoInfoBase & obj );
 
     /** \relates RepoInfoBase */
-    using RepoInfoBase_Ptr = shared_ptr<RepoInfoBase>;
+    using RepoInfoBase_Ptr = std::shared_ptr<RepoInfoBase>;
     /** \relates RepoInfoBase */
-    using RepoInfoBase_constPtr = shared_ptr<const RepoInfoBase>;
+    using RepoInfoBase_constPtr = std::shared_ptr<const RepoInfoBase>;
 
 
     /////////////////////////////////////////////////////////////////

--- a/zypp/repo/RepoMirrorList.cc
+++ b/zypp/repo/RepoMirrorList.cc
@@ -11,6 +11,7 @@
 */
 
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <vector>
 #include <time.h>
@@ -59,7 +60,7 @@ namespace zypp
         { return _localfile; }
 
       private:
-        shared_ptr<MediaSetAccess> _access;
+        std::shared_ptr<MediaSetAccess> _access;
         Pathname _localfile;
       };
       ///////////////////////////////////////////////////////////////////

--- a/zypp/repo/RepoProvideFile.cc
+++ b/zypp/repo/RepoProvideFile.cc
@@ -10,6 +10,7 @@
  *
 */
 #include <iostream>
+#include <memory>
 #include <fstream>
 #include <sstream>
 #include <set>
@@ -139,7 +140,7 @@ namespace zypp
 
       ~Impl()
       {
-        std::map<Url, shared_ptr<MediaSetAccess> >::iterator it;
+        std::map<Url, std::shared_ptr<MediaSetAccess> >::iterator it;
         for ( it = _medias.begin();
               it != _medias.end();
               ++it )
@@ -155,11 +156,11 @@ namespace zypp
        *
        * \todo This mixture of media and repos specific data is fragile.
       */
-      shared_ptr<MediaSetAccess> mediaAccessForUrl( const Url &url, RepoInfo repo )
+      std::shared_ptr<MediaSetAccess> mediaAccessForUrl( const Url &url, RepoInfo repo )
       {
-        std::map<Url, shared_ptr<MediaSetAccess> >::const_iterator it;
+        std::map<Url, std::shared_ptr<MediaSetAccess> >::const_iterator it;
         it = _medias.find(url);
-        shared_ptr<MediaSetAccess> media;
+        std::shared_ptr<MediaSetAccess> media;
         if ( it != _medias.end() )
         {
           media = it->second;
@@ -174,7 +175,7 @@ namespace zypp
       }
 
       private:
-        void setVerifierForRepo( const RepoInfo& repo, const shared_ptr<MediaSetAccess>& media )
+        void setVerifierForRepo( const RepoInfo& repo, const std::shared_ptr<MediaSetAccess>& media )
         {
           // Always set the MediaSetAccess label.
           media->setLabel( repo.name() );
@@ -186,7 +187,7 @@ namespace zypp
           {
             if ( PathInfo(mediafile).isExist() )
             {
-              std::map<shared_ptr<MediaSetAccess>, RepoInfo>::const_iterator it;
+              std::map<std::shared_ptr<MediaSetAccess>, RepoInfo>::const_iterator it;
               it = _verifier.find(media);
               if ( it != _verifier.end() )
               {
@@ -222,8 +223,8 @@ namespace zypp
         }
 
       private:
-        std::map<shared_ptr<MediaSetAccess>, RepoInfo> _verifier;
-        std::map<Url, shared_ptr<MediaSetAccess> > _medias;
+        std::map<std::shared_ptr<MediaSetAccess>, RepoInfo> _verifier;
+        std::map<Url, std::shared_ptr<MediaSetAccess> > _medias;
 
       public:
         ProvideFilePolicy _defaultPolicy;
@@ -304,7 +305,7 @@ namespace zypp
         try
         {
           MIL << "Providing file of repo '" << repo_r.alias() << "' from " << url << endl;
-          shared_ptr<MediaSetAccess> access = _impl->mediaAccessForUrl( url, repo_r );
+          std::shared_ptr<MediaSetAccess> access = _impl->mediaAccessForUrl( url, repo_r );
 
           fetcher.enqueue( locWithPath, policy_r.fileChecker() );
           fetcher.start( destinationDir, *access );

--- a/zypp/repo/SUSEMediaVerifier.cc
+++ b/zypp/repo/SUSEMediaVerifier.cc
@@ -8,6 +8,8 @@
 \---------------------------------------------------------------------*/
 
 #include <fstream>
+#include <memory>
+
 #include <zypp/base/Logger.h>
 #include <zypp/base/Gettext.h>
 #include <zypp/repo/SUSEMediaVerifier.h>
@@ -109,7 +111,7 @@ namespace zypp
       }
 
     private:
-      shared_ptr<SMVData> _smvData;
+      std::shared_ptr<SMVData> _smvData;
       media::MediaNr _mediaNr = 1;
     };
 

--- a/zypp/sat/SolvIterMixin.h
+++ b/zypp/sat/SolvIterMixin.h
@@ -13,8 +13,8 @@
 #define ZYPP_SAT_SOLVITERMIXIN_H
 
 #include <iosfwd>
+#include <memory>
 
-#include <zypp/base/PtrTypes.h>
 #include <zypp/base/Iterator.h>
 #include <zypp/base/Hash.h>
 
@@ -48,7 +48,7 @@ namespace zypp
         UnifyByIdent()
           : _uset( new Uset )
         {}
-        shared_ptr<Uset> _uset;
+        std::shared_ptr<Uset> _uset;
       };
 
 

--- a/zypp/sat/SolvableSpec.cc
+++ b/zypp/sat/SolvableSpec.cc
@@ -9,6 +9,7 @@
 /** \file	zypp/sat/SolvableSpec.cc
  */
 #include <iostream>
+#include <memory>
 
 #include <zypp/base/LogTools.h>
 #include <zypp/base/IOStream.h>
@@ -117,7 +118,7 @@ namespace zypp
       CapabilitySet _provides;
       bool _addIdenticalInstalledToo = false;
       mutable SolvableSet _cacheIdenticalInstalled;	// follows _cache
-      mutable shared_ptr<WhatProvides> _cache;
+      mutable std::shared_ptr<WhatProvides> _cache;
 
     private:
       friend Impl * rwcowClone<Impl>( const Impl * rhs );

--- a/zypp/sat/Transaction.cc
+++ b/zypp/sat/Transaction.cc
@@ -294,9 +294,9 @@ namespace zypp
 
       public:
         /** Offer default Impl. */
-        static shared_ptr<Impl> nullimpl()
+        static std::shared_ptr<Impl> nullimpl()
         {
-          static shared_ptr<Impl> _nullimpl( new Impl );
+          static std::shared_ptr<Impl> _nullimpl( new Impl );
           return _nullimpl;
         }
     };

--- a/zypp/sat/WhatObsoletes.cc
+++ b/zypp/sat/WhatObsoletes.cc
@@ -79,7 +79,7 @@ namespace zypp
     namespace
     {
       /** Add item to the set created on demand. */
-      inline void addToSet( Solvable item, set_type *& pdata, shared_ptr<void>& _private )
+      inline void addToSet( Solvable item, set_type *& pdata, std::shared_ptr<void>& _private )
       {
         if ( ! pdata )
         {

--- a/zypp/sat/WhatObsoletes.h
+++ b/zypp/sat/WhatObsoletes.h
@@ -13,6 +13,7 @@
 #define ZYPP_SAT_WHATOBSOLETES_H
 
 #include <iosfwd>
+#include <memory>
 #include <vector>
 
 #include <zypp/sat/WhatProvides.h>
@@ -95,7 +96,7 @@ namespace zypp
 
       private:
         const sat::detail::IdType * _begin;
-        shared_ptr<void> _private;
+        std::shared_ptr<void> _private;
     };
     ///////////////////////////////////////////////////////////////////
 

--- a/zypp/target/modalias/Modalias.cc
+++ b/zypp/target/modalias/Modalias.cc
@@ -16,6 +16,7 @@ extern "C"
 
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <vector>
 
 #undef ZYPP_BASE_LOGGER_LOGGROUP
@@ -189,9 +190,9 @@ namespace zypp
 
     public:
       /** Offer default Impl. */
-      static shared_ptr<Impl> nullimpl()
+      static std::shared_ptr<Impl> nullimpl()
       {
-        static shared_ptr<Impl> _nullimpl( new Impl );
+        static std::shared_ptr<Impl> _nullimpl( new Impl );
         return _nullimpl;
       }
 

--- a/zypp/target/rpm/RpmDb.cc
+++ b/zypp/target/rpm/RpmDb.cc
@@ -24,6 +24,7 @@ extern "C"
 #include <sstream>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -162,7 +163,7 @@ struct KeyRingSignalReceiver : callback::ReceiveReport<KeyRingSignals>
   RpmDb &_rpmdb;
 };
 
-static shared_ptr<KeyRingSignalReceiver> sKeyRingReceiver;
+static std::shared_ptr<KeyRingSignalReceiver> sKeyRingReceiver;
 
 unsigned diffFiles(const std::string& file1, const std::string& file2, std::string& out, int maxlines)
 {

--- a/zypp/ui/Selectable.h
+++ b/zypp/ui/Selectable.h
@@ -13,6 +13,7 @@
 #define ZYPP_UI_SELECTABLE_H
 
 #include <iosfwd>
+#include <memory>
 #include <utility>
 
 #include <zypp/base/ReferenceCounted.h>
@@ -561,7 +562,7 @@ namespace zypp
     public:
       /** Implementation  */
       struct Impl;
-      using Impl_Ptr = shared_ptr<Impl>;
+      using Impl_Ptr = std::shared_ptr<Impl>;
       /** Default ctor */
       Selectable( Impl_Ptr pimpl_r );
     private:

--- a/zypp/zypp_detail/ZYppImpl.cc
+++ b/zypp/zypp_detail/ZYppImpl.cc
@@ -11,6 +11,7 @@
 */
 
 #include <iostream>
+#include <memory>
 #include <zypp/TmpPath.h>
 #include <zypp/base/Logger.h>
 #include <zypp/base/String.h>
@@ -86,7 +87,7 @@ namespace zypp
   {
     ScopedDisableMediaChangeReport::ScopedDisableMediaChangeReport( bool condition_r )
     {
-      static weak_ptr<callback::TempConnect<media::MediaChangeReport> > globalguard;
+      static std::weak_ptr<callback::TempConnect<media::MediaChangeReport> > globalguard;
       if ( condition_r && ! (_guard = globalguard.lock()) )
       {
         // aquire a new one....

--- a/zypp/zypp_detail/ZYppImpl.h
+++ b/zypp/zypp_detail/ZYppImpl.h
@@ -13,6 +13,7 @@
 #define ZYPP_ZYPP_DETAIL_ZYPPIMPL_H
 
 #include <iosfwd>
+#include <memory>
 
 #include <zypp/TmpPath.h>
 #include <zypp/Target.h>
@@ -135,7 +136,7 @@ namespace zypp
       /** */
       Pathname _home_path;
       /** defined mount points, used for disk usage counting */
-      shared_ptr<DiskUsageCounter> _disk_usage;
+      std::shared_ptr<DiskUsageCounter> _disk_usage;
     };
     ///////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
C++ 11 introduced `std::shared_ptr` and `std::weak_ptr`. Those pointer types were introduced in Boost and included in the C++ standard.

This pull request is a first draft to see if the project is interested in such type of changes and to decide on the direction to go.

Known issues:
[ ] No consideration of deprecation for other parts or project depending on `zypp:*_ptr`.
[ ] There might be more things in `PtrTypes.h` that can be clean up.
[ ] Tests are not adapted, nor compiled.
[ ] Software depending on libzypp might need adjustments, too.