### PR TITLE
Fix mainpage/examples in doxygen

### DIFF
--- a/doc/autodoc/Doxyfile.cmake
+++ b/doc/autodoc/Doxyfile.cmake
@@ -69,7 +69,7 @@ WARN_LOGFILE           = @DOXYGEN_WARNINGS@
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @ZYPP_SOURCE_DIRS@
+INPUT                  = @ZYPP_DOCINCLUDE_DIR@ @ZYPP_SOURCE_DIRS@
 FILE_PATTERNS          = *.h *.hh *.hxx *.hpp *.h++ *.c *.cc *.cxx *.cpp *.c++ *.tcc *.hcc *.doc
 RECURSIVE              = YES
 EXCLUDE                =


### PR DESCRIPTION
Add back ZYPP_DOCINCLUDE_DIR into the doxygen config file, so that the extra pages from doc/autoinclude are added to the generated configuration. It got lost in a earlier refactoring.