### PR TITLE
Url query part: `=` is a safe char in value

### DIFF
--- a/tests/zypp/Url_test.cc
+++ b/tests/zypp/Url_test.cc
@@ -316,4 +316,21 @@ BOOST_AUTO_TEST_CASE(plugin_querystring_args)
   BOOST_CHECK_EQUAL( pm["o"], "" );
 }
 
+BOOST_AUTO_TEST_CASE(bsc1234304)
+{
+  // Removing or adding queryparams should not alter the encoding of other queryparams.
+  // Old code decoded and re-encoded all params. "__token__=exp=%3D%26" was changed to
+  // "__token__=exp==%26" by this. That's not wrong, but we'd like to preserve the original
+  // params if possible.
+  Url u { "https://dl.suse.com/?__token__=exp=%3D%261862049599~acl=/SUSE/*~hmac=968c8dc9&t%3Dt" };
+  BOOST_CHECK_EQUAL( u.getQueryString(), "__token__=exp=%3D%261862049599~acl=/SUSE/*~hmac=968c8dc9&t%3Dt" );
+  u.delQueryParam("t=t");
+  BOOST_CHECK_EQUAL( u.getQueryString(), "__token__=exp=%3D%261862049599~acl=/SUSE/*~hmac=968c8dc9" );
+  u.setQueryParam("t=t", "a" );
+  BOOST_CHECK_EQUAL( u.getQueryString(), "__token__=exp=%3D%261862049599~acl=/SUSE/*~hmac=968c8dc9&t%3Dt=a" );
+  u.setQueryParam("t=t", "b" );
+  BOOST_CHECK_EQUAL( u.getQueryString(), "__token__=exp=%3D%261862049599~acl=/SUSE/*~hmac=968c8dc9&t%3Dt=b" );
+
+}
+
 // vim: set ts=2 sts=2 sw=2 ai et:

--- a/tests/zypp/Url_test.cc
+++ b/tests/zypp/Url_test.cc
@@ -197,25 +197,26 @@ BOOST_AUTO_TEST_CASE(test_url3)
   BOOST_CHECK_EQUAL( url.asString(),
   "http://localhost/path/to?hoho=ha%20ha#frag");
 
-  // will be encoded as "foo%3Dbar%26key=foo%26bar%3Dvalue"
+  // will be encoded as "foo%3Dbar%26key=foo%26bar=value"
+  // bsc#1234304: `=` must be encoded in key but is a safe char in value
   key = "foo=bar&key";
   val = "foo&bar=value";
   url.setQueryParam(key, val);
   BOOST_CHECK_EQUAL( url.asString(),
-  "http://localhost/path/to?foo%3Dbar%26key=foo%26bar%3Dvalue&hoho=ha%20ha#frag");
+  "http://localhost/path/to?foo%3Dbar%26key=foo%26bar=value&hoho=ha%20ha#frag");
 
   // will be encoded as "foo%25bar=is%25de%25ad"
   key = "foo%bar";
   val = "is%de%ad";
   url.setQueryParam(key, val);
   BOOST_CHECK_EQUAL( url.asString(),
-  "http://localhost/path/to?foo%25bar=is%25de%25ad&foo%3Dbar%26key=foo%26bar%3Dvalue&hoho=ha%20ha#frag");
+  "http://localhost/path/to?foo%25bar=is%25de%25ad&foo%3Dbar%26key=foo%26bar=value&hoho=ha%20ha#frag");
 
   // get encoded query parameters and compare with results:
   zypp::url::ParamVec params( url.getQueryStringVec());
   const char * const  result[] = {
     "foo%25bar=is%25de%25ad",
-    "foo%3Dbar%26key=foo%26bar%3Dvalue",
+    "foo%3Dbar%26key=foo%26bar=value",
     "hoho=ha%20ha"
   };
   BOOST_CHECK( params.size() == (sizeof(result)/sizeof(result[0])));

--- a/zypp-core/url/UrlBase.cc
+++ b/zypp-core/url/UrlBase.cc
@@ -1267,7 +1267,8 @@ namespace zypp
           pmap,
           config("psep_pathparam"),
           config("vsep_pathparam"),
-          config("safe_pathparams")
+          config("safe_pathparams"),
+          url::E_DECODED
         )
       );
     }
@@ -1298,7 +1299,7 @@ namespace zypp
 
     // ---------------------------------------------------------------
     void
-    UrlBase::setQueryStringMap(const zypp::url::ParamMap &pmap)
+    UrlBase::setQueryStringMap(const zypp::url::ParamMap &pmap, EEncoding eflag)
     {
       if( config("psep_querystr").empty() ||
           config("vsep_querystr").empty())
@@ -1312,7 +1313,8 @@ namespace zypp
           pmap,
           config("psep_querystr"),
           config("vsep_querystr"),
-          config("safe_querystr")
+          config("safe_querystr"),
+          eflag
         )
       );
     }
@@ -1321,18 +1323,38 @@ namespace zypp
     void
     UrlBase::setQueryParam(const std::string &param, const std::string &value)
     {
-          zypp::url::ParamMap pmap( getQueryStringMap(zypp::url::E_DECODED));
-          pmap[param] = value;
-          setQueryStringMap(pmap);
+          zypp::url::ParamMap pmap( getQueryStringMap(zypp::url::E_ENCODED));
+          std::string newval = url::join(
+            ParamMap{ {param,value} },
+            config("psep_querystr"),
+            config("vsep_querystr"),
+            config("safe_querystr"),
+            url::E_DECODED
+          );
+          zypp::url::ParamMap newmap;
+          url::split(
+            newmap,
+            newval,
+            config("psep_querystr"),
+            config("vsep_querystr"),
+            url::E_ENCODED
+          );
+          pmap[newmap.begin()->first] = newmap.begin()->second;
+          setQueryStringMap(pmap, url::E_ENCODED);
     }
 
     // ---------------------------------------------------------------
     void
     UrlBase::delQueryParam(const std::string &param)
     {
-          zypp::url::ParamMap pmap( getQueryStringMap(zypp::url::E_DECODED));
-          pmap.erase(param);
-          setQueryStringMap(pmap);
+          zypp::url::ParamMap pmap( getQueryStringMap(zypp::url::E_ENCODED));
+          for ( auto it = pmap.begin(), last = pmap.end(); it != last; ) {
+            if ( url::decode( it->first ) == param )
+              it = pmap.erase( it );
+            else
+              ++it;
+          }
+          setQueryStringMap(pmap, url::E_ENCODED);
     }
 
 

--- a/zypp-core/url/UrlBase.h
+++ b/zypp-core/url/UrlBase.h
@@ -849,11 +849,12 @@ namespace zypp
       /**
        * \brief Set the query parameters.
        * \param qmap The map with decoded query parameters.
+       * \param eflag Tells whether keys and values in pmap are already encoded or decoded.
        * \throws UrlNotSupportedException if parameter parsing
        *         is not supported for a URL (scheme).
        */
       virtual void
-      setQueryStringMap(const zypp::url::ParamMap &qmap);
+      setQueryStringMap(const zypp::url::ParamMap &qmap, EEncoding eflag);
 
       /**
        * \brief Set or add value for the specified query parameter.

--- a/zypp-core/url/UrlUtils.cc
+++ b/zypp-core/url/UrlUtils.cc
@@ -281,14 +281,18 @@ namespace zypp
           _("Invalid parameter array join separator character")
         ));
       }
+      std::string safeKey;
+      std::string safeVal;
 
-      std::string join_safe;
       for(std::string::size_type i=0; i<safe.size(); i++)
       {
-        if( psep.find(safe[i]) == std::string::npos &&
-            vsep.find(safe[i]) == std::string::npos)
-        {
-          join_safe.append(1, safe[i]);
+        if( psep.find(safe[i]) == std::string::npos ) {
+          if ( vsep.find(safe[i]) == std::string::npos ) {
+            safeKey.append(1, safe[i]);
+            safeVal.append(1, safe[i]);
+          } else {
+            safeVal.append(1, safe[i]);
+          }
         }
       }
       std::string              str;
@@ -296,15 +300,15 @@ namespace zypp
 
       if( i != pmap.end())
       {
-        str = encode(i->first, join_safe);
+        str = encode(i->first, safeKey);
         if( !i->second.empty())
-          str += vsep + encode(i->second, join_safe);
+          str += vsep + encode(i->second, safeVal);
 
         while( ++i != pmap.end())
         {
-          str += psep + encode(i->first, join_safe);
+          str += psep + encode(i->first, safeKey);
           if( !i->second.empty())
-            str +=  vsep + encode(i->second, join_safe);
+            str +=  vsep + encode(i->second, safeVal);
         }
       }
 

--- a/zypp-core/url/UrlUtils.cc
+++ b/zypp-core/url/UrlUtils.cc
@@ -163,7 +163,7 @@ namespace zypp
     void
     split(ParamVec          &pvec,
           const std::string &pstr,
-                const std::string &psep)
+          const std::string &psep)
     {
       size_t beg = 0, len = 0;
       if( psep.empty())
@@ -273,7 +273,8 @@ namespace zypp
     join(const ParamMap    &pmap,
          const std::string &psep,
          const std::string &vsep,
-         const std::string &safe)
+         const std::string &safe,
+         EEncoding         eflag)
     {
       if( psep.empty() || vsep.empty())
       {
@@ -281,34 +282,50 @@ namespace zypp
           _("Invalid parameter array join separator character")
         ));
       }
-      std::string safeKey;
-      std::string safeVal;
 
-      for(std::string::size_type i=0; i<safe.size(); i++)
+      std::string str;
+
+      if ( eflag == E_DECODED )
       {
-        if( psep.find(safe[i]) == std::string::npos ) {
-          if ( vsep.find(safe[i]) == std::string::npos ) {
-            safeKey.append(1, safe[i]);
-            safeVal.append(1, safe[i]);
-          } else {
-            safeVal.append(1, safe[i]);
+        std::string safeKey;
+        std::string safeVal;
+
+        for(std::string::size_type i=0; i<safe.size(); i++)
+        {
+          if( psep.find(safe[i]) == std::string::npos ) {
+            if ( vsep.find(safe[i]) == std::string::npos ) {
+              safeKey.append(1, safe[i]);
+              safeVal.append(1, safe[i]);
+            } else {
+              safeVal.append(1, safe[i]);
+            }
+          }
+        }
+
+        ParamMap::const_iterator i( pmap.begin());
+
+        if( i != pmap.end())
+        {
+          str = encode(i->first, safeKey);
+          if( !i->second.empty())
+            str += vsep + encode(i->second, safeVal);
+
+          while( ++i != pmap.end())
+          {
+            str += psep + encode(i->first, safeKey);
+            if( !i->second.empty())
+              str +=  vsep + encode(i->second, safeVal);
           }
         }
       }
-      std::string              str;
-      ParamMap::const_iterator i( pmap.begin());
-
-      if( i != pmap.end())
+      else
       {
-        str = encode(i->first, safeKey);
-        if( !i->second.empty())
-          str += vsep + encode(i->second, safeVal);
-
-        while( ++i != pmap.end())
-        {
-          str += psep + encode(i->first, safeKey);
-          if( !i->second.empty())
-            str +=  vsep + encode(i->second, safeVal);
+        for ( const auto & [k,v] : pmap ) {
+          if ( not str.empty() )
+            str += psep;
+          str += k;
+          str += vsep;
+          str += v;
         }
       }
 

--- a/zypp-core/url/UrlUtils.h
+++ b/zypp-core/url/UrlUtils.h
@@ -232,10 +232,12 @@ namespace zypp
      *
      * See encode() function from details about the \p safe characters.
      *
+     *
      * \param pmap    Reference to a parameter map.
      * \param psep    Separator character to use between key-value pairs.
      * \param vsep    Separator character to use between keys and values.
      * \param safe    List of characters to accept without encoding.
+     * \param eflag   Tells whether keys and values in pmap are already encoded or decoded.
      * \return A URL percent-encoded parameter string.
      * \throws UrlNotSupportedException if \p psep or \p vsep separator
      *         is empty.
@@ -244,7 +246,8 @@ namespace zypp
     join(const ParamMap     &pmap,
          const std::string  &psep,
          const std::string  &vsep,
-         const std::string  &safe);
+         const std::string  &safe,
+         EEncoding          eflag);
 
 
     //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
 ([bsc#1234304](https://bugzilla.suse.com/show_bug.cgi?id=1234304))