### PR TITLE
Fix small typo

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -4150,7 +4150,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm het misluk."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ar.po
+++ b/po/ar.po
@@ -4177,7 +4177,7 @@ msgid "applydeltarpm failed."
 msgstr "فشل applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ast.po
+++ b/po/ast.po
@@ -4140,7 +4140,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/be.po
+++ b/po/be.po
@@ -4238,7 +4238,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/bg.po
+++ b/po/bg.po
@@ -4392,7 +4392,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/bn.po
+++ b/po/bn.po
@@ -4149,7 +4149,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm ব্যর্থ হয়েছে।"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/bs.po
+++ b/po/bs.po
@@ -4651,7 +4651,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ca.po
+++ b/po/ca.po
@@ -4572,7 +4572,7 @@ msgid "applydeltarpm failed."
 msgstr "ha fallat aplicar de l'RPM delta."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "No hi ha permís per escriure la memòria cau del repositori."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/cs.po
+++ b/po/cs.po
@@ -4384,7 +4384,7 @@ msgid "applydeltarpm failed."
 msgstr "Aplikování delta RPM se nezdařilo."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/cy.po
+++ b/po/cy.po
@@ -4453,7 +4453,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/da.po
+++ b/po/da.po
@@ -4160,7 +4160,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm mislykkedes."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/de.po
+++ b/po/de.po
@@ -4185,7 +4185,7 @@ msgid "applydeltarpm failed."
 msgstr "Fehler bei applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/el.po
+++ b/po/el.po
@@ -4163,7 +4163,7 @@ msgid "applydeltarpm failed."
 msgstr "Αποτυχία applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4159,7 +4159,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm failed."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/es.po
+++ b/po/es.po
@@ -4198,7 +4198,7 @@ msgid "applydeltarpm failed."
 msgstr "Error de applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/et.po
+++ b/po/et.po
@@ -4160,7 +4160,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm nurjus."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/fa.po
+++ b/po/fa.po
@@ -4156,7 +4156,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm ناموفق بود."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/fi.po
+++ b/po/fi.po
@@ -4383,7 +4383,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm epäonnistui."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Ei käyttöoikeutta kirjoittaa asennuslähteen välimuistiin."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/fr.po
+++ b/po/fr.po
@@ -4192,7 +4192,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm a échoué."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/gl.po
+++ b/po/gl.po
@@ -4499,7 +4499,7 @@ msgid "applydeltarpm failed."
 msgstr "fallou applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/gu.po
+++ b/po/gu.po
@@ -4151,7 +4151,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm નિષ્ફળ."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/he.po
+++ b/po/he.po
@@ -4634,7 +4634,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/hi.po
+++ b/po/hi.po
@@ -4152,7 +4152,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm नाकाम रहा।"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/hr.po
+++ b/po/hr.po
@@ -4293,7 +4293,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/hu.po
+++ b/po/hu.po
@@ -4447,7 +4447,7 @@ msgid "applydeltarpm failed."
 msgstr "az applydeltarpm futtatása sikertelen."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/id.po
+++ b/po/id.po
@@ -4610,7 +4610,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm gagal."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Tidak ada izin untuk menulis cache repositori."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/it.po
+++ b/po/it.po
@@ -4183,7 +4183,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm non riuscito."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ja.po
+++ b/po/ja.po
@@ -4166,7 +4166,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpmが失敗しました。"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "リポジトリキャッシュへの書き込み許可がありません。"
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ka.po
+++ b/po/ka.po
@@ -4139,7 +4139,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/km.po
+++ b/po/km.po
@@ -4154,7 +4154,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm បាន​បរាជ័យ ។"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ko.po
+++ b/po/ko.po
@@ -4348,7 +4348,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm 실패."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ku.po
+++ b/po/ku.po
@@ -4224,7 +4224,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/lt.po
+++ b/po/lt.po
@@ -4264,7 +4264,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm nepavyko."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/mk.po
+++ b/po/mk.po
@@ -4480,7 +4480,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/mr.po
+++ b/po/mr.po
@@ -4150,7 +4150,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm अयशस्वी"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/nb.po
+++ b/po/nb.po
@@ -4300,7 +4300,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm mislyktes."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Ingen tillatelse til å skrive pakkebrønn hurtiglager."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/nl.po
+++ b/po/nl.po
@@ -4190,7 +4190,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm mislukt."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Geen toestemming naar cache van opslagruimte te schrijven."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/nn.po
+++ b/po/nn.po
@@ -4139,7 +4139,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/pa.po
+++ b/po/pa.po
@@ -4155,7 +4155,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm ਫੇਲ੍ਹ ਹੋਇਆ।"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/pl.po
+++ b/po/pl.po
@@ -4165,7 +4165,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm zakończone niepowodzeniem."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/pt.po
+++ b/po/pt.po
@@ -4380,7 +4380,7 @@ msgid "applydeltarpm failed."
 msgstr "falhou o applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4188,7 +4188,7 @@ msgid "applydeltarpm failed."
 msgstr "Falha no applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Nenhuma permissão para gravar no cache do repositório."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ro.po
+++ b/po/ro.po
@@ -4184,7 +4184,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm a eșuat."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ru.po
+++ b/po/ru.po
@@ -4171,7 +4171,7 @@ msgid "applydeltarpm failed."
 msgstr "сбой в applydeltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/si.po
+++ b/po/si.po
@@ -4170,7 +4170,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/sk.po
+++ b/po/sk.po
@@ -4165,7 +4165,7 @@ msgid "applydeltarpm failed."
 msgstr "Aplikovanie delta rpm zlyhalo."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Žiadne oprávnenie na zápis do vyrovnávacej pamäte repozitárov."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/sl.po
+++ b/po/sl.po
@@ -4620,7 +4620,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm ni uspel."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr "Ni dovoljenja za zapis predpomnilnika vira."
 
 #: zypp/repo/RepoException.cc:130

--- a/po/sr.po
+++ b/po/sr.po
@@ -4266,7 +4266,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/sv.po
+++ b/po/sv.po
@@ -4341,7 +4341,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm misslyckades."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/ta.po
+++ b/po/ta.po
@@ -4147,7 +4147,7 @@ msgid "applydeltarpm failed."
 msgstr "அப்ளைடெல்டாஆர்பிஎம் தோல்வியுற்றது."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/th.po
+++ b/po/th.po
@@ -4231,7 +4231,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/tr.po
+++ b/po/tr.po
@@ -4837,7 +4837,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/uk.po
+++ b/po/uk.po
@@ -4350,7 +4350,7 @@ msgid "applydeltarpm failed."
 msgstr "застосування дельти rpm зазнало невдачі."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/vi.po
+++ b/po/vi.po
@@ -4142,7 +4142,7 @@ msgid "applydeltarpm failed."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/wa.po
+++ b/po/wa.po
@@ -4174,7 +4174,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm a fwait berwete."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/xh.po
+++ b/po/xh.po
@@ -4154,7 +4154,7 @@ msgid "applydeltarpm failed."
 msgstr "kusilele ukusetyenziswa kwe-deltarpm."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4151,7 +4151,7 @@ msgid "applydeltarpm failed."
 msgstr "Applydeltarpm 已失败。"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4149,7 +4149,7 @@ msgid "applydeltarpm failed."
 msgstr "applydeltarpm 失敗。"
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130

--- a/po/zu.po
+++ b/po/zu.po
@@ -4153,7 +4153,7 @@ msgid "applydeltarpm failed."
 msgstr "i-applydeltarpm ihlulekile."
 
 #: zypp/repo/RepoException.cc:73
-msgid "No permision to write repository cache."
+msgid "No permission to write repository cache."
 msgstr ""
 
 #: zypp/repo/RepoException.cc:130


### PR DESCRIPTION
Replace `permision` with `permission` in the language files.