### PR TITLE
Explicitly_set_pool_DISTTYPE_RPM (fixes #726)

### DIFF
--- a/zypp-logic/zypp/ng/sat/stringpool.cc
+++ b/zypp-logic/zypp/ng/sat/stringpool.cc
@@ -33,6 +33,10 @@ namespace zyppng::sat {
     {
       ZYPP_THROW( zypp::Exception( _("Can not create sat-pool.") ) );
     }
+    // libzypp#726: If the disttype is unset, ::pool_evrcmp_str uses
+    // the default flavor set at compiletime. But even on DEBIAN we
+    // handle rpm packages, so their rules must be applied.
+    ::pool_setdisttype( _pool, DISTTYPE_RPM );
   }
 
 }

--- a/zypp/zypp/sat/detail/PoolImpl.cc
+++ b/zypp/zypp/sat/detail/PoolImpl.cc
@@ -186,8 +186,9 @@ namespace zypp
       PoolImpl::PoolImpl()
         : _pool( zyppng::sat::StringPool::instance().getPool() )
       {
-        // by now we support only a RPM backend
-        ::pool_setdisttype(_pool, DISTTYPE_RPM );
+        // libzypp#726: ::pool_setdisttype(_pool, DISTTYPE_RPM )
+        // is already set by the StringPool::instance because the
+        // disttype affects the version string comparison.
 
         // initialialize logging
         if ( env::LIBSOLV_DEBUGMASK() )


### PR DESCRIPTION
If the disttype is unset, ::pool_evrcmp_str uses the default flavor set at compiletime. But even on DEBIAN we handle rpm packages, so their rules must be applied.