### PR TITLE
Fall back to a writable location when precaching packages without root

### DIFF
--- a/zypp-logic/zypp/RepoInfo.h
+++ b/zypp-logic/zypp/RepoInfo.h
@@ -308,9 +308,28 @@ namespace zypp
       bool usesAutoMetadataPaths() const;
 
       /**
-       * \short Path where this repo packages are cached
+       * @brief Returns a path to the system-defined package cache.
+       * @return the path of the system packages cache
+       */
+      Pathname systemPackagesPath() const;
+
+      /**
+       * @brief Returns a path to the user-controller read/write package cache.
+       * Returns a path under the user's home directory.
+       * If XDG_CACHE_HOME is defined uses XDG_CACHE_HOME/zypp/packages directory.
+       * Uses $HOME/.cache otherwise.
+       * @return the path of the user read/write package cache
+       */
+      Pathname userConfigPackagesPath() const;
+
+      /**
+       * @brief packagesPath Checks if the effective user is allowed to write into the system package cache.
+       * If it's allowed, then return that.
+       * If it's not allowed return the users's package cache (XDG_CACHE_HOME).
+       * @return The path of the packages cache
        */
       Pathname packagesPath() const;
+
       /**
        * \short set the path where the local packages are stored
        *

--- a/zypp-logic/zypp/repo/PackageProvider.h
+++ b/zypp-logic/zypp/repo/PackageProvider.h
@@ -27,6 +27,25 @@ namespace zypp
   namespace repo
   {
 
+    namespace env {
+      /** XDG_CACHE_HOME: base directory relative to which user specific non-essential data files should be stored.
+       * http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+       */
+      inline filesystem::Pathname XDG_CACHE_HOME()
+      {
+        filesystem::Pathname ret;
+        const char * envp = getenv( "XDG_CACHE_HOME" );
+        if ( envp && *envp )
+          ret = envp;
+        else
+        {
+          ret = getenv( "HOME" );
+          ret /= ".cache";
+        }
+        return ret;
+      }
+    } //namespace env
+
     ///////////////////////////////////////////////////////////////////
     /// \class PackageProviderPolicy
     /// \brief Policies and options for \ref PackageProvider

--- a/zypp-logic/zypp/repo/RepoProvideFile.h
+++ b/zypp-logic/zypp/repo/RepoProvideFile.h
@@ -49,6 +49,17 @@ namespace zypp
                              const ProvideFilePolicy & policy_r = ProvideFilePolicy() );
 
     /**
+     * returns a set of paths.
+     *
+     * Depending on the privilege level of the effective user, the path requested will be
+     * - the user r/w cache location if it's a regular unprivileged user
+     * - the system r/o cache location otherwise
+     * @param repo_r
+     * @return a list of paths
+     */
+    std::vector<Pathname> repositoryPaths( RepoInfo repo_r );
+
+    /**
      * \short Provides files from different repos
      *
      * Class that allows to get files from repositories


### PR DESCRIPTION
Until now, when using the --installroot option and the preload mechanism, we get "could not create target file" errors during the preloading phase because zypper tries to write into the general packages cache directory (`/var/cache/zypp/packages/repo-oss/.preload`).

With this change, we detect the lack of permissions and fallback to a writable temporary cache directory, somewhere in
`/var/tmp/zypp.something/var/cache/zypp/packages`.

bsc#1247948