### PR TITLE
zypp-curl: Enable HTTP3 if supported by curl and wait for confirmation on multiplexing support

### DIFF
--- a/zypp-logic/zypp-curl/ng/network/request.cc
+++ b/zypp-logic/zypp-curl/ng/network/request.cc
@@ -120,7 +120,9 @@ namespace zyppng {
       setCurlOption( CURLOPT_NOPROGRESS, 0L);
       setCurlOption( CURLOPT_FAILONERROR, 1L);
       setCurlOption( CURLOPT_NOSIGNAL, 1L);
+#if CURLVERSION_AT_LEAST(8,16,0)
       setCurlOption( CURLOPT_PIPEWAIT, 1L);
+#endif
 #if CURLVERSION_AT_LEAST(7,66,0)
       setCurlOption( CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
 #endif

--- a/zypp-logic/zypp-curl/ng/network/request.cc
+++ b/zypp-logic/zypp-curl/ng/network/request.cc
@@ -120,6 +120,10 @@ namespace zyppng {
       setCurlOption( CURLOPT_NOPROGRESS, 0L);
       setCurlOption( CURLOPT_FAILONERROR, 1L);
       setCurlOption( CURLOPT_NOSIGNAL, 1L);
+      setCurlOption( CURLOPT_PIPEWAIT, 1L);
+#if CURLVERSION_AT_LEAST(7,66,0)
+      setCurlOption( CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
+#endif
 
       std::string urlBuffer( _url.asString() );
       setCurlOption( CURLOPT_URL, urlBuffer.c_str() );


### PR DESCRIPTION
After this patch one can confirm connections to the fastly CDN use HTTP3 and multiplexing works over a single UDP "connection" instead of opening a multitude of them and later catching up. (multiplexing is enabled by default in libcurl)

Other mirrors that support HTTP2 and "confirm" multiplex also do over TCP.

Most other mirrors work over http 1.1 where there is no multiplexing and curl no longer support pipelining so multiple connections are attempted.

side effect: Tiny delay to start download.