### PR TITLE
zypp.conf: Add `lock_timeout` ($ZYPP_LOCK_TIMEOUT) (bsc#1239809)

### DIFF
--- a/zypp.conf
+++ b/zypp.conf
@@ -1,11 +1,20 @@
 ## Configuration file for software management
 ## /etc/zypp/zypp.conf
 ##
-## Boolean values are 0 1 yes no on off true false
-
+## - Boolean values are 0 1 yes no on off true false
+## - Environment variables may overwrite corresponding config values
 
 [main]
-
+##
+## If zypp is locked by another process this is the number of seconds to wait
+## for the lock to become available. A negative value will wait forever. If the
+## lock can not be acquired within the specified time an exception is raised.
+##
+## Valid values: number
+## Default value: 0
+## Environment variable: ZYPP_LOCK_TIMEOUT
+##
+# lock_timeout = 0
 
 ##
 ## Override the detected architecture

--- a/zypp/ZConfig.cc
+++ b/zypp/ZConfig.cc
@@ -528,7 +528,10 @@ namespace zypp
                 if ( _initialTargetDefaults.consume( entry, value ) )
                   continue;
 
-                if ( entry == "arch" )
+                if ( entry == "lock_timeout" ) {
+                  str::strtonum( value, cfg_lockTimeout );
+                }
+                else if ( entry == "arch" )
                 {
                   Arch carch( value );
                   if ( carch != cfg_arch )
@@ -767,6 +770,8 @@ namespace zypp
     Pathname _parsedZyppConf;
     Pathname _announced_root_path;
 
+    long cfg_lockTimeout = 0; // signed!
+
     Arch     cfg_arch;
     Locale   cfg_textLocale;
 
@@ -956,6 +961,15 @@ namespace zypp
   //
   ZConfig::~ZConfig( )
   {}
+
+  long ZConfig::lockTimeout() const
+  {
+    const char * env = getenv("ZYPP_LOCK_TIMEOUT");
+    if ( env ) {
+      return str::strtonum<long>( env );
+    }
+    return _pimpl->cfg_lockTimeout;
+  }
 
   void ZConfig::notifyTargetChanged()
   { return _pimpl->notifyTargetChanged(); }

--- a/zypp/ZConfig.h
+++ b/zypp/ZConfig.h
@@ -76,6 +76,10 @@ namespace zypp
       std::ostream & about( std::ostream & str ) const;
 
     public:
+      /** The number of seconds to wait for the zypp lock to become available. */
+      long lockTimeout() const;
+
+    public:
 
       /** The target root directory.
        * Returns an empty path if no target is set.

--- a/zypp/ZYppFactory.cc
+++ b/zypp/ZYppFactory.cc
@@ -25,6 +25,7 @@ extern "C"
 #include <zypp/base/Backtrace.h>
 #include <zypp/base/LogControl.h>
 #include <zypp/PathInfo.h>
+#include <zypp/ZConfig.h>
 
 #include <zypp/ZYppFactory.h>
 #include <zypp/zypp_detail/ZYppImpl.h>
@@ -396,7 +397,7 @@ namespace zypp
       {
         bool failed = true;
         // bsc#1184399,1213231: A negative ZYPP_LOCK_TIMEOUT will wait forever.
-        const long LOCK_TIMEOUT = str::strtonum<long>( getenv( "ZYPP_LOCK_TIMEOUT" ) );
+        const long LOCK_TIMEOUT = ZConfig::instance().lockTimeout();
         if ( LOCK_TIMEOUT != 0 )
         {
           Date logwait = Date::now();


### PR DESCRIPTION
If zypp is locked by another process this is the number of seconds to wait for the lock to become available. A negative value will wait forever. If the lock can not be acquired within the specified time an exception is raised. The setting may be overwritten by the ZYPP_LOCK_TIMEOUT environment variables