### PR TITLE
Disable deltarpm by default.

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -208,7 +208,7 @@
 ## Whether to consider using a .delta.rpm when downloading a package
 ##
 ## Valid values: boolean
-## Default value: true
+## Default value: false
 ##
 ## Using a delta rpm will decrease the download size for package updates
 ## since it does not contain all files of the package but only the binary
@@ -216,7 +216,7 @@
 ## is an expensive operation (memory,CPU). If your network connection is
 ## not too slow, you benefit from disabling .delta.rpm.
 ##
-# download.use_deltarpm = true
+# download.use_deltarpm = false
 
 ##
 ## Whether to consider using a deltarpm even when rpm is local

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -495,7 +495,7 @@ namespace zypp
         , repo_add_probe          	( false )
         , repo_refresh_delay      	( 10 )
         , repoLabelIsAlias              ( false )
-        , download_use_deltarpm   	( true )
+        , download_use_deltarpm   	( false )
         , download_use_deltarpm_always  ( false )
         , download_media_prefer_download( true )
         , download_mediaMountdir	( "/var/adm/mount" )


### PR DESCRIPTION
TL;DR - ~80% of countries will see a greater than 200% improvement in zypper download performance by disabling drpms. Countries that are in the remaining ~20% will see potentially a 20% decrease in download speed. These are worst case estimates to skew in favour of the countries with lower bandwidths.

Delta RPM's allow a full RPM to be reconstituted on the client system. This represents a resource trade - assuming that the network bandwidth is low and the CPU fast, a smaller package download is worth the cost of the fast CPU and IOPS to reassemble the RPM.

However as with all trades, there is a *crossover* point - where the CPU time and needed IOPS to rebuild the RPM now costs more time than simply doing the full the download of the RPM over the network (especially if IOPS > bandwidth).

Other distros believe this crossover has already been met. In 2023 fedora disable deltarpms by default:
- https://fedoraproject.org/wiki/Changes/Drop_Delta_RPMs

OpenSUSE community users have believed that we also have reached this crossover. This generally is from anecdotal evidence, but has wide consensus amongst generally reliable and technically informed members of the community.

However, we should not just rely on anecdotes, but collect data and evidence to make informed decisions. For this reason, I have performed these tests and given the following analysis.

These tests were performed from Australia with a 100MBit internet connection. This places us around ~46 out of 182 per:
- https://en.wikipedia.org/wiki/List_of_countries_by_Internet_connection_speeds

Tests were performed on a fresh installed OpenSUSE Leap 15.6 server. The machine has 4 cps and 4 gb of ram, on NVME storage capable of 5000mb/s of sustained write IOPS. The CPU is an  Intel(R) Xeon(R) Silver 4310 CPU @ 2.10GHz.

As the default server install has not updated, I performed a `time zypper dup --download-only -y` as a measurement of the performance.

  291 packages to upgrade, 6 new, 1 to change arch.
  Overall download size: 893.9 MiB. Already cached: 0 B. Download only.

> NOTE: For some reason zypper reports the same size with drpm enabled or not.

Since there are many packages to update, this allows us to create an averaged effective dl rate for drpm vs rpm, where the effective dl speed for drpm to be valuable as a tool must exceed that of the effective dl speed of just downloading the rpm as a whole. We are not just seeing a small fraction, but an amortized view of a variety of potential drpms and their application from large to small. We also importantly are seeing the new user experience of their *first* update.

Effective dl is calculated as dl size divided by actual time.

| drpm   | limit   | time              | effective dl
|--------|---------|-------------------|-----------
| y      | 100mbit | 8 min 11.321 secs | 1.81MB/s
| n      | 100mbit | 2 min 51.283 secs | 5.21MB/s

What we see here is that in the default case, the use of drpms is significantly slower. For all countries *above* Australia in the rankings, they will see a similar poor experience. This already indicates that drpm may not be effective in many locales, especially as many of the locales *above* Australia in the internet speed rankings have orders of magnitude large populations, and thus user bases of OpenSUSE as a distribution.

We now need to ask, what is the cross over point where drpm is effective? To do this the machine was set up with an iptables rate limit, and access to a 10GBe mirror. The rate limit is configured with:

  wondershaper -a eth0 -d 1000 -u 1000

Where -d/-u are dl/ul in Kbps. Wondershaper is a script interface to linux tc qdiscs which gives a reliable bandwidth limiter.

| drpm   | limit   | time               | effective dl
|--------|---------|--------------------|--------------
| y      | 10gbe   |  5 min 28.891 secs |  2.71MB/s
| n      | 10gbe   |  0 min  9.388 secs | 95.20MB/s
|--------|---------|--------------------|--------------
| y      | 1gbit   |  5 min 31.770 secs |  2.69MB/s
| n      | 1gbit   |  0 min 16.719 secs | 53.46MB/s
|--------|---------|--------------------|--------------
| y      | 100mbit |  6 min  8.452 secs |  2.42MB/s
| n      | 100mbit |  1 min 27.715 secs | 10.19MB/s
|--------|---------|--------------------|--------------
| y      |  50mbit |  6 min 45.998 secs |  2.20MB/s
| n      |  50mbit |  2 min 45.883 secs |  5.38MB/s
|--------|---------|--------------------|--------------
| y      |  20mbit |  8 min 42.597 secs |  1.71MB/s
| n      |  20mbit |  6 min 40.791 secs |  2.23MB/s
|--------|---------|--------------------|--------------
| y      |  15mbit |  9 min 46.970 secs |  1.52MB/s
| n      |  15mbit |  8 min 51.271 secs |  1.68MB/s
|--------|---------|--------------------|--------------
| y      |  13mbit | 10 min 24.145 secs |  1.43MB/s
| n      |  13mbit | 10 min 11.465 secs |  1.46MB/s
|--------|---------|--------------------|--------------
| y      |  10mbit | 11 min 50.369 secs |  1.25MB/s
| n      |  10mbit | 13 min 12.428 secs |  1.12MB/s

A limitation of this approach is the lack of latency in the connection. We assume that the true crossover point is higher as a result of this since latency affects TCP ACKs, and can cause reductions in overall bandwidth. For this reason, given the data above and the crossover point of 13mbit presented, we will assume that the true crossover point is 20mbit giving a 25% margin of error. Remember that the presented results are not linear, thus why we chose 20mbit Additionally 25% far exceeds the P=0.05 (5%) confidence interval normally demanded of research statistics, and this is in favour of the *worse* case.

So analysing these data we can see some trends. The first is that clients which are NOT bandwidth constrained, are *not* benefiting from drpms. The reason is how drpms are applied which is a single threaded process. The machine in question has a mid-range server CPU and high IOPS, so even assuming *better* hardware, the results at best could be twice as fast, but still fall significantly short of simply downloading the rpm. Users with high bandwidth connections also tend to have high performing CPUs and storage, and are not benefiting from drpms as a result given the data presented with a moderate CPU and high performing IO configuration.

For clients that *are* bandwidth constrained, this also correlates with lower performance hardware, so again drpms are going to perform poorly due to the CPU and IO demands. This once again shows us that drpms are not going to assist over rpms, since the rpm download only requires IO to be greater than or equal to bandwidth, and in a low bandwidth environment even a 5200rpm hard drive in a laptop will have write IOPS that outperform the low bandwidth.

These trends actually skew the reality - the persons who would benefit from drpms are those with the slowest CPUs and IOPS, and yet they still have a poor experience with them as bandwidth still has improved enough that the single threaded drpm apply process can not exceed it. And those with high bandwidth, also have fast CPUs and IOPS, but these CPU no longer actually outperform the bandwidth these users have available to them.

As a result, we can see from these data that the trade is no longer worth while. Even with conservative estimates, 20.5% of countries *may* gain from drpms, while 79.5% are actively harmed by them.

In the case of the 20.5% percent that gain, the benefit is 11% improvement, but for users who have available bandwidth, disabling drpms gives them a 200% improvement (assuming 50mbit).

For these reasons, delta rpms have outlived this usefulness. They were important and relevant at a time where bandwidth constraints were tighter globally, but this no longer holds true, and even in bandwidth limited cases users will majority benefit from the removal of drpms.