### PR TITLE
StringV: guard hasPrefix/hasPrefixCI against reading past the view end

### DIFF
--- a/zypp-logic/zypp-core/base/StringV.h
+++ b/zypp-logic/zypp-core/base/StringV.h
@@ -93,11 +93,11 @@ namespace zypp
 
     /** Return whether \a str_r has prefix \a prefix_r. */
     inline bool hasPrefix( std::string_view str_r, std::string_view prefix_r )
-    { return( ::strncmp( str_r.data(), prefix_r.data(), prefix_r.size() ) == 0 ); }
+    { return( str_r.size() >= prefix_r.size() && ::strncmp( str_r.data(), prefix_r.data(), prefix_r.size() ) == 0 ); }
 
     /** \overload Case insensitive */
     inline bool hasPrefixCI( std::string_view str_r, std::string_view prefix_r  )
-    { return( ::strncasecmp( str_r.data(), prefix_r.data(), prefix_r.size()  ) == 0 ); }
+    { return( str_r.size() >= prefix_r.size() && ::strncasecmp( str_r.data(), prefix_r.data(), prefix_r.size()  ) == 0 ); }
 
     ///////////////////////////////////////////////////////////////////
     namespace detail

--- a/zypp/tests/zypp/StringV_test.cc
+++ b/zypp/tests/zypp/StringV_test.cc
@@ -234,3 +234,49 @@ BOOST_AUTO_TEST_CASE(trimming)
   BOOST_CHECK_EQUAL(  trim(" \t1\t ", " "),  "\t1\t" );
   BOOST_CHECK_EQUAL(  trim(" \t1\t ", ""),  " \t1\t " );
 }
+
+BOOST_AUTO_TEST_CASE(prefix)
+{
+  // The empty prefix is always present.
+  BOOST_CHECK( hasPrefix( "", "" ) );
+  BOOST_CHECK( hasPrefix( "abc", "" ) );
+  BOOST_CHECK( hasPrefixCI( "", "" ) );
+  BOOST_CHECK( hasPrefixCI( "abc", "" ) );
+
+  // Plain prefix matching.
+  BOOST_CHECK( hasPrefix( "abc", "a" ) );
+  BOOST_CHECK( hasPrefix( "abc", "ab" ) );
+  BOOST_CHECK( hasPrefix( "abc", "abc" ) );
+  BOOST_CHECK( ! hasPrefix( "abc", "b" ) );
+  BOOST_CHECK( ! hasPrefix( "abc", "Ab" ) );
+
+  // Case insensitive matching.
+  BOOST_CHECK( hasPrefixCI( "abc", "A" ) );
+  BOOST_CHECK( hasPrefixCI( "abc", "AB" ) );
+  BOOST_CHECK( hasPrefixCI( "abc", "ABC" ) );
+  BOOST_CHECK( hasPrefixCI( "ABC", "abc" ) );
+  BOOST_CHECK( ! hasPrefixCI( "abc", "B" ) );
+
+  // The view is shorter than the prefix: must return false WITHOUT reading
+  // past the end of the view's underlying buffer (which would be UB).
+  BOOST_CHECK( ! hasPrefix( "ab", "abc" ) );
+  BOOST_CHECK( ! hasPrefix( "", "x" ) );
+  BOOST_CHECK( ! hasPrefixCI( "ab", "abc" ) );
+  BOOST_CHECK( ! hasPrefixCI( "", "x" ) );
+
+  // string_view of a partial range: hasPrefix must look only at the
+  // visible part of the view, not at the surrounding buffer. With the
+  // previous strncmp-only implementation this returned true because
+  // strncmp would read past the view's end into the buffer.
+  const char buf[] = "abcdef";
+  std::string_view sv( buf, 3 );  // "abc" backed by a longer buffer
+  BOOST_CHECK_EQUAL( sv.size(), 3u );
+  BOOST_CHECK( ! hasPrefix( sv, "abcd" ) );
+  BOOST_CHECK( ! hasPrefix( sv, "abcde" ) );
+  BOOST_CHECK( ! hasPrefixCI( sv, "ABCD" ) );
+  BOOST_CHECK( ! hasPrefixCI( sv, "ABCDE" ) );
+  // But the view's own prefixes are still detected.
+  BOOST_CHECK( hasPrefix( sv, "abc" ) );
+  BOOST_CHECK( hasPrefix( sv, "ab" ) );
+  BOOST_CHECK( hasPrefixCI( sv, "ABC" ) );
+}


### PR DESCRIPTION
## Summary

`zypp::strv::hasPrefix(std::string_view, std::string_view)` and its case-insensitive overload pass `prefix_r.size()` straight to `::strncmp` / `::strncasecmp` without first checking that `str_r.size() >= prefix_r.size()`. Because `std::string_view` is not required to be NUL-terminated, when the prefix is longer than the view both calls read past the end of the view's underlying buffer (undefined behavior, flagged by AddressSanitizer as a heap-buffer-overflow). If the bytes following the view happen to match the rest of the prefix, the call also returns the wrong boolean result.

This PR adds the missing length short-circuit, matching the style already used by `str::hasSuffix` in `zypp-core/base/String.h`, and adds a regression test case in `StringV_test.cc`.

```cpp
inline bool hasPrefix( std::string_view str_r, std::string_view prefix_r )
{ return( str_r.size() >= prefix_r.size() && ::strncmp( str_r.data(), prefix_r.data(), prefix_r.size() ) == 0 ); }

inline bool hasPrefixCI( std::string_view str_r, std::string_view prefix_r  )
{ return( str_r.size() >= prefix_r.size() && ::strncasecmp( str_r.data(), prefix_r.data(), prefix_r.size()  ) == 0 ); }
```

Callers in the zyppng curl path (`curlmultiparthandler.cc`, `request.cc`) check curl-supplied header lines against literals like `"HTTP/"`, `"Location:"`, `"Content-Length:"`, `"Content-Range:"`, `"Content-Type:"` after trimming, so a trimmed view shorter than the literal would previously have triggered the over-read.

Closes #735

## Reproducer (AddressSanitizer)

```cpp
char *p = (char*)malloc(3);
p[0] = 'a'; p[1] = 'b'; p[2] = 'c';
std::string_view sv( p, 3 );
zypp::strv::hasPrefix( sv, "abcde" );  // heap-buffer-overflow, may also return true
```

```
==…==ERROR: AddressSanitizer: heap-buffer-overflow on address …
READ of size 4 at … thread T0
    #0 strncmp …
    #1 hasPrefix(std::string_view, std::string_view) …
```

After the fix the call returns `false` without entering `strncmp`.

## Test plan

- [x] Added `BOOST_AUTO_TEST_CASE(prefix)` in `zypp/tests/zypp/StringV_test.cc` covering:
  - empty prefix (always present),
  - plain prefix matches (including full string and case mismatch),
  - case-insensitive matches,
  - prefix strictly longer than the view (must return false; previously could be UB or wrong result),
  - a `std::string_view` that aliases a longer underlying buffer (the case that previously returned `true` for a too-long prefix because `strncmp` walked into the surrounding bytes).
- [x] Replicated the buggy and fixed implementations standalone under `g++ -std=c++17 -fsanitize=address` to verify ASan flags the original `strncmp` over-read and that the size-guarded version returns the correct result without reading past the view end.