### PR TITLE
Do not join the log thread in a forked child

### DIFF
--- a/zypp-logic/zypp-core/base/LogControl.cc
+++ b/zypp-logic/zypp-core/base/LogControl.cc
@@ -110,6 +110,15 @@ namespace zypp
 
     void stop () {
       _stopSignal.notify();
+      if ( _ownerPid != getpid() )
+      {
+        // We are in a forked child: the worker thread only exists in the
+        // parent, join() would block forever (e.g. a fork server calling
+        // exit() hangs in this dtor at __run_exit_handlers). Detach so
+        // ~thread() does not std::terminate().
+        _thread.detach();
+        return;
+      }
       if ( _thread.get_id() != std::this_thread::get_id() )
         _thread.join();
     }
@@ -133,6 +142,8 @@ namespace zypp
         workerMain();
       });
     }
+
+    pid_t _ownerPid = getpid();
 
     void workerMain () {
 


### PR DESCRIPTION
Note: ClaudeAI came up with this and it looks reasonable to me. Give it extra careful review+testing.
Check it live at https://build.opensuse.org/project/show/home:bmwiedemann:zypperd

===

A forked child inherits the `LogThread` singleton object, but not the thread itself. When such a child exits via `exit()` instead of `_exit()`, the LogThread destructor runs from `__run_exit_handlers` and `join()` blocks forever on a thread that does not exist in this process.

Observed with a fork-per-request zypper daemon (zypperd): a worker child that received `SIGPIPE` went through `Zypper::immediateExit -> exit()` and hung in the futex wait inside ~LogThread.

Remember the pid that created the thread and detach instead of joining when the destructor runs in a different process.

