### PR TITLE
Remove some of the pre-C++11 macros to emulate range-base for loops

### DIFF
--- a/tools/zypp-pubkey.cc
+++ b/tools/zypp-pubkey.cc
@@ -93,14 +93,14 @@ int main( int argc, char * argv[] )
   if ( ! vm.count( "key-file" ) )
   {
     std::string last;
-    for_each_( it, rpmpubkeys )
+    for ( const PublicKey& rpmpubkey : rpmpubkeys )
     {
-      if ( last == it->gpgPubkeyVersion() )
-        cout << *it << endl;
+      if ( last == rpmpubkey.gpgPubkeyVersion() )
+        cout << rpmpubkey << endl;
       else
       {
-        dumpPubkeyOn( cout, *it );
-        last = it->gpgPubkeyVersion();
+        dumpPubkeyOn( cout, rpmpubkey );
+        last = rpmpubkey.gpgPubkeyVersion();
       }
     }
     return 0;
@@ -108,20 +108,20 @@ int main( int argc, char * argv[] )
 
   ///////////////////////////////////////////////////////////////////
 
-  for_each_( it, vm["key-file"].as< std::vector<std::string> >() )
+  for ( const std::string& keyfile : vm["key-file"].as< std::vector<std::string> >() )
   {
-    cout << "=== " << PathInfo(*it) << endl;
-    PublicKey pubkey( *it );
+    cout << "=== " << PathInfo( keyfile ) << endl;
+    PublicKey pubkey( keyfile );
     dumpPubkeyOn( cout, pubkey );
 
     std::string pubkeyV( pubkey.gpgPubkeyVersion() );
     std::string pubkeyR( pubkey.gpgPubkeyRelease() );
     unsigned count = 0;
-    for_each_( rpmpub, rpmpubkeys )
+    for ( const PublicKey& rpmpub : rpmpubkeys )
     {
-      if ( rpmpub->gpgPubkeyVersion() == pubkeyV )
+      if ( rpmpub.gpgPubkeyVersion() == pubkeyV )
       {
-        int cmp = rpmpub->gpgPubkeyRelease().compare( pubkeyR );
+        int cmp = rpmpub.gpgPubkeyRelease().compare( pubkeyR );
         if ( cmp < 0 )
           cout << "<<< ";
         else if ( cmp > 0 )
@@ -131,7 +131,7 @@ int main( int argc, char * argv[] )
           ++count;
           cout << "*** ";
         }
-        cout << "gpg-pubkey-" << rpmpub->gpgPubkeyVersion() << "-" << rpmpub->gpgPubkeyRelease() << " " << rpmpub->daysToLive() << endl;
+        cout << "gpg-pubkey-" << rpmpub.gpgPubkeyVersion() << "-" << rpmpub.gpgPubkeyRelease() << " " << rpmpub.daysToLive() << endl;
       }
     }
     if ( ! count )

--- a/zypp-common/private/keyring_p.cc
+++ b/zypp-common/private/keyring_p.cc
@@ -269,9 +269,9 @@ namespace zypp
     const std::list<PublicKeyData> & keys( publicKeyData( keyring ) );
     std::list<PublicKey> ret;
 
-    for_( it, keys.begin(), keys.end() )
+    for ( const PublicKeyData& keyData : keys )
     {
-      PublicKey key( exportKey( *it, keyring ) );
+      PublicKey key( exportKey( keyData, keyring ) );
       ret.push_back( key );
       MIL << "Found key " << key << endl;
     }

--- a/zypp-core/ExternalProgram.cc
+++ b/zypp-core/ExternalProgram.cc
@@ -70,9 +70,9 @@ namespace zypp {
     {
       const char * argvp[argv.size() + 1];
       unsigned c = 0;
-      for_( i, argv.begin(), argv.end() )
+      for ( const std::string & arg : argv )
       {
-        argvp[c] = i->c_str();
+        argvp[c] = arg.c_str();
         ++c;
       }
       argvp[c] = 0;
@@ -90,9 +90,9 @@ namespace zypp {
     {
       const char * argvp[argv.size() + 1];
       unsigned c = 0;
-      for_( i, argv.begin(), argv.end() )
+      for ( const std::string & arg : argv )
       {
-        argvp[c] = i->c_str();
+        argvp[c] = arg.c_str();
         ++c;
       }
       argvp[c] = 0;

--- a/zypp-core/base/Easy.h
+++ b/zypp-core/base/Easy.h
@@ -25,7 +25,6 @@
  * \endcode
 */
 #define for_(IT,BEG,END) for ( auto IT = BEG, _for_end = END; IT != _for_end; ++IT )
-#define for_each_(IT,CONT) for_( IT, (CONT).begin(), (CONT).end() )
 
 /** Simple C-array iterator
  * \code

--- a/zypp-core/base/Easy.h
+++ b/zypp-core/base/Easy.h
@@ -24,11 +24,7 @@
  *  }
  * \endcode
 */
-#ifndef __GXX_EXPERIMENTAL_CXX0X__
-#define for_(IT,BEG,END) for ( __typeof__(BEG) IT = BEG, _for_end = END; IT != _for_end; ++IT )
-#else
 #define for_(IT,BEG,END) for ( auto IT = BEG, _for_end = END; IT != _for_end; ++IT )
-#endif
 #define for_each_(IT,CONT) for_( IT, (CONT).begin(), (CONT).end() )
 
 /** Simple C-array iterator

--- a/zypp-core/base/String.h
+++ b/zypp-core/base/String.h
@@ -812,20 +812,20 @@ namespace zypp
           else
           {
             std::string toadd( asString(*iter) );
-            for_( ch, toadd.begin(), toadd.end() )
+            for ( const char ch : toadd )
             {
-              switch ( *ch )
+              switch ( ch )
               {
                 case '"':
                 case '\'':
                 case '\\':
                   buf.push_back( '\\' );
-                  buf.push_back( *ch );
+                  buf.push_back( ch );
                   break;
                 default:
-                  if ( *ch == sep_r )
+                  if ( ch == sep_r )
                     buf.push_back( '\\' );
-                  buf.push_back( *ch );
+                  buf.push_back( ch );
               }
             }
           }

--- a/zypp-curl/proxyinfo/proxyinfoimpl.h
+++ b/zypp-curl/proxyinfo/proxyinfoimpl.h
@@ -59,9 +59,9 @@ namespace zypp {
         // A leading '.' in the pattern is ignored. Some implementations
         // need '.foo.ba' to prevent 'foo.ba' from matching 'xfoo.ba'.
         std::string host( str::toLower( url_r.getHost() ) );
-        for_( it, noproxy.begin(), noproxy.end() )
+        for ( const std::string & np : noproxy )
         {
-          std::string pattern( str::toLower( (*it)[0] == '.' ? it->c_str() + 1 : it->c_str() ) );
+          std::string pattern( str::toLower( np[0] == '.' ? np.c_str() + 1 : np.c_str() ) );
           if ( str::hasSuffix( host, pattern )
                && ( host.size() == pattern.size()
                     || host[host.size()-pattern.size()-1] == '.' ) )

--- a/zypp-media/auth/credentialmanager.cc
+++ b/zypp-media/auth/credentialmanager.cc
@@ -288,10 +288,10 @@ namespace zypp
       bpci::scoped_lock lock( lockFile );
 
       std::ofstream fs(file.c_str());
-      for_(it, creds.begin(), creds.end())
+      for ( auto& credentials : creds )
       {
-        (*it)->dumpAsIniOn(fs);
-        (*it)->setLastDatabaseUpdate( now );
+        credentials->dumpAsIniOn( fs );
+        credentials->setLastDatabaseUpdate( now );
         fs << endl;
       }
       if ( !fs ) {


### PR DESCRIPTION
* I did not remove the now unused `for_each_` for possible external uses. Should I remove it?
* I just removed some uses of `for_`. More are following once this is merged.