### PR TITLE
Gatekeep mirrored origin

### DIFF
--- a/zypp-logic/zypp-core/MirroredOrigin.cc
+++ b/zypp-logic/zypp-core/MirroredOrigin.cc
@@ -134,10 +134,7 @@ namespace zypp {
   }
 
   struct MirroredOrigin::Private {
-    Private( OriginEndpoint &&authority = {}, std::vector<OriginEndpoint> &&mirrors = {} )
-      : _authority( std::move(authority) )
-      , _origins( std::move(mirrors) )
-    {}
+    Private() = default;
     ~Private() = default;
 
     Private *clone () const {


### PR DESCRIPTION
This way we create a class that the rest of the code can trust that it does not contain invalid origins.

This is another step in the direction of https://github.com/openSUSE/libzypp/pull/699