### PR TITLE
Append a trailing slash to baseUrl

### DIFF
--- a/package/libzypp.changes
+++ b/package/libzypp.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun  4 07:43:41 UTC 2025 - Dirk Müller <dmueller@suse.com>
+
+- fix baseurl mirrorlist generation
+
+-------------------------------------------------------------------
 Mon Jun  2 17:50:53 CEST 2025 - ma@suse.de
 
 - Do not warn about no mirrors if mirrorlist was switched on

--- a/zypp/RepoInfo.cc
+++ b/zypp/RepoInfo.cc
@@ -186,7 +186,9 @@ namespace zypp
            && repo::RepoMirrorList::urlSupportsMirrorLink( *_baseUrls.transformedBegin() ) ) {
 
         mlurl = *_baseUrls.transformedBegin ();
-        mlurl.appendPathName("/");
+        if (!mlurl.getPathName().empty() && mlurl.getPathName() != "/" && !zypp::str::endsWith(mlurl.getPathName(), "/") ) {
+          mlurl.setPathName(mlurl.getPathName() + "/");
+        }
         mlurl.setQueryParam("mirrorlist", std::string() );
 
         MIL << "Detected opensuse.org baseUrl with no mirrors, requesting them from : " << mlurl.asString() << std::endl;


### PR DESCRIPTION
The previous code appendPathName() wasn't doing anything because that function is ignoring empty or "/" as parameter. so do it opencoded instead.