### PR TITLE
Only use zypp::*_ptr instead of boost::*_ptr

### DIFF
--- a/zypp-core/base/LogControl.cc
+++ b/zypp-core/base/LogControl.cc
@@ -18,6 +18,7 @@
 #include <zypp-core/base/Logger.h>
 #include <zypp-core/base/LogControl.h>
 #include <zypp-core/base/ProfilingFormater.h>
+#include <zypp-core/base/PtrTypes.h>
 #include <zypp-core/base/String.h>
 #include <zypp-core/Date.h>
 #include <zypp-core/TriBool.h>
@@ -96,12 +97,12 @@ namespace zypp
       return t;
     }
 
-    void setLineWriter ( boost::shared_ptr<log::LineWriter> writer ) {
+    void setLineWriter ( zypp::shared_ptr<log::LineWriter> writer ) {
       std::lock_guard lk( _lineWriterLock );
       _lineWriter = std::move(writer);
     }
 
-    boost::shared_ptr<log::LineWriter> getLineWriter () {
+    zypp::shared_ptr<log::LineWriter> getLineWriter () {
       std::lock_guard lk( _lineWriterLock );
       auto lw = _lineWriter;
       return lw;
@@ -207,12 +208,12 @@ namespace zypp
     std::thread _thread;
     zyppng::Wakeup _stopSignal;
 
-    // since the public API uses boost::shared_ptr we can not use the atomic
+    // since the public API uses boost::shared_ptr (via the alias zypp::shared_ptr) we can not use the atomic
     // functionalities provided in std.
     // this lock type can be used safely in signals
     SpinLock _lineWriterLock;
     // boost shared_ptr has a lock free implementation of reference counting so it can be used from signal handlers as well
-    boost::shared_ptr<log::LineWriter> _lineWriter{ nullptr };
+    shared_ptr<log::LineWriter> _lineWriter{ nullptr };
   };
 
   class LogClient

--- a/zypp/ZYpp.h
+++ b/zypp/ZYpp.h
@@ -59,9 +59,8 @@ namespace zypp
     friend std::ostream & operator<<( std::ostream & str, const ZYpp & obj );
 
   public:
-    // can't get swig working if shared_ptr is without namespace here
-    using Ptr = ::boost::shared_ptr<ZYpp>;
-    using constPtr = ::boost::shared_ptr<const ZYpp>;
+    using Ptr = shared_ptr<ZYpp>;
+    using constPtr = shared_ptr<const ZYpp>;
 
   public:
 

--- a/zypp/target/RpmPostTransCollector.cc
+++ b/zypp/target/RpmPostTransCollector.cc
@@ -18,6 +18,7 @@
 #include <zypp/base/Regex.h>
 #include <zypp/base/IOStream.h>
 #include <zypp/base/InputStream.h>
+#include <zypp/base/PtrTypes.h>
 #include <zypp/target/RpmPostTransCollector.h>
 
 #include <zypp/TmpPath.h>
@@ -389,7 +390,7 @@ namespace zypp
         Pathname _root;
         std::optional<ScriptList> _scripts;
         std::optional<Dumpfile> _dumpfile;
-        boost::scoped_ptr<filesystem::TmpDir> _ptrTmpdir;
+        scoped_ptr<filesystem::TmpDir> _ptrTmpdir;
 
         UserDataJobReport _myJobReport;       ///< JobReport with ContentType "cmdout/%posttrans"
 


### PR DESCRIPTION
Preparation for a future switch of `boost::*_ptr` to C++11 `std::*_ptr`. This needs care and a transition as software using libzypp needs adaption.
*_ptr = shared_ptr, scoped_ptr, weak_ptr, intrusive_ptr