### PR TITLE
TestcaseSetup: support testcase:<relative-path> Url-type repos

### DIFF
--- a/zypp/zypp/misc/TestcaseSetup.cc
+++ b/zypp/zypp/misc/TestcaseSetup.cc
@@ -372,7 +372,7 @@ namespace zypp::misc::testcase
   bool TestcaseSetup::loadRepo( zypp::RepoManager &manager, const TestcaseSetup &setup, const RepoData &data )
   {
     const auto &repoData = data.data();
-    Pathname pathname = setup._pimpl->globalPath + repoData.path;
+    Pathname pathname = Pathname::assertprefix ( setup._pimpl->globalPath, repoData.path );
     MIL << "'" << pathname << "'" << std::endl;
 
     Repository repo;
@@ -397,7 +397,7 @@ namespace zypp::misc::testcase
           // fixture itself (e.g. a local susetags/rpm-md directory), resolved
           // against the testcase directory. Any other scheme (http://, dir:,
           // ftp://, ...) is used verbatim, unchanged from prior behaviour.
-          repoUrl = ( setup._pimpl->globalPath / repoUrl.getPathName() ).asUrl();
+          repoUrl =  Pathname::assertprefix ( setup._pimpl->globalPath, repoUrl.getPathName() ).asUrl();
           // Bundled fixtures are never signed — same precedent as
           // zypp-logic/tests/lib/TestSetup.h::loadRepo(), which disables
           // gpgCheck for its own local test repos. Absolute URLs (any other

--- a/zypp/zypp/misc/TestcaseSetup.cc
+++ b/zypp/zypp/misc/TestcaseSetup.cc
@@ -389,7 +389,23 @@ namespace zypp::misc::testcase
         nrepo.setEnabled    ( true );
         nrepo.setAutorefresh( false );
         nrepo.setPriority   ( repoData.priority );
-        nrepo.addBaseUrl   ( Url(repoData.path) );
+
+        Url repoUrl( repoData.path );
+        if ( repoUrl.getScheme() == "testcase" )
+        {
+          // testcase:<relative-path> — a repo bundled alongside the testcase
+          // fixture itself (e.g. a local susetags/rpm-md directory), resolved
+          // against the testcase directory. Any other scheme (http://, dir:,
+          // ftp://, ...) is used verbatim, unchanged from prior behaviour.
+          repoUrl = ( setup._pimpl->globalPath / repoUrl.getPathName() ).asUrl();
+          // Bundled fixtures are never signed — same precedent as
+          // zypp-logic/tests/lib/TestSetup.h::loadRepo(), which disables
+          // gpgCheck for its own local test repos. Absolute URLs (any other
+          // scheme) are untouched: a testcase pointing at a real repo keeps
+          // whatever signature checking it would normally get.
+          nrepo.setGpgCheck( false );
+        }
+        nrepo.addBaseUrl( repoUrl );
 
         manager.refreshMetadata( nrepo );
         manager.buildCache( nrepo );


### PR DESCRIPTION
Resolves against the testcase directory (like Testtags/Helix already do) instead of using the path verbatim, so a testcase can bundle its own local repo fixture. Disables gpgCheck for this scheme only, same precedent as TestSetup.h::loadRepo().