### PR TITLE
Deprioritize invalid mirrors

### DIFF
--- a/zypp/tests/media/MediaCurl_test.cc
+++ b/zypp/tests/media/MediaCurl_test.cc
@@ -8,6 +8,7 @@
 
 #include <zypp/media/MediaManager.h>
 #include <zypp-core/Url.h>
+#include <zypp-core/MirroredOrigin.h>
 #include <zypp/Digest.h>
 
 #include <iostream>
@@ -500,4 +501,82 @@ BOOST_DATA_TEST_CASE( provide_via_proxy_bsc1245220, bdata::make( backend ), back
 
   BOOST_REQUIRE_NO_THROW(mm.provideFile( id, loc ));
 }
+
+// case: verify that failed mirrors are deprioritized for subsequent requests
+BOOST_DATA_TEST_CASE( test_mirror_fallback_persistence, bdata::make( backend ), backend )
+{
+  // Setup ZConfig to avoid touching real system files
+  zypp::filesystem::TmpDir repoManagerRoot;
+  zypp::ZConfig::instance().setRepoManagerRoot( repoManagerRoot.path() );
+
+  // 1. Setup two servers on different ports
+  WebServer serverFail( "/tmp", 10001 );
+  WebServer serverSuccess( "/tmp", 10002 );
+  BOOST_REQUIRE( serverFail.start() );
+  BOOST_REQUIRE( serverSuccess.start() );
+
+  int failServerRequests = 0;
+  int successServerRequests = 0;
+
+  serverFail.setDefaultHandler( [&]( WebServer::Request &req ) {
+    failServerRequests++;
+    if ( req.params["REQUEST_URI"].find("file1") != std::string::npos )
+        req.rout << "Status: 404 Not Found\r\n\r\n";
+    else
+        req.rout << "Status: 200 OK\r\n\r\nSuccess from FailServer";
+  });
+
+  serverSuccess.setDefaultHandler( [&]( WebServer::Request &req ) {
+    successServerRequests++;
+    req.rout << "Status: 200 OK\r\n\r\nSuccess from SuccessServer";
+  });
+
+  // 2. Setup MirroredOrigin
+  // Authority: Use a non-existent port to force connection failure and fallback
+  zypp::Url authUrl("http://localhost:9999/authority");
+  authUrl.setQueryParam("mediahandler", backend);
+  
+  zypp::MirroredOrigin origin( authUrl );
+  
+  zypp::Url url1 = serverFail.url();
+  url1.setQueryParam("mediahandler", backend);
+  origin.addMirror( url1 );
+
+  zypp::Url url2 = serverSuccess.url();
+  url2.setQueryParam("mediahandler", backend);
+  origin.addMirror( url2 );
+
+  zypp::media::MediaManager mm;
+  zypp::media::MediaAccessId id;
+  id = mm.open( origin );
+  mm.attach(id);
+  zypp_defer {
+    mm.releaseAll ();
+    mm.close (id);
+  };
+
+  // 3. First download: file1
+  // Expected behavior: 
+  // - mirrorOrder() returns [1, 2, 0]
+  // - Tries Mirror 1 (FailServer) -> returns 404
+  // - Falls back to Mirror 2 (SuccessServer) -> returns 200
+  zypp::OnMediaLocation loc1("/handler/file1");
+  BOOST_CHECK_NO_THROW( mm.provideFile( id, loc1 ) );
+  
+  BOOST_CHECK_EQUAL( failServerRequests, 1 );
+  BOOST_CHECK_EQUAL( successServerRequests, 1 );
+
+  // 4. Second download: file2
+  // DESIRED BEHAVIOR:
+  // After the first failure, Mirror 1 should have been moved to the end of the list.
+  // Thus, it should try Mirror 2 (serverSuccess) FIRST for file2.
+  zypp::OnMediaLocation loc2("/handler/file2");
+  BOOST_CHECK_NO_THROW( mm.provideFile( id, loc2 ) );
+
+  // VERIFICATION: confirm that failed mirror was NOT tried again
+  // (We expect failServerRequests to remain 1)
+  BOOST_CHECK_MESSAGE( failServerRequests == 1, 
+    "Failed mirror was NOT reordered! (failServerRequests=" << failServerRequests << ")" );
+}
+
 

--- a/zypp/zypp/media/MediaCurl.cc
+++ b/zypp/zypp/media/MediaCurl.cc
@@ -561,6 +561,9 @@ void MediaCurl::getFileCopy( const OnMediaLocation & srcFile , const Pathname & 
     } catch (MediaException & excpt_r) {
       if ( !canTryNextMirror ( excpt_r ) )
         ZYPP_RETHROW(excpt_r);
+
+      that->deprioritizeMirror( mirr );
+
       lastErr = ZYPP_FWD_CURRENT_EXCPT();
     }
   }
@@ -851,6 +854,9 @@ bool MediaCurl::getDoesFileExist( const Pathname & filename ) const
     } catch (MediaException & excpt_r) {
       if ( !canTryNextMirror ( excpt_r ) )
         ZYPP_RETHROW(excpt_r);
+
+      that->deprioritizeMirror( i );
+
       lastErr = ZYPP_FWD_CURRENT_EXCPT();
     }
   }

--- a/zypp/zypp/media/MediaCurl2.cc
+++ b/zypp/zypp/media/MediaCurl2.cc
@@ -265,6 +265,9 @@ namespace zypp {
             }
             ZYPP_RETHROW(excpt_r);
           }
+
+          this->deprioritizeMirror( mirr );
+
           ZYPP_CAUGHT(excpt_r);
           continue;
         }
@@ -318,6 +321,9 @@ namespace zypp {
           if( !canTryNextMirror ( e ) ) {
             break;
           }
+
+          this->deprioritizeMirror( mirr );
+
           continue;
         }
         // exists

--- a/zypp/zypp/media/MediaHandler.h
+++ b/zypp/zypp/media/MediaHandler.h
@@ -497,6 +497,11 @@ class MediaHandler {
         std::string protocol() const { return _origin.scheme(); }
 
         /**
+         * Access the internal MirroredOrigin (authority and mirrors).
+         **/
+        const MirroredOrigin &origin() const { return _origin; }
+
+        /**
          * Primary Url used.
          **/
         Url url() const { return _origin.authority().url(); }

--- a/zypp/zypp/media/MediaNetworkCommonHandler.cc
+++ b/zypp/zypp/media/MediaNetworkCommonHandler.cc
@@ -38,6 +38,11 @@ namespace zypp::media
   {
     _redirTargets.clear ();
     std::transform ( _origin.begin(), _origin.end(), std::back_inserter(_redirTargets), []( const OriginEndpoint &url_r ) { return findGeoIPRedirect(url_r.url()); } );
+
+    // initialize default mirror order: mirrors [1..N] then authority [0]
+    _mirrOrder.reserve( _origin.endpointCount() );
+    for( unsigned i = 1; i < _origin.endpointCount () ; i++ ) { _mirrOrder.push_back(i); }
+    _mirrOrder.push_back(0);
   }
 
   void MediaNetworkCommonHandler::attachTo (bool next)
@@ -322,16 +327,21 @@ namespace zypp::media
 
   std::vector<unsigned int> MediaNetworkCommonHandler::mirrorOrder(const OnMediaLocation &loc) const
   {
-    std::vector<unsigned> mirrOrder;
     if ( !loc.mirrorsAllowed () ) {
       MIL << "Fetching file " << loc << " from authority only: " << _origin << std::endl;
-      mirrOrder.push_back (0); // only authority
-    } else {
-      mirrOrder.reserve( _origin.endpointCount() );
-      for( unsigned i = 1; i < _origin.endpointCount () ; i++ ) { mirrOrder.push_back(i) ;}
-      mirrOrder.push_back(0); // authority last
+      return { 0 }; // only authority
     }
-    return mirrOrder;
+    return _mirrOrder;
+  }
+
+  void MediaNetworkCommonHandler::deprioritizeMirror( unsigned mirr ) const
+  {
+    auto it = std::find( _mirrOrder.begin(), _mirrOrder.end(), mirr );
+    if ( it != _mirrOrder.end() && _mirrOrder.size() > 1 )
+    {
+        // move found index to the end
+        std::rotate( it, it + 1, _mirrOrder.end() );
+    }
   }
 
   bool MediaNetworkCommonHandler::authenticate( const Url &url, CredentialManager &cm, TransferSettings &settings, const std::string & availAuthTypes, bool firstTry )

--- a/zypp/zypp/media/MediaNetworkCommonHandler.h
+++ b/zypp/zypp/media/MediaNetworkCommonHandler.h
@@ -88,6 +88,11 @@ namespace zypp
 
       std::vector<unsigned> mirrorOrder( const OnMediaLocation &loc ) const;
 
+      /**
+       * @brief Move mirror index @a mirr to the end of the attempt list.
+       */
+      void deprioritizeMirror( unsigned mirr ) const;
+
     public:
 
       // standard auth procedure, shared with CommitPackagePreloader
@@ -114,6 +119,7 @@ namespace zypp
 
     protected:
       std::vector<Url> _redirTargets;
+      mutable std::vector<unsigned> _mirrOrder;
     };
 
   } // namespace media


### PR DESCRIPTION
When we download packages from a list of mirrors and one of those mirrors has some problem, each of those packages will try to download from the faulty mirror before falling back to the next one.

This change adds some memory to the MediaNetworkCommonHandle so if a mirror has a problem, we put it at the back of the list so the next package does not try to download from it.

Fixes https://github.com/openSUSE/zypper/issues/636