### PR TITLE
Fix different schemas for authorities and mirrors

### DIFF
--- a/zypp-logic/zypp-core/MirroredOrigin.cc
+++ b/zypp-logic/zypp-core/MirroredOrigin.cc
@@ -176,7 +176,6 @@ namespace zypp {
     }
 
     const auto &newScheme = newAuthority.scheme();
-    bool newAuthIsDl = newAuthority.url().schemeIsDownloading();
 
     _pimpl->_authorities.clear();
     _pimpl->_authorities.push_back( std::move(newAuthority) );
@@ -186,9 +185,9 @@ namespace zypp {
 
     // house keeeping, we want only compatible mirrors
     for ( auto i = _pimpl->_origins.begin (); i != _pimpl->_origins.end(); ) {
-      if (    ( newAuthIsDl && !i->schemeIsDownloading() ) // drop mirror if its not downloading but authority is
-           && ( i->scheme () != newScheme )                // otherwise drop if scheme is not identical
-      ) {
+      // drop mirror if it's scheme conflicts with the authorities scheme
+      // otherwise drop if scheme is not identical
+      if ( !areAuthoritiesCompatible(*i) && ( i->scheme () != newScheme ) ) {
         MIL << "Dropping mirror " << *i << " scheme is not compatible to new authority URL ( " << i->scheme() << " vs " << newScheme << ")" << std::endl;
         i = _pimpl->_origins.erase(i);
       } else {
@@ -200,6 +199,23 @@ namespace zypp {
   const std::vector<OriginEndpoint> &MirroredOrigin::authorities() const
   {
     return _pimpl->_authorities;
+  }
+
+  bool MirroredOrigin::isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror)
+  {
+    return (authority.schemeIsDownloading() && mirror.schemeIsDownloading())
+        || (!authority.schemeIsDownloading() && !mirror.schemeIsDownloading());
+  }
+
+  bool MirroredOrigin::areAuthoritiesCompatible(const OriginEndpoint& mirror)
+  {
+    for (auto authority: _pimpl->_authorities)
+    {
+      if (!isAuthorityCompatible(authority, mirror))
+        return false;
+    }
+
+    return true;
   }
 
   const OriginEndpoint &MirroredOrigin::authority() const
@@ -258,11 +274,9 @@ namespace zypp {
 
     if ( _pimpl->authoritiesAreValid() ) {
       const auto &authScheme = _pimpl->_authorities[0].scheme();
-      bool authIsDl = _pimpl->_authorities[0].schemeIsDownloading();
 
-      if ( ( authIsDl && !newMirror.schemeIsDownloading () )
-           && ( authScheme != newMirror.scheme () )
-      ) {
+      // As all the authorities are either downloading or non-downloading, if the first is compatible, the rest are as well
+      if ( !isAuthorityCompatible(authority(), newMirror) && ( authScheme != newMirror.scheme () ) ) {
         MIL << "Ignoring mirror " << newMirror << " scheme is not compatible to authority URL ( " << newMirror.scheme() << " vs " << authScheme << ")" << std::endl;
         return false;
       }

--- a/zypp-logic/zypp-core/MirroredOrigin.cc
+++ b/zypp-logic/zypp-core/MirroredOrigin.cc
@@ -187,7 +187,7 @@ namespace zypp {
     for ( auto i = _pimpl->_origins.begin (); i != _pimpl->_origins.end(); ) {
       // drop mirror if it's scheme conflicts with the authorities scheme
       // otherwise drop if scheme is not identical
-      if ( !areAuthoritiesCompatible(*i) && ( i->scheme () != newScheme ) ) {
+      if ( i->scheme () != newScheme && !isAuthorityCompatible(authority(), *i) ) {
         MIL << "Dropping mirror " << *i << " scheme is not compatible to new authority URL ( " << i->scheme() << " vs " << newScheme << ")" << std::endl;
         i = _pimpl->_origins.erase(i);
       } else {
@@ -201,15 +201,9 @@ namespace zypp {
     return _pimpl->_authorities;
   }
 
-  bool MirroredOrigin::isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror)
+  bool MirroredOrigin::areAuthoritiesCompatible(const OriginEndpoint& mirror) const
   {
-    return (authority.schemeIsDownloading() && mirror.schemeIsDownloading())
-        || (!authority.schemeIsDownloading() && !mirror.schemeIsDownloading());
-  }
-
-  bool MirroredOrigin::areAuthoritiesCompatible(const OriginEndpoint& mirror)
-  {
-    for (auto authority: _pimpl->_authorities)
+    for (const auto &authority: _pimpl->_authorities)
     {
       if (!isAuthorityCompatible(authority, mirror))
         return false;
@@ -276,7 +270,7 @@ namespace zypp {
       const auto &authScheme = _pimpl->_authorities[0].scheme();
 
       // As all the authorities are either downloading or non-downloading, if the first is compatible, the rest are as well
-      if ( !isAuthorityCompatible(authority(), newMirror) && ( authScheme != newMirror.scheme () ) ) {
+      if ( authScheme != newMirror.scheme () && !isAuthorityCompatible(authority(), newMirror) ) {
         MIL << "Ignoring mirror " << newMirror << " scheme is not compatible to authority URL ( " << newMirror.scheme() << " vs " << authScheme << ")" << std::endl;
         return false;
       }

--- a/zypp-logic/zypp-core/MirroredOrigin.cc
+++ b/zypp-logic/zypp-core/MirroredOrigin.cc
@@ -187,7 +187,7 @@ namespace zypp {
     for ( auto i = _pimpl->_origins.begin (); i != _pimpl->_origins.end(); ) {
       // drop mirror if it's scheme conflicts with the authorities scheme
       // otherwise drop if scheme is not identical
-      if ( i->scheme () != newScheme && !isAuthorityCompatible(authority(), *i) ) {
+      if ( !isAuthorityCompatible(authority(), *i) ) {
         MIL << "Dropping mirror " << *i << " scheme is not compatible to new authority URL ( " << i->scheme() << " vs " << newScheme << ")" << std::endl;
         i = _pimpl->_origins.erase(i);
       } else {
@@ -270,7 +270,7 @@ namespace zypp {
       const auto &authScheme = _pimpl->_authorities[0].scheme();
 
       // As all the authorities are either downloading or non-downloading, if the first is compatible, the rest are as well
-      if ( authScheme != newMirror.scheme () && !isAuthorityCompatible(authority(), newMirror) ) {
+      if ( !isAuthorityCompatible(authority(), newMirror) ) {
         MIL << "Ignoring mirror " << newMirror << " scheme is not compatible to authority URL ( " << newMirror.scheme() << " vs " << authScheme << ")" << std::endl;
         return false;
       }

--- a/zypp-logic/zypp-core/MirroredOrigin.h
+++ b/zypp-logic/zypp-core/MirroredOrigin.h
@@ -304,9 +304,19 @@ namespace zypp {
     const OriginEndpoint &at( uint index ) const;
     OriginEndpoint &at( uint index );
 
+    /*!
+     * Check if all authorities are compatible with a specific mirror
+     */
+    bool areAuthoritiesCompatible(const OriginEndpoint& mirror);
+
   private:
     struct Private;
     RWCOW_pointer<Private> _pimpl;
+
+    /*!
+     * An authority and a mirror are not compatible if one is downloadable and the other is not
+     */
+    bool isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror);
   };
 
   ZYPP_API std::ostream & operator<<( std::ostream & str, const MirroredOrigin & origin );

--- a/zypp-logic/zypp-core/MirroredOrigin.h
+++ b/zypp-logic/zypp-core/MirroredOrigin.h
@@ -307,7 +307,7 @@ namespace zypp {
     /*!
      * Check if all authorities are compatible with a specific mirror
      */
-    bool areAuthoritiesCompatible(const OriginEndpoint& mirror);
+    bool areAuthoritiesCompatible(const OriginEndpoint& mirror) const;
 
   private:
     struct Private;
@@ -316,7 +316,10 @@ namespace zypp {
     /*!
      * An authority and a mirror are not compatible if one is downloadable and the other is not
      */
-    bool isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror);
+    static bool isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror)
+    {
+      return (authority.schemeIsDownloading() == mirror.schemeIsDownloading());
+    }
   };
 
   ZYPP_API std::ostream & operator<<( std::ostream & str, const MirroredOrigin & origin );

--- a/zypp-logic/zypp-core/MirroredOrigin.h
+++ b/zypp-logic/zypp-core/MirroredOrigin.h
@@ -318,7 +318,9 @@ namespace zypp {
      */
     static bool isAuthorityCompatible(const OriginEndpoint& authority, const OriginEndpoint& mirror)
     {
-      return (authority.schemeIsDownloading() == mirror.schemeIsDownloading());
+      if (authority.scheme() == mirror.scheme())
+          return true;
+      return authority.schemeIsDownloading() && mirror.schemeIsDownloading();
     }
   };
 

--- a/zypp/tests/zypp/MirroredOrigin_test.cc
+++ b/zypp/tests/zypp/MirroredOrigin_test.cc
@@ -146,6 +146,13 @@ BOOST_AUTO_TEST_CASE(clean_mirrors_on_auth_change)
     // should retain original order
     BOOST_CHECK_EQUAL( origin[1], OriginEndpoint{http_mirror1} );
     BOOST_CHECK_EQUAL( origin[2], OriginEndpoint{https_auth} );
+
+    // specifying the authority to be a non downloading scheme should remove all downloading ones as well
+    origin.setAuthority( file_auth );
+    BOOST_CHECK(origin.isValid());
+    BOOST_CHECK(!origin.schemeIsDownloading());
+    BOOST_CHECK(!origin.authority().schemeIsDownloading());
+    BOOST_CHECK_EQUAL( origin.mirrors ().size(), 0 );
 }
 
 

--- a/zypp/tests/zypp/MirroredOrigin_test.cc
+++ b/zypp/tests/zypp/MirroredOrigin_test.cc
@@ -155,6 +155,25 @@ BOOST_AUTO_TEST_CASE(clean_mirrors_on_auth_change)
     BOOST_CHECK_EQUAL( origin.mirrors ().size(), 0 );
 }
 
+BOOST_AUTO_TEST_CASE(non_downloading_different_schemes_incompatible)
+{
+    BOOST_TEST_MESSAGE("Testing MirroredOrigin: Non-downloading schemes with different types should be incompatible...");
+    // dvd and file are both non-downloading, but they are different schemes
+    // They should NOT be compatible - you can't use a file mirror for a dvd authority
+    MirroredOrigin origin(dvd_auth);
+
+    // Adding a file mirror to a dvd authority should fail because they are different non-downloading schemes
+    BOOST_CHECK_EQUAL(
+                origin.addMirror(file_auth),
+                false
+                );
+    BOOST_CHECK_EQUAL( origin.mirrors().size(), 0 );
+
+    // Adding another dvd mirror should work (same scheme)
+    OriginEndpoint dvd_mirror{Url("dvd:///mnt/backup_dvd")};
+    BOOST_CHECK_EQUAL( origin.addMirror(dvd_mirror), true );
+    BOOST_CHECK_EQUAL( origin.mirrors().size(), 1 );
+}
 
 BOOST_AUTO_TEST_CASE(iteration_and_access)
 {


### PR DESCRIPTION
When an authority is a downloading one and its mirrors is not (or the other way around) it's scheme is considered incompatible, so we clean its mirrors to not have mixed schemes.