### PR TITLE
Set default value for config option 'download_use_deltarpm' to false

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -208,7 +208,7 @@
 ## Whether to consider using a .delta.rpm when downloading a package
 ##
 ## Valid values: boolean
-## Default value: true
+## Default value: false
 ##
 ## Using a delta rpm will decrease the download size for package updates
 ## since it does not contain all files of the package but only the binary
@@ -216,7 +216,7 @@
 ## is an expensive operation (memory,CPU). If your network connection is
 ## not too slow, you benefit from disabling .delta.rpm.
 ##
-# download.use_deltarpm = true
+# download.use_deltarpm = false
 
 ##
 ## Whether to consider using a deltarpm even when rpm is local

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -495,7 +495,7 @@ namespace zypp
         , repo_add_probe          	( false )
         , repo_refresh_delay      	( 10 )
         , repoLabelIsAlias              ( false )
-        , download_use_deltarpm   	( true )
+        , download_use_deltarpm   	( false)
         , download_use_deltarpm_always  ( false )
         , download_media_prefer_download( true )
         , download_mediaMountdir	( "/var/adm/mount" )


### PR DESCRIPTION
Nowadays, network bandwidth is no longer so much of an issue, so changing the default setting can save memory and CPU time when downloading.

See #581