### PR TITLE
Fix lost double slash when appending to an absolute FTP url

### DIFF
--- a/tests/zypp/MediaSetAccess_test.cc
+++ b/tests/zypp/MediaSetAccess_test.cc
@@ -328,5 +328,17 @@ BOOST_AUTO_TEST_CASE(msa_remote_tests_ftp)
   msa_remote_tests_impl<FtpServer>();
 }
 
+BOOST_AUTO_TEST_CASE(ftp_absolute_path)
+{
+  FtpServer srv( DATADIR, 10002 );
+  BOOST_REQUIRE( srv.start() );
+
+  zypp::Url base = srv.url();
+  base.setPathName ( zypp::str::Str() << "//" << DATADIR );
+
+  MediaSetAccess setaccess( base, "/" );
+  OnMediaLocation loc( "/src1/cd1/test.txt" );
+  BOOST_CHECK_NO_THROW( setaccess.provideFile ( loc ) );
+}
 
 // vim: set ts=2 sts=2 sw=2 ai et:

--- a/zypp-core/Url.cc
+++ b/zypp-core/Url.cc
@@ -802,7 +802,29 @@ namespace zypp
   // -----------------------------------------------------------------
 
   void Url::appendPathName( const Pathname & path_r, EEncoding eflag_r )
-  { if ( ! path_r.emptyOrRoot() ) setPathName( Pathname(getPathName( eflag_r )) / path_r, eflag_r ); }
+  {
+    if ( ! path_r.emptyOrRoot() ) {
+      // Check on string level to restore leading double slashes "//" (E_DECODED)
+      // Most important for ftp: where "/%2f" (E_ENCODED) denotes an absolute path.
+      std::string upath { getPathName( url::E_DECODED ) };
+      if ( upath.empty() ) {
+        setPathName( path_r.absolutename(), eflag_r );
+      } else {
+        bool doubleslhash = str::startsWith( upath, "//" );
+        Pathname npath { upath };   // now let Pathname handle the correct concatenation
+        if ( eflag_r == url::E_DECODED ) {
+          npath /= path_r;
+        } else {
+          npath /= url::decode( path_r.asString() );
+        }
+        if ( doubleslhash ) {
+          setPathName( "/" + npath.asString(), url::E_DECODED );
+        } else {
+          setPathName( npath.asString(), url::E_DECODED );
+        }
+      }
+    }
+  }
 
   // -----------------------------------------------------------------
   void

--- a/zypp/media/MediaNetworkCommonHandler.cc
+++ b/zypp/media/MediaNetworkCommonHandler.cc
@@ -112,15 +112,9 @@ namespace zypp::media
     if ( canRedir )
       MIL << "Redirecting " << filename_r << " request to geoip location." << std::endl;
 
-    // Simply extend the URLs pathname. An 'absolute' URL path
-    // is achieved by encoding the leading '/' in an URL path:2
-    //   URL: ftp://user@server		-> ~user
-    //   URL: ftp://user@server/		-> ~user
-    //   URL: ftp://user@server//		-> ~user
-    //   URL: ftp://user@server/%2F	-> /
-    //                         ^- this '/' is just a separator
-    Url newurl( baseUrl );
-    newurl.setPathName( ( Pathname("./"+baseUrl.getPathName()) / filename_r ).asString().substr(1) );
+    // Simply extend the URLs pathname:
+    Url newurl { baseUrl };
+    newurl.appendPathName( filename_r );
     return newurl;
   }
 


### PR DESCRIPTION
[bsc#1238315](https://bugzilla.suse.com/show_bug.cgi?id=1238315)

Ftp actually differs between absolute and relative URL paths. Absolute path names begin with a double slash encoded as '/%2F'. This must be preserved when manipulating the path.