### PR TITLE
zypp.conf: add solver.NoUpdateProvide (default: false) option

### DIFF
--- a/zypp/doc/zypp.conf.5.txt
+++ b/zypp/doc/zypp.conf.5.txt
@@ -252,6 +252,12 @@ _Update_: Focus on updating requested packages and their dependencies as much as
 This option should be used on a case by case basis, enabled via command line options or switches the applications offer. Changing the global default on a system where unattended actions are performed, may easily damage your system.
 
 // --------------------------------------------------------------------------------
+*solver.noUpdateProvide* (__false__)::
+    [_Expert Only!_] In general, packages that obsolete another package are treated as update candidates for the obsoleted package. However, SUSE-specific update rules prefer candidates that also explicitly 'provide' the obsoleted package.
++
+Sometimes it is necessary or helpful to disable this rule.
+
+// --------------------------------------------------------------------------------
 *solver.checkSystemFile* (_/etc/zypp/systemCheck_)::
     This file contains requirements and conflicts which fulfill the needs of a running system. For example the system would be broken if no *glibc* or *kernel* is installed. The resolver is always aware of these constraints and watches they are not violated.
 +

--- a/zypp/zypp/Resolver.cc
+++ b/zypp/zypp/Resolver.cc
@@ -120,6 +120,10 @@ namespace zypp
   void Resolver::setDefaultCleandepsOnRemove()		{ _pimpl->setCleandepsOnRemove( indeterminate ); }
   bool Resolver::cleandepsOnRemove() const		{ return _pimpl->cleandepsOnRemove(); }
 
+  void Resolver::setNoUpdateProvide( bool yesno_r )	{ _pimpl->setNoUpdateProvide( yesno_r ); }
+  void Resolver::setDefaultNoUpdateProvide()		{ _pimpl->setNoUpdateProvide( indeterminate ); }
+  bool Resolver::noUpdateProvide() const		{ return _pimpl->noUpdateProvide(); }
+
 #define ZOLV_FLAG_BOOL( ZSETTER, ZGETTER )					\
   void Resolver::ZSETTER( bool yesno_r ){ _pimpl->ZSETTER( yesno_r ); }		\
   bool Resolver::ZGETTER() const	{ return _pimpl->ZGETTER(); }		\

--- a/zypp/zypp/Resolver.h
+++ b/zypp/zypp/Resolver.h
@@ -313,6 +313,17 @@ namespace zypp
     void setDefaultCleandepsOnRemove(); // set back to default (in zypp.conf)
     bool cleandepsOnRemove() const;
 
+    /** Do not prefer update candidates also providing the old package.
+     * In general, packages that obsolete another package are treated as
+     * update candidates for the obsoleted package. However, SUSE-specific
+     * update rules prefer candidates that also explicitly 'provide' the
+     * obsoleted package.
+     * Sometimes it is necessary or helpful to disable this rule.
+     */
+    void setNoUpdateProvide( bool yesno_r );
+    void setDefaultNoUpdateProvide(); // set back to default (in zypp.conf)
+    bool noUpdateProvide() const;
+
     /** \name  Solver flags for DUP mode.
      * DUP mode default settings differ from 'ordinary' ones. Default for
      * all DUP flags is \c true unless overwritten by zypp.conf.

--- a/zypp/zypp/ZConfig.cc
+++ b/zypp/zypp/ZConfig.cc
@@ -248,6 +248,7 @@ namespace zypp
       , solver_dupAllowArchChange           ( true )
       , solver_dupAllowVendorChange         ( false )
       , solver_cleandepsOnRemove            ( false )
+      , solver_noUpdateProvide              ( false )
       , solver_upgradeTestcasesToKeep       ( 2 )
       , solverUpgradeRemoveDroppedPackages  ( true )
       {}
@@ -289,6 +290,10 @@ namespace zypp
         {
           solver_cleandepsOnRemove.set( str::strToBool( value, solver_cleandepsOnRemove ) );
         }
+        else if ( entry == "solver.noUpdateProvide" )
+        {
+          solver_noUpdateProvide.set( str::strToBool( value, solver_noUpdateProvide ) );
+        }
         else if ( entry == "solver.upgradeTestcasesToKeep" )
         {
           solver_upgradeTestcasesToKeep.set( str::strtonum<unsigned>( value ) );
@@ -311,6 +316,7 @@ namespace zypp
       Option<bool>        solver_dupAllowArchChange;
       Option<bool>        solver_dupAllowVendorChange;
       Option<bool>        solver_cleandepsOnRemove;
+      Option<bool>        solver_noUpdateProvide;
       Option<unsigned>    solver_upgradeTestcasesToKeep;
       DefaultOption<bool> solverUpgradeRemoveDroppedPackages;
     };
@@ -1101,6 +1107,7 @@ namespace zypp
   ResolverFocus ZConfig::solver_focus() const           { return _pimpl->targetDefaults().solver_focus; }
   bool ZConfig::solver_onlyRequires() const             { return _pimpl->targetDefaults().solver_onlyRequires; }
   bool ZConfig::solver_allowVendorChange() const        { return _pimpl->targetDefaults().solver_allowVendorChange; }
+  bool ZConfig::solver_noUpdateProvide() const          { return _pimpl->targetDefaults().solver_noUpdateProvide; }
   bool ZConfig::solver_dupAllowDowngrade() const        { return _pimpl->targetDefaults().solver_dupAllowDowngrade; }
   bool ZConfig::solver_dupAllowNameChange() const       { return _pimpl->targetDefaults().solver_dupAllowNameChange; }
   bool ZConfig::solver_dupAllowArchChange() const       { return _pimpl->targetDefaults().solver_dupAllowArchChange; }

--- a/zypp/zypp/ZConfig.h
+++ b/zypp/zypp/ZConfig.h
@@ -461,6 +461,16 @@ namespace zypp
        */
       bool solver_cleandepsOnRemove() const;
 
+      /** Do not prefer update candidates also providing the old package.
+       * In general, packages that obsolete another package are treated as
+       * update candidates for the obsoleted package. However, SUSE-specific
+       * update rules prefer candidates that also explicitly 'provide' the
+       * obsoleted package.
+       *
+       * Sometimes it is necessary or helpful to disable this rule.
+       */
+      bool solver_noUpdateProvide() const;
+
       /**
        * When committing a dist upgrade (e.g. <tt>zypper dup</tt>)
        * a solver testcase is written. It is needed in bugreports,

--- a/zypp/zypp/misc/TestcaseSetup.cc
+++ b/zypp/zypp/misc/TestcaseSetup.cc
@@ -116,6 +116,9 @@ namespace zypp::misc::testcase
   bool TestcaseSetup::cleandepsOnRemove() const
   { return _pimpl->cleandepsOnRemove; }
 
+  bool TestcaseSetup::noUpdateProvide() const
+  { return _pimpl->noUpdateProvide; }
+
   bool TestcaseSetup::allowDowngrade() const
   { return _pimpl->allowDowngrade; }
 

--- a/zypp/zypp/misc/TestcaseSetup.h
+++ b/zypp/zypp/misc/TestcaseSetup.h
@@ -108,6 +108,7 @@ namespace zypp::misc::testcase
     bool onlyRequires() const;
     bool forceResolve() const;
     bool cleandepsOnRemove() const;
+    bool noUpdateProvide() const;
 
     bool allowDowngrade() const;
     bool allowNameChange() const;

--- a/zypp/zypp/misc/TestcaseSetupImpl.h
+++ b/zypp/zypp/misc/TestcaseSetupImpl.h
@@ -67,6 +67,7 @@ namespace zypp::misc::testcase
     bool onlyRequires               = false;
     bool forceResolve               = false;
     bool cleandepsOnRemove          = false;
+    bool noUpdateProvide            = false;
 
     bool allowDowngrade     = false;
     bool allowNameChange    = false;

--- a/zypp/zypp/misc/YamlTestcaseHelpers.h
+++ b/zypp/zypp/misc/YamlTestcaseHelpers.h
@@ -83,6 +83,7 @@ namespace yamltest::detail {
         if_SolverFlag( forceResolve )
 
         if_SolverFlag( cleandepsOnRemove )
+        if_SolverFlag( noUpdateProvide )
 
         if_SolverFlag( allowDowngrade )
         if_SolverFlag( allowNameChange )

--- a/zypp/zypp/solver/detail/Resolver.cc
+++ b/zypp/zypp/solver/detail/Resolver.cc
@@ -86,6 +86,7 @@ Resolver::Resolver (ResPool  pool)
     , _applyDefault_focus                ( true )
     , _applyDefault_forceResolve         ( true )
     , _applyDefault_cleandepsOnRemove    ( true )
+    , _applyDefault_noUpdateProvide      ( true )
     , _applyDefault_onlyRequires         ( true )
     , _applyDefault_allowDowngrade       ( true )
     , _applyDefault_allowNameChange      ( true )
@@ -121,6 +122,7 @@ void Resolver::setDefaultSolverFlags( bool all_r )
 
   ZOLV_FLAG_DEFAULT( setForceResolve         ,forceResolve         );
   ZOLV_FLAG_DEFAULT( setCleandepsOnRemove    ,cleandepsOnRemove    );
+  ZOLV_FLAG_DEFAULT( setNoUpdateProvide      ,noUpdateProvide      );
   ZOLV_FLAG_DEFAULT( setOnlyRequires         ,onlyRequires         );
   ZOLV_FLAG_DEFAULT( setAllowDowngrade       ,allowDowngrade       );
   ZOLV_FLAG_DEFAULT( setAllowNameChange      ,allowNameChange      );
@@ -151,7 +153,7 @@ bool Resolver::removeUnneeded() const                   { return _satResolver->_
     { _applyDefault_##ZGETTER = indeterminate(state_r);					\
       bool newval = _applyDefault_##ZGETTER ? ZVARDEFAULT : bool(state_r);		\
       if ( ZVARNAME != newval ) {							\
-        DBG << #ZGETTER << ": changed from " << (bool)ZVARNAME << " to " << newval << endl;\
+        DBG << #ZGETTER << ": changed from " << (bool)ZVARNAME << " to " << newval << " | " << (_applyDefault_##ZGETTER ? "changed default" : "explicitly set" ) << endl;\
         ZVARNAME = newval;								\
       }											\
     }											\
@@ -166,6 +168,7 @@ bool Resolver::removeUnneeded() const                   { return _satResolver->_
 // NOTE: ZVARDEFAULT must be in sync with SATResolver ctor
 ZOLV_FLAG_SATSOLV( setForceResolve         ,forceResolve         ,false                                             ,_allowuninstall        )
 ZOLV_FLAG_SATSOLV( setCleandepsOnRemove    ,cleandepsOnRemove    ,ZConfig::instance().solver_cleandepsOnRemove()    ,_cleandepsOnRemove     )
+ZOLV_FLAG_SATSOLV( setNoUpdateProvide      ,noUpdateProvide      ,ZConfig::instance().solver_noUpdateProvide()      ,_noUpdateProvide       )
 ZOLV_FLAG_SATSOLV( setOnlyRequires         ,onlyRequires         ,ZConfig::instance().solver_onlyRequires()         ,_onlyRequires          )
 ZOLV_FLAG_SATSOLV( setAllowDowngrade       ,allowDowngrade       ,false                                             ,_allowdowngrade        )
 ZOLV_FLAG_SATSOLV( setAllowNameChange      ,allowNameChange      ,true /*bsc#1071466*/                              ,_allownamechange       )

--- a/zypp/zypp/solver/detail/Resolver.h
+++ b/zypp/zypp/solver/detail/Resolver.h
@@ -93,6 +93,7 @@ class ZYPP_API_DEPTESTOMATIC Resolver : private base::NonCopyable
     bool _applyDefault_focus:1;
     bool _applyDefault_forceResolve:1;
     bool _applyDefault_cleandepsOnRemove:1;
+    bool _applyDefault_noUpdateProvide:1;
     bool _applyDefault_onlyRequires:1;
     bool _applyDefault_allowDowngrade:1;
     bool _applyDefault_allowNameChange:1;
@@ -213,6 +214,7 @@ class ZYPP_API_DEPTESTOMATIC Resolver : private base::NonCopyable
 
     ZOLV_FLAG_TRIBOOL( setForceResolve          ,forceResolve         )
     ZOLV_FLAG_TRIBOOL( setCleandepsOnRemove     ,cleandepsOnRemove    )
+    ZOLV_FLAG_TRIBOOL( setNoUpdateProvide       ,noUpdateProvide      )
     ZOLV_FLAG_TRIBOOL( setOnlyRequires          ,onlyRequires         )
     ZOLV_FLAG_TRIBOOL( setAllowDowngrade        ,allowDowngrade       )
     ZOLV_FLAG_TRIBOOL( setAllowNameChange       ,allowNameChange      )

--- a/zypp/zypp/solver/detail/SATResolver.cc
+++ b/zypp/zypp/solver/detail/SATResolver.cc
@@ -298,8 +298,8 @@ SATResolver::SATResolver (ResPool  pool, sat::detail::CPool *satPool)
     , _allowarchchange		( false )
     , _allowvendorchange	( ZConfig::instance().solver_allowVendorChange() )
     , _allowuninstall		( false )
-    , _updatesystem(false)
-    , _noupdateprovide		( false )
+    , _updatesystem             ( false )
+    , _noUpdateProvide		( ZConfig::instance().solver_noUpdateProvide() )
     , _dosplitprovides		( true )
     , _onlyRequires		(ZConfig::instance().solver_onlyRequires())
     , _ignorealreadyrecommended(true)
@@ -663,7 +663,7 @@ void SATResolver::solverInitSetModeJobsAndFlags()
     solver_set_flag(_satSolver, SOLVER_FLAG_ALLOW_ARCHCHANGE,		_allowarchchange);
     solver_set_flag(_satSolver, SOLVER_FLAG_ALLOW_VENDORCHANGE,		_allowvendorchange);
     solver_set_flag(_satSolver, SOLVER_FLAG_ALLOW_UNINSTALL,		_allowuninstall);
-    solver_set_flag(_satSolver, SOLVER_FLAG_NO_UPDATEPROVIDE,		_noupdateprovide);
+    solver_set_flag(_satSolver, SOLVER_FLAG_NO_UPDATEPROVIDE,		_noUpdateProvide);
     solver_set_flag(_satSolver, SOLVER_FLAG_SPLITPROVIDES,		_dosplitprovides);
     solver_set_flag(_satSolver, SOLVER_FLAG_IGNORE_RECOMMENDED, 	false);		// resolve recommended namespaces
     solver_set_flag(_satSolver, SOLVER_FLAG_ONLY_NAMESPACE_RECOMMENDED,	_onlyRequires);	//

--- a/zypp/zypp/solver/detail/SATResolver.h
+++ b/zypp/zypp/solver/detail/SATResolver.h
@@ -94,7 +94,7 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
     bool _allowvendorchange:1;		// allow one to change vendor of installed solvables
     bool _allowuninstall:1;		// allow removal of installed solvables
     bool _updatesystem:1;		// update
-    bool _noupdateprovide:1;		// true: update packages needs not to provide old package
+    bool _noUpdateProvide:1;		// true: do not prefer update candidates also providing the old package
     bool _dosplitprovides:1;		// true: consider legacy split provides
     bool _onlyRequires:1;		// true: consider required packages only (but recommended namespaces)
     bool _ignorealreadyrecommended:1;	// true: ignore recommended packages that were already recommended by the installed packages
@@ -198,8 +198,8 @@ class SATResolver : public base::ReferenceCounted, private base::NonCopyable, pr
     bool updatesystem () const {return _updatesystem;}
     void setUpdatesystem ( const bool updatesystem) { _updatesystem = updatesystem;}
 
-    bool noupdateprovide () const {return _noupdateprovide;}
-    void setNoupdateprovide ( const bool noupdateprovide) { _noupdateprovide = noupdateprovide;}
+    bool noUpdateProvide () const {return _noUpdateProvide;}
+    void setNoUpdateProvide ( const bool noUpdateProvide) { _noUpdateProvide = noUpdateProvide;}
 
     bool dosplitprovides () const {return _dosplitprovides;}
     void setDosplitprovides ( const bool dosplitprovides) { _dosplitprovides = dosplitprovides;}

--- a/zypp/zypp/solver/detail/Testcase.cc
+++ b/zypp/zypp/solver/detail/Testcase.cc
@@ -283,6 +283,7 @@ namespace zypp
         addTag( "forceResolve",             resolver.forceResolve() );
 
         addTag( "cleandepsOnRemove",        resolver.cleandepsOnRemove() );
+        addTag( "noUpdateProvide",          resolver.noUpdateProvide() );
 
         addTag( "allowDowngrade",           resolver.allowDowngrade() );
         addTag( "allowNameChange",          resolver.allowNameChange() );


### PR DESCRIPTION
In general, packages that obsolete another package are treated as update candidates for the obsoleted package. However, SUSE-specific update rules prefer candidates that also explicitly 'provide' the obsoleted package.

Sometimes it is necessary or helpful to disable this rule.