### PR TITLE
cmake: check location of fcgi header and adjust include accordingly

### DIFF
--- a/tests/lib/CMakeLists.txt
+++ b/tests/lib/CMakeLists.txt
@@ -40,5 +40,12 @@ ADD_LIBRARY(zypp_test_utils STATIC
  WebServer.cc
 )
 
+# These headers are in different subdirectories depending on the
+# distribution
+CHECK_INCLUDE_FILE( fastcgi/fcgiapp.h FASTCGI_HEADER_DIR )
+IF ( FASTCGI_HEADER_DIR )
+  target_compile_definitions( zypp_test_utils PRIVATE FCGI_IN_SUBDIR=1)
+ENDIF ( FASTCGI_HEADER_DIR )
+
 target_link_libraries( zypp_test_utils PRIVATE zypp_lib_compiler_flags )
 TARGET_LINK_LIBRARIES( zypp_test_utils PUBLIC ${LIBFCGI} ${LIBFCGI++} pthread )

--- a/tests/lib/WebServer.cc
+++ b/tests/lib/WebServer.cc
@@ -26,8 +26,13 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
+#if FCGI_IN_SUBDIR
 #include <fastcgi/fcgiapp.h>
 #include <fastcgi/fcgio.h>
+#else
+#include <fcgiapp.h>
+#include <fcgio.h>
+#endif
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
On Debian and derivatives the fcgi headers are not stored in a fastcgi/ subdirectory:

https://packages.debian.org/trixie/amd64/libfcgi-dev/filelist