### PR TITLE
Fix hasCredentials() to require both username AND password to be non-…

### DIFF
--- a/zypp-logic/zypp-curl/transfersettings.cc
+++ b/zypp-logic/zypp-curl/transfersettings.cc
@@ -155,7 +155,7 @@ namespace zypp
 
 
     bool TransferSettings::hasCredentials() const
-    { return not _impl->_username.empty(); }
+    { return not _impl->_username.empty() && not _impl->_password.empty(); }
 
     void TransferSettings::setUsername( const std::string &val_r )
     { _impl->_username = val_r; }

--- a/zypp-logic/zypp-curl/transfersettings.h
+++ b/zypp-logic/zypp-curl/transfersettings.h
@@ -60,7 +60,7 @@ namespace zypp
       const std::string &userAgentString() const;
 
 
-      /** has a username, maybe even the password */
+      /** has a non-empty username and a non-empty password */
       bool hasCredentials() const;
 
       /** log credentials to stream hiding the password. */


### PR DESCRIPTION
…empty [(bsc#1273242)](https://bugzilla.suse.com/show_bug.cgi?id=1273242)

This avoids an unnecessary 2nd 401 response sending just the username in case the username but no password is known. Now it immediately fetches the credentials from disk if no password is known.