### PR TITLE
Add CommitActiveReport: backend-agnostic point-of-no-return signal

### DIFF
--- a/zypp/zypp/ZYppCallbacks.h
+++ b/zypp/zypp/ZYppCallbacks.h
@@ -584,6 +584,39 @@ namespace zypp
 
 
     ///////////////////////////////////////////////////////////////////
+    /// \class CommitActiveReport
+    /// \brief Fired exactly once per \ref TargetImpl::commit call, marking
+    /// the point at which the actual RPM transaction becomes irreversible.
+    ///
+    /// This report exists to give callers (e.g. an MCP worker mediating
+    /// cancellation requests) a single, backend-agnostic synchronization
+    /// point: \ref start is called before any persistent
+    /// state (locks, requested locales, autoinstalled) is written or the
+    /// RPM transaction begins, regardless of Legacy vs SingleTrans backend.
+    ///
+    /// Returning \c false aborts the commit
+    /// \ref TargetImpl::commit throws \ref TargetAbortedException.
+    /// This lets a receiver (e.g. one mediating an external cancellation
+    /// request) decline safely rather than relying on an external process
+    /// signal racing against the point of no return.
+    ///////////////////////////////////////////////////////////////////
+    struct ZYPP_API CommitActiveReport : public callback::ReportBase
+    {
+      /** Called once, synchronously, before the irreversible transaction
+       * begins. Return \c false to abort the commit before anything has
+       * been touched. */
+      virtual bool start( const UserData & = UserData() /*userdata*/ ) { return true; }
+
+      /**
+       * Called when all target state has been written. Commit is done and safe.
+       */
+      virtual void end  ( const UserData & = UserData() /*userdata*/ ) { }
+
+      // added for future use to avoid breaking compatibility
+      virtual void step ( const UserData & = UserData() /*userdata*/ ) { }
+    };
+
+    ///////////////////////////////////////////////////////////////////
     namespace rpm
     {
 

--- a/zypp/zypp/target/TargetImpl.cc
+++ b/zypp/zypp/target/TargetImpl.cc
@@ -1463,19 +1463,8 @@ namespace zypp
       {
         result.rTransactionStepList().insert( steps.end(), result.transaction().begin(), result.transaction().end() );
       }
+
       MIL << "Todo: " << result << endl;
-
-      ///////////////////////////////////////////////////////////////////
-      // Prepare execution of commit plugins:
-      ///////////////////////////////////////////////////////////////////
-      PluginExecutor commitPlugins;
-
-      if ( ( root() == "/" || zypp::env::TRANSACTIONAL_UPDATE() ) && ! policy_r.dryRun() )
-      {
-        commitPlugins.load( ZConfig::instance().pluginsPath()/"commit" );
-      }
-      if ( commitPlugins )
-        commitPlugins.send( transactionPluginFrame( "COMMITBEGIN", steps ) );
 
       ///////////////////////////////////////////////////////////////////
       // Write out a testcase if we're in dist upgrade mode.
@@ -1490,34 +1479,6 @@ namespace zypp
         {
           DBG << "dryRun: Not writing upgrade testcase." << endl;
         }
-      }
-
-     ///////////////////////////////////////////////////////////////////
-      // Store non-package data:
-      ///////////////////////////////////////////////////////////////////
-      if ( ! policy_r.dryRun() )
-      {
-        filesystem::assert_dir( home() );
-        // requested locales
-        _requestedLocalesFile.setLocales( pool_r.getRequestedLocales() );
-        // autoinstalled
-        {
-          SolvIdentFile::Data newdata;
-          for ( sat::Queue::value_type id : result.rTransaction().autoInstalled() )
-            newdata.insert( IdString(id) );
-          _autoInstalledFile.setData( newdata );
-        }
-        // hard locks
-        if ( ZConfig::instance().apply_locks_file() )
-        {
-          HardLocksFile::Data newdata;
-          pool_r.getHardLockQueries( newdata );
-          _hardLocksFile.setData( newdata );
-        }
-      }
-      else
-      {
-        DBG << "dryRun: Not storing non-package data." << endl;
       }
 
       ///////////////////////////////////////////////////////////////////
@@ -1642,9 +1603,56 @@ namespace zypp
         }
         else
         {
+          // Commit starts
+          callback::SendReport<target::CommitActiveReport> commitActiveReport;
+          if ( ! commitActiveReport->start() )
+          {
+            WAR << "commit aborted: CommitActiveReport declined" << endl;
+            ZYPP_THROW( TargetAbortedException( ) );
+          }
+
+          ///////////////////////////////////////////////////////////////////
+          // Prepare execution of commit plugins:
+          ///////////////////////////////////////////////////////////////////
+          PluginExecutor commitPlugins;
+
+          if ( ( root() == "/" || zypp::env::TRANSACTIONAL_UPDATE() ) && ! policy_r.dryRun() )
+          {
+            commitPlugins.load( ZConfig::instance().pluginsPath()/"commit" );
+          }
+          if ( commitPlugins )
+            commitPlugins.send( transactionPluginFrame( "COMMITBEGIN", steps ) );
+
+          ///////////////////////////////////////////////////////////////////
+          // Store non-package data:
+          ///////////////////////////////////////////////////////////////////
           if ( ! policy_r.dryRun() )
           {
+            filesystem::assert_dir( home() );
+            // requested locales
+            _requestedLocalesFile.setLocales( pool_r.getRequestedLocales() );
+            // autoinstalled
+            {
+              SolvIdentFile::Data newdata;
+              for ( sat::Queue::value_type id : result.rTransaction().autoInstalled() )
+                newdata.insert( IdString(id) );
+              _autoInstalledFile.setData( newdata );
+            }
+            // hard locks
+            if ( ZConfig::instance().apply_locks_file() )
+            {
+              HardLocksFile::Data newdata;
+              pool_r.getHardLockQueries( newdata );
+              _hardLocksFile.setData( newdata );
+            }
+          }
+          else
+          {
+            DBG << "dryRun: Not storing non-package data." << endl;
+          }
 
+          if ( ! policy_r.dryRun() )
+          {
             if ( policy_r.singleTransModeEnabled() ) {
               commitInSingleTransaction( policy_r, packageCache, result );
             } else {
@@ -1669,6 +1677,22 @@ namespace zypp
               }
             }
           }
+
+          ///////////////////////////////////////////////////////////////////
+          // Send result to commit plugins:
+          ///////////////////////////////////////////////////////////////////
+          if ( commitPlugins )
+            commitPlugins.send( transactionPluginFrame( "COMMITEND", steps ) );
+
+          ///////////////////////////////////////////////////////////////////
+          // Try to rebuild solv file while rpm database is still in cache
+          ///////////////////////////////////////////////////////////////////
+          if ( ! policy_r.dryRun() )
+          {
+            buildCache();
+          }
+
+          commitActiveReport->end();
         }
       }
       else
@@ -1690,20 +1714,6 @@ namespace zypp
           filesystem::assert_dir( _root/"/var/lib" );
           filesystem::symlink( "../../usr/lib/sysimage/rpm", _root/"/var/lib/rpm" );
         }
-      }
-
-      ///////////////////////////////////////////////////////////////////
-      // Send result to commit plugins:
-      ///////////////////////////////////////////////////////////////////
-      if ( commitPlugins )
-        commitPlugins.send( transactionPluginFrame( "COMMITEND", steps ) );
-
-      ///////////////////////////////////////////////////////////////////
-      // Try to rebuild solv file while rpm database is still in cache
-      ///////////////////////////////////////////////////////////////////
-      if ( ! policy_r.dryRun() )
-      {
-        buildCache();
       }
 
       MIL << "TargetImpl::commit(<pool>, " << policy_r << ") returns: " << result << endl;


### PR DESCRIPTION
Fired synchronously via CommitActiveReport::start() in TargetImpl::commit, after download/preload but before any persistent state is written or the RPM transaction begins, regardless of backend. Returning false aborts the commit before anything is touched.

Also relocates non-package data writes and COMMITBEGIN/COMMITEND/ buildCache() to fire after a successful preload instead of before it.