### PR TITLE
Fix 'zypper ps' when running in incus container

### DIFF
--- a/zypp/misc/CheckAccessDeleted.cc
+++ b/zypp/misc/CheckAccessDeleted.cc
@@ -295,6 +295,9 @@ namespace zypp
     const char * t = 0;
     const char * n = 0;
 
+    // match any stat error appended to file path
+    static const str::regex statErr(R"(.*\(stat: [^)]+\)$)");
+
     for_( ch, line_r.c_str(), ch+line_r.size() )
     {
       switch ( *ch )
@@ -330,7 +333,9 @@ namespace zypp
             || ( *f == 'l' && *(f+1) == 't' && *(f+2) == 'x' && *(f+3) == '\0' ) ) )
       return;	// wrong filedescriptor type
 
-    if ( str::contains( n, "(stat: Permission denied)" ) )
+    // lib/dialects/linux/dproc.c will append stat error to file path
+    // if the file has not been detected as deleted. Ignore those cases
+    if ( str::regex_match( n, statErr ) )
       return;	// Avoid reporting false positive due to insufficient permission.
 
     if ( ! _verbose )


### PR DESCRIPTION
When running under incus zypper ps always report all files as deleted.

I did check it on a Tumbleweed fresh incus container, but I believe this problem arise in other lxc/lxd/incus configurations. The host distribution has no impact. Another [bug report](https://bugzilla.opensuse.org/show_bug.cgi?id=1229106) exists about this issue

Seems to be lsof which uses '/proc/<pid>/map_files' which cause 'Operation not permitted' errors. The libzypp code currently handle 'Permission denied' errors.

After checking in [lsof code](https://github.com/lsof-org/lsof/blob/bbf320ce586a848f880bca7b758d50ae4c712624/lib/dialects/linux/dproc.c#L1570). Stat errors are not produced in case files are deleted.

This commit simply change the 'Permission denied' check to a regex match, so all stat errors are safely ignored (since we do only care about deleted files)
