### PR TITLE
Improve fix for incorrect filesize handling (bsc#1245220)

### DIFF
--- a/zypp/media/MediaCurl.h
+++ b/zypp/media/MediaCurl.h
@@ -81,7 +81,8 @@ class MediaCurl : public MediaNetworkCommonHandler, public internal::CurlPollHel
     static int aliveCallback( void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow );
     /** Callback reporting download progress. */
     static int progressCallback( void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow );
-    static CURL *progressCallback_getcurl( void *clientp );
+    /** Callback writing the data into our file */
+    static size_t writeCallback( char *ptr, size_t size, size_t nmemb, void *userdata );
 
     void checkProtocol(const Url &url) const override;
 


### PR DESCRIPTION
This patch improves the handling of tracking downloaded filesize by adding a custom writefunction in the MediaCurl backend. The previous fix had the problem that even a redirect would change the expected filesize and thus give us again false alarms. Now we track exactly what is written to the file instead of relying on the curl callbacks.