### PR TITLE
zypp.conf: Allow [env] section to add environment variables.

### DIFF
--- a/zypp/doc/zypp.conf.5.txt
+++ b/zypp/doc/zypp.conf.5.txt
@@ -363,6 +363,15 @@ The file is read if it exists, but new credentials are usually stored in the use
 *arch* (_<UNSET>_)::
     [__Expert Only!_] Only set it if you actually know what you're doing! Overrides the _autodetected_ system architecture. Sometimes used for testing, but there's actually no use case unless the autodetection would fail.
 
+*[env]*
+~~~~~~~
+The section allows _adding_ environment variables after the host system's configuration has been parsed. Each _key/value_ pair is applied to the process environment if it does not already exist. It will neither amend nor unset already existing environment variables.
+
+*key = value* attempts to set the environment variable named _key_ to _value_.
+
+This feature is designed to enable environment-specific settings or debugging options over an extended period. However, note that any environment variables required before configuration files are parsed cannot be set here, as they will have no effect. (e.g. ZYPP_LOGFILE)
+
+
 FILES
 -----
 _/{vendorconfdir}/zypp/zypp.conf +
@@ -395,5 +404,3 @@ _ZYPP_CONF_::
 SEE ALSO
 --------
 *zypper*(8)
-
-

--- a/zypp/zypp/ZConfig.cc
+++ b/zypp/zypp/ZConfig.cc
@@ -9,13 +9,15 @@
 /** \file	zypp/ZConfig.cc
  *
 */
-
+#include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <map>
 #include <zypp-core/APIConfig.h>
 #include <zypp-core/base/LogTools.h>
 #include <zypp-core/base/IOStream.h>
 #include <zypp-core/base/InputStream>
+#include <zypp-core/base/Errno.h>
 #include <zypp-core/base/String.h>
 #include <zypp-core/base/Regex.h>
 
@@ -341,6 +343,9 @@ namespace zypp
         MIL << "libzypp: " LIBZYPP_VERSION_STRING << " (" << LIBZYPP_CODESTREAM << ")" << endl;
 
         ZyppConfIniMap iniMap;  // Scan the default zypp.conf settings
+
+        using EnvMap = std::map<std::string,std::string>;
+        std::optional<EnvMap> envMap;
         for ( const auto & section : iniMap.sections() ) {
           for ( const auto & [entry,value] : iniMap.entries( section ) ) {
 
@@ -525,8 +530,35 @@ namespace zypp
                 pWAR( "zypp.conf: Unknown entry in [main]:", entry, "=", value );
               }
             }
+            else if ( section == "env" )
+            {
+              if ( !envMap )
+                envMap = EnvMap();
+              auto [it, inserted] = envMap->emplace( entry, value );
+              if ( !inserted ) {
+                WAR << "zypp.conf [env]: duplicate key '" << entry << "', shadowing previous value '" << it->second << "' with '" << value << "'" << endl;
+                it->second = value;
+              }
+            }
             else { // unknown section {
               pWAR( "zypp.conf: Unknown section:", str::sconcat("[",section,"]"), entry, "=", value );
+            }
+          }
+        }
+
+        if ( envMap ) {
+          for ( const auto & [entry, value] : *envMap ) {
+            const char* exists = ::getenv( entry.c_str() );
+            if ( exists == nullptr ) {
+              if ( ::setenv( entry.c_str(), value.c_str(), 0 ) != 0 ) {
+                pWAR( "zypp.conf [env]: set", str::sconcat("'",entry,"=",value,"'"), ": failed", Errno() );
+              }
+              else {
+                pMIL( "zypp.conf [env]: set", str::sconcat("'",entry,"=",value,"'") );
+              }
+            }
+            else {
+              pWAR( "zypp.conf [env]: skip", str::sconcat("'",entry,"=",value,"'"), ": is already set to", str::sconcat("'",exists,"'") );
             }
           }
         }


### PR DESCRIPTION
This feature is designed to enable environment-specific settings or debugging options over an extended period. See zypp.conf(5).