### PR TITLE
libzypp.spec: Add missing graphviz-gd BuildRequires (boo#1259842)

### DIFF
--- a/zypp/libzypp.spec.cmake
+++ b/zypp/libzypp.spec.cmake
@@ -153,6 +153,7 @@ BuildRequires:  ghostscript
 BuildRequires:  gcc-c++ >= 7
 BuildRequires:  gettext-devel
 BuildRequires:  graphviz
+BuildRequires:  graphviz-gd
 BuildRequires:  libxml2-devel
 BuildRequires:  yaml-cpp-devel
 


### PR DESCRIPTION
The build log is littered with:

Format: "png" not recognized. Use one of: canon cmap cmapx cmapx_np dot dot_json eps fig gv imap imap_np ismap json json0 pic plain plain-ext pov ps ps2 svg svg_inline svgz tk xdot xdot1.2 xdot1.4 xdot_json

This can be resolved by adding graphviz-gd as a build dependency.